### PR TITLE
Fix hairline bugs in table borders.

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -231,7 +231,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
             return;
         }
         
-        Area borderBounds = new Area(BorderPainter.generateBorderBounds(backgroundBounds, border, false));
+        Area borderBounds = new Area(BorderPainter.generateBorderBounds(backgroundBounds, border, true));
 
         Shape oldclip = getClip();
         if(oldclip != null) {


### PR DESCRIPTION
We need to get the full interior Area, otherwise we will have some
super small hairline gaps in the PDF. They are always small but also
always visible in the PDF independent of the zoom level.

Broken
![image](https://cloud.githubusercontent.com/assets/711674/17593923/d0e1f58c-5fe7-11e6-9b41-73f2631f4c7a.png)

vs.

fixed
![image](https://cloud.githubusercontent.com/assets/711674/17593929/d57a4cb6-5fe7-11e6-993f-879ef853e994.png)
