### PR TITLE
#23: PDFBox-Graphics2D based SVG rendering

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -111,4 +111,9 @@ public interface OutputDevice {
     
     public boolean isSupportsCMYKColors();
 
+    /**
+     * Draw something using a Graphics2D at the given rectangle.
+     */
+    public void drawWithGraphics(float x, float y, float width, float height, OutputDeviceGraphicsDrawer renderer);
+
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDeviceGraphicsDrawer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDeviceGraphicsDrawer.java
@@ -1,0 +1,17 @@
+package com.openhtmltopdf.extend;
+
+import java.awt.*;
+
+/**
+ * Render something on a Graphics2D on the OutputDevice.
+ *
+ * @FunctionalInterface
+ */
+public interface OutputDeviceGraphicsDrawer {
+
+	/**
+	 * Draw something using the given graphics. For PDFs it will be converted to vector drawings.
+	 * @param graphics2D the graphics you can use to draw
+	 */
+	public void render(Graphics2D graphics2D);
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/SVGDrawer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/SVGDrawer.java
@@ -1,15 +1,14 @@
 package com.openhtmltopdf.extend;
 
-import java.util.List;
-
-import org.w3c.dom.Element;
-
 import com.openhtmltopdf.css.sheet.FontFaceRule;
 import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.render.RenderingContext;
+import org.w3c.dom.Element;
+
+import java.util.List;
 
 public interface SVGDrawer {
-	public void drawSVG(Element svgElement, OutputDevice outputDevice, RenderingContext ctx, double x, double y, float dotsPerInch);
+	public void drawSVG(Element svgElement, OutputDevice outputDevice, RenderingContext ctx, double x, double y, double width, double height, double dotsPerPixel);
 
 	public void importFontFaceRules(List<FontFaceRule> fontFaces, SharedContext shared);
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
@@ -21,10 +21,7 @@ package com.openhtmltopdf.swing;
 
 import com.openhtmltopdf.css.parser.FSColor;
 import com.openhtmltopdf.css.parser.FSRGBColor;
-import com.openhtmltopdf.extend.FSGlyphVector;
-import com.openhtmltopdf.extend.FSImage;
-import com.openhtmltopdf.extend.OutputDevice;
-import com.openhtmltopdf.extend.ReplacedElement;
+import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.render.*;
 
 import javax.swing.*;
@@ -280,7 +277,14 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
         return true;
     }
 
-    private Stack<AffineTransform> transformStack = new Stack<AffineTransform>();
+	@Override
+	public void drawWithGraphics(float x, float y, float width, float height, OutputDeviceGraphicsDrawer renderer) {
+		Graphics2D graphics = (Graphics2D) _graphics.create((int) x, (int) y, (int) width, (int) height);
+		renderer.render(graphics);
+		graphics.dispose();
+	}
+
+	private Stack<AffineTransform> transformStack = new Stack<AffineTransform>();
     private Stack<Shape> clipStack= new Stack<Shape>();
 
 	@Override

--- a/openhtmltopdf-examples/pom.xml
+++ b/openhtmltopdf-examples/pom.xml
@@ -40,6 +40,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.openhtmltopdf</groupId>
+      <artifactId>openhtmltopdf-svg-support</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/openhtmltopdf-examples/src/main/resources/testcases/svg-inline.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/svg-inline.html
@@ -1,0 +1,143 @@
+<html>
+<head>
+    <style>
+        svg {
+            border: 2px solid black;
+        }
+    </style>
+</head>
+<body>
+
+<h1>Some inline SVG examples</h1>
+
+Some examples how inline SVG is rendered.
+
+<h2>JSON-Symbol</h2>
+
+<!-- Taken from https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 102" width="200" height="200">
+	<radialGradient id="jsongrad" cx="65" cy="90" r="100" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#EEF"/><stop offset="1"/></radialGradient>
+	<path d="M61,02 A 49,49 0,0,0 39,98 C 9,79 10,24 45,25 C 72,24 65,75 50,75 C 93,79 91,21 62,02" id="jsonswirl" fill="url(#jsongrad)"/>
+	<use xlink:href="#jsonswirl" transform="rotate(180 50,50)"/>
+</svg>
+
+<h2>Barchart</h2>
+<!--
+
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<!-- ========================================================================= -->
+<!-- Illustrates how SVG can be used for high quality graphs.                  -->
+<!--                                                                           -->
+<!-- @author vincent.hardy@eng.sun.com                                         -->
+<!-- @author neeme.praks@one.lv                                                -->
+<!-- @version $Id$        -->
+<!-- ========================================================================= -->
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="body" width="450" height="500" xml:space="preserve" viewBox="0 0 450 500">
+    <title>Bar Chart</title>
+
+    <g id="barChart" transform="translate(40, 100)" fill-rule="evenodd" clip-rule="evenodd" stroke="none" class="legend"
+        stroke-width="1" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" style="text-anchor:start">
+
+        <g id="GridAndLegend" style="stroke:none;">
+            <g stroke="black">
+
+                <!-- "floor" and "wall" -->
+                <path fill="lightgray" stroke="darkgray" d="M 27,240 l   15,-15 v -224 l -15,15" />
+                <path fill="lightgray" stroke="darkgray" d="M 41,225 v -224     h  316 v 224" />
+                <path fill="darkgray" stroke="none"      d="M 27,240 l   15,-15 h  316 l -15,15" />
+
+				<!-- axis lines -->
+                <path d="M 27,240 h  316"/>
+                <path d="M 27,240 v -224"/>
+
+				<!-- value axis major gridlines -->
+                <g style="fill:none;">
+                    <path d="M 27,202 l 15,-15 h 316" />
+                    <path d="M 27,165 l 15,-15 h 316" />
+                    <path d="M 27,127 l 15,-15 h 316" />
+                    <path d="M 27, 90 l 15,-15 h 316" />
+                    <path d="M 27, 53 l 15,-15 h 316" />
+                </g>
+
+				<!-- category axis major ticks -->
+                <path d="M  27,245 v -5"/>
+                <path d="M 106,245 v -5"/>
+                <path d="M 185,245 v -5"/>
+                <path d="M 264,245 v -5"/>
+
+				<!-- value axis minor ticks -->
+                <path d="M 22,240 h 5"/>
+                <path d="M 22,202 h 5"/>
+                <path d="M 22,165 h 5"/>
+                <path d="M 22,127 h 5"/>
+                <path d="M 22, 90 h 5"/>
+                <path d="M 22, 53 h 5"/>
+                <path d="M 22, 15 h 5"/>
+            </g>
+
+            <text transform="matrix(1 0 0 1 54  256)">Shoe</text>
+            <text transform="matrix(1 0 0 1 142 256)">Car</text>
+            <text transform="matrix(1 0 0 1 211 256)">Travel</text>
+            <text transform="matrix(1 0 0 1 285 256)">Computer</text>
+
+            <text transform="matrix(1 0 0 1 13 247)"><tspan x="0" y="0">0</tspan></text>
+            <text transform="matrix(1 0 0 1  6 209)"><tspan x="0" y="0">10</tspan></text>
+            <text transform="matrix(1 0 0 1  6 171)"><tspan x="0" y="0">20</tspan></text>
+            <text transform="matrix(1 0 0 1  6 134)"><tspan x="0" y="0">30</tspan></text>
+            <text transform="matrix(1 0 0 1  6  96)"><tspan x="0" y="0">40</tspan></text>
+            <text transform="matrix(1 0 0 1  6  60)"><tspan x="0" y="0">50</tspan></text>
+            <text transform="matrix(1 0 0 1  6  22)"><tspan x="0" y="0">60</tspan></text>
+        </g>
+
+        <g id="ShoeBar">
+            <path style="fill:#8686E0;" d="M  86,240 v  -37 l 15    -15 v  37 l -15,15 z"/>
+            <path style="fill:#5B5B97;" d="M  86,203 h  -39 l 15    -15 h  39 l -15,15 z"/>
+            <path style="fill:#7575C3;" d="M  47,203 v   37 h 39 v  -37 H  47 z"/>
+        </g>
+        <g id="CarBar">
+            <path style="fill:#8686E0;" d="M 165,240 v  -74 l 15    -15 v  74 l -15,15 z"/>
+            <path style="fill:#5B5B97;" d="M 165,166 h  -39 l 15    -15 h  39 l -15,15 z"/>
+            <path style="fill:#7575C3;" d="M 126,166 v   74 h 39 v  -74 h -39 z"/>
+        </g>
+        <g id="TravelBar">
+            <path style="fill:#8686E0;" d="M 244,240 v  -37 l 15    -15 v  37 l -15,15 z"/>
+            <path style="fill:#5B5B97;" d="M 244,203 h  -39 l 15    -15 h  39 l -15,15 z"/>
+            <path style="fill:#7575C3;" d="M 205,203 v   37 h 39 v  -37 h -39 z"/>
+        </g>
+        <g id="ComputerBar">
+            <path style="fill:#8686E0;" d="M 323,240 v -224 l 15    -15 v 224 l -15,15 z"/>
+            <path style="fill:#5B5B97;" d="M 323, 16 h  -39 l 15    -15 h  39 l -15,15 z"/>
+            <path style="fill:#7575C3;" d="M 284, 16 v  224 h 39 v -224 h -39 z"/>
+        </g>
+
+    </g>
+
+	<!-- ============================================================= -->
+	<!-- Batik sample mark                                             -->
+	<!-- ============================================================= -->
+	<!--
+	<use xlink:href="batikLogo.svg#Batik_Tag_Box" />
+	-->
+
+</svg>
+
+<b>End of SVGs</b>
+
+</body>
+</html>

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>openhtmltopdf-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+	  <dependency>
+		  <groupId>de.rototor.pdfbox</groupId>
+		  <artifactId>graphics2d</artifactId>
+		  <version>0.1</version>
+	  </dependency>
   </dependencies>
 
   <build>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -29,13 +29,14 @@ import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.css.style.CssContext;
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.extend.OutputDevice;
+import com.openhtmltopdf.extend.OutputDeviceGraphicsDrawer;
 import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription;
 import com.openhtmltopdf.pdfboxout.PdfBoxForm.CheckboxStyle;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.util.Configuration;
 import com.openhtmltopdf.util.XRLog;
-
+import de.rototor.pdfbox.graphics2d.PdfBoxGraphics2D;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -59,7 +60,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import javax.imageio.ImageIO;
-
 import java.awt.*;
 import java.awt.RenderingHints.Key;
 import java.awt.geom.*;
@@ -1313,6 +1313,33 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
 
     public boolean isSupportsCMYKColors() {
         return true;
+    }
+
+    @Override
+    public void drawWithGraphics(float x, float y, float width, float height, OutputDeviceGraphicsDrawer renderer) {
+        try {
+            PdfBoxGraphics2D pdfBoxGraphics2D = new PdfBoxGraphics2D(_writer, (int) width, (int) height);
+            /*
+             * We *could* customize the PDF mapping here. But for now the default is enough.
+             */
+
+            /*
+             * Do rendering
+             */
+            renderer.render(pdfBoxGraphics2D);
+            /*
+             * Dispose to close the XStream
+             */
+            pdfBoxGraphics2D.dispose();
+
+            /*
+             * And then stamp it
+             */
+            _cp.placeXForm(x,y,pdfBoxGraphics2D.getXFormObject());
+        }
+        catch(IOException e){
+            throw new RuntimeException("Error while drawing on Graphics2D", e);
+        }
     }
 
     public List findPagePositionsByID(CssContext c, Pattern pattern) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSVGReplacedElement.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSVGReplacedElement.java
@@ -1,13 +1,12 @@
 package com.openhtmltopdf.pdfboxout;
 
-import java.awt.Point;
-
-import org.w3c.dom.Element;
-
 import com.openhtmltopdf.extend.SVGDrawer;
 import com.openhtmltopdf.layout.LayoutContext;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.RenderingContext;
+import org.w3c.dom.Element;
+
+import java.awt.*;
 
 public class PdfBoxSVGReplacedElement implements PdfBoxReplacedElement {
     private final Element e;
@@ -80,6 +79,6 @@ public class PdfBoxSVGReplacedElement implements PdfBoxReplacedElement {
 
     @Override
     public void paint(RenderingContext c, PdfBoxOutputDevice outputDevice, BlockBox box) {
-        svg.drawSVG(e, outputDevice, c, point.getX(), point.getY(), this.dotsPerPixel * 96f);
+        svg.drawSVG(e, outputDevice, c, point.getX(), point.getY(), getIntrinsicWidth(), getIntrinsicHeight(), dotsPerPixel);
     }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
@@ -320,7 +320,7 @@ public class PdfContentStreamAdapter {
         try {
 			cs.saveGraphicsState();
 			AffineTransform tf = new AffineTransform();
-            tf.translate(x,y);
+            tf.translate(x,0);
 			cs.transform(new Matrix(tf));
 			cs.drawForm(xFormObject);
 			cs.restoreGraphicsState();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
@@ -1,19 +1,20 @@
 package com.openhtmltopdf.pdfboxout;
 
-import java.awt.geom.AffineTransform;
-import java.io.IOException;
-import java.util.Locale;
-
+import com.openhtmltopdf.util.XRLog;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
 import org.apache.pdfbox.util.Matrix;
 
-import com.openhtmltopdf.util.XRLog;
+import java.awt.geom.AffineTransform;
+import java.io.IOException;
+import java.util.Locale;
 
 public class PdfContentStreamAdapter {
     private final PDPageContentStream cs;
+
 
     public static class PdfException extends RuntimeException {
         private static final long serialVersionUID = 1L;
@@ -48,11 +49,11 @@ public class PdfContentStreamAdapter {
             logAndThrow("addRect", e);
         }
     }
-    
+
     public void newPath() {
         // I think PDF-BOX does this automatically.
     }
-    
+
     public void setExtGState(PDExtendedGraphicsState gs) {
         try {
             cs.setGraphicsStateParameters(gs);
@@ -283,6 +284,12 @@ public class PdfContentStreamAdapter {
 
     public void setMiterLimit(float miterLimit) {
         // TODO Not currently supported by PDF-BOX.
+		// TODO: Use official API when the next version is released. See PDFBOX-3669
+        try {
+            cs.appendRawCommands(miterLimit + " M ");
+        } catch (IOException e) {
+            logAndThrow("drawImage", e);
+        }
     }
 
     public void setTextSpacing(float nonSpaceAdjust) {
@@ -306,6 +313,19 @@ public class PdfContentStreamAdapter {
            cs.transform(new Matrix(transform));
         } catch (IOException e) {
             logAndThrow("setPdfMatrix", e);
+        }
+    }
+
+    public void placeXForm(float x, float y, PDFormXObject xFormObject) {
+        try {
+			cs.saveGraphicsState();
+			AffineTransform tf = new AffineTransform();
+            tf.translate(x,y);
+			cs.transform(new Matrix(tf));
+			cs.drawForm(xFormObject);
+			cs.restoreGraphicsState();
+        } catch (IOException e) {
+            logAndThrow("placeXForm", e);
         }
     }
 }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGDrawer.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGDrawer.java
@@ -1,8 +1,12 @@
 package com.openhtmltopdf.svgsupport;
 
-import java.util.List;
-import java.util.logging.Level;
-
+import com.openhtmltopdf.css.sheet.FontFaceRule;
+import com.openhtmltopdf.extend.OutputDevice;
+import com.openhtmltopdf.extend.SVGDrawer;
+import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.render.RenderingContext;
+import com.openhtmltopdf.svgsupport.PDFTranscoder.OpenHtmlFontResolver;
+import com.openhtmltopdf.util.XRLog;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.transcoder.TranscoderException;
 import org.apache.batik.transcoder.TranscoderInput;
@@ -11,13 +15,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
-import com.openhtmltopdf.css.sheet.FontFaceRule;
-import com.openhtmltopdf.extend.OutputDevice;
-import com.openhtmltopdf.extend.SVGDrawer;
-import com.openhtmltopdf.layout.SharedContext;
-import com.openhtmltopdf.render.RenderingContext;
-import com.openhtmltopdf.svgsupport.PDFTranscoder.OpenHtmlFontResolver;
-import com.openhtmltopdf.util.XRLog;
+import java.util.List;
+import java.util.logging.Level;
 
 public class BatikSVGDrawer implements SVGDrawer {
 
@@ -32,14 +31,14 @@ public class BatikSVGDrawer implements SVGDrawer {
 	}
 	
 	@Override
-	public void drawSVG(Element svgElement, OutputDevice outputDevice, RenderingContext ctx, double x, double y, float dotsPerInch) {
+	public void drawSVG(Element svgElement, OutputDevice outputDevice, RenderingContext ctx, double x, double y, double width, double height, double dotsPerPixel) {
 
 		if (this.fontResolver == null) {
 			XRLog.general(Level.INFO, "importFontFaceRules has not been called for this pdf transcoder");
 			this.fontResolver = new OpenHtmlFontResolver();
 		}
 		
-		PDFTranscoder transcoder = new PDFTranscoder(outputDevice, ctx, x, y, this.fontResolver, dotsPerInch);
+		PDFTranscoder transcoder = new PDFTranscoder(outputDevice, ctx, x, y, width, height, this.fontResolver, dotsPerPixel);
 		
 		try {
 			DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFGraphics2DOutputDeviceAdapter.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFGraphics2DOutputDeviceAdapter.java
@@ -1,19 +1,12 @@
 package com.openhtmltopdf.svgsupport;
 
-import java.awt.AlphaComposite;
-import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsDevice;
-import java.awt.Image;
-import java.awt.Paint;
-import java.awt.Rectangle;
-import java.awt.Shape;
-import java.awt.Stroke;
+import com.openhtmltopdf.css.parser.FSRGBColor;
+import com.openhtmltopdf.extend.OutputDevice;
+import com.openhtmltopdf.render.RenderingContext;
+import org.apache.batik.ext.awt.g2d.AbstractGraphics2D;
+import org.apache.batik.ext.awt.g2d.GraphicContext;
+
+import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
@@ -22,13 +15,7 @@ import java.awt.image.RenderedImage;
 import java.awt.image.renderable.RenderableImage;
 import java.text.AttributedCharacterIterator;
 
-import org.apache.batik.ext.awt.g2d.AbstractGraphics2D;
-import org.apache.batik.ext.awt.g2d.GraphicContext;
-
-import com.openhtmltopdf.css.parser.FSRGBColor;
-import com.openhtmltopdf.extend.OutputDevice;
-import com.openhtmltopdf.render.RenderingContext;
-
+@Deprecated
 public class PDFGraphics2DOutputDeviceAdapter extends AbstractGraphics2D {
 
 	private final RenderingContext ctx;


### PR DESCRIPTION
This implements the SVG rendering using my pdfbox-graphics2d (see https://github.com/rototor/pdfbox-graphics2d). 

Run the testrunner and look at the resulting svg-inline.pdf. The SVGs are drawn, but the position and size is wrong. Also the text on the barchart-sample is not displayed. (This works in the pdfbox-graphics2d testdriver, so something must be wrong with the font resolving, did not investigate yet). 

At the moment I have no idea how to position right.

The PDFBox-Graphics2D puts all drawcalls into a XForm. This XForm can then be placed wherever one may want. 

PdfBoxOutputDevice.drawWithGraphics() and PdfContentStreamAdapter.placeXForm() may need to be adapted to scale and place the resulting XForm correct. 

drawWithGraphics() should not only work with SVGs but in general, because we have some reports were we draw bar graphs using Graphics2D. These reports are still using JasperReports (and iText underneath), but we want to migrate away from  JasperReports and iText to openhtmltopdf.

It would be perfect if one could call drawWithGraphics() only with the position arguments of the ReplacedElement and the resulting XForm would be placed correctly. 

Do you have any hints how this can be implemented or could you fix the positioning?

Thanks.