### PR TITLE
Fix issue #3: enable text justification using CSS's text-align

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -98,6 +98,8 @@ import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.util.Configuration;
 import com.openhtmltopdf.util.XRLog;
 
+import static com.openhtmltopdf.test.DocumentDiffTest.width;
+
 public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDevice {
     private static final int FILL = 1;
     private static final int STROKE = 2;
@@ -452,10 +454,14 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
         _cp.beginText();
         _cp.setFont(desc.getFont(), fontSize);
         _cp.setTextMatrix((float) mx[0], b, c, (float) mx[3], (float) mx[4], (float) mx[5]);
-        
-        if (info != null) {
-            _cp.setTextSpacing(info.getNonSpaceAdjust());
-            _cp.setSpaceSpacing(info.getSpaceAdjust());
+
+        if (info != null ) {
+            // The JustificationInfo numbers need to be normalized using the current document DPI
+            _cp.setTextSpacing(info.getNonSpaceAdjust() / _dotsPerPoint);
+            _cp.setSpaceSpacing(info.getSpaceAdjust() / _dotsPerPoint);
+        } else {
+            _cp.setTextSpacing(0.0f);
+            _cp.setSpaceSpacing(0.0f);
         }
         
         _cp.drawString(s);

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
@@ -285,11 +285,19 @@ public class PdfContentStreamAdapter {
     }
 
     public void setTextSpacing(float nonSpaceAdjust) {
-        // TODO Not currently supported in PDF-BOX.
+        try {
+            cs.appendRawCommands(String.format("%f Tc\n", nonSpaceAdjust).replace(',', '.'));
+        } catch (IOException e) {
+            logAndThrow("setSpaceSpacing", e);
+        }
     }
 
     public void setSpaceSpacing(float spaceAdjust) {
-        // TODO Not currently supported in PDF-BOX.
+        try {
+            cs.appendRawCommands(String.format("%f Tw\n", spaceAdjust).replace(',', '.'));
+        } catch (IOException e) {
+            logAndThrow("setSpaceSpacing", e);
+        }
     }
 
     public void setPdfMatrix(AffineTransform transform) {


### PR DESCRIPTION
PDFBox doesn't support the Tc and Tw operators, so, they are manually added inside setCharacterSpacing and setWordSpacing. 
The actual value must be normalized by using the document's dots per point as well.
