### PR TITLE
Graphics2d builder and testdriver 

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -30,17 +30,8 @@ import java.awt.geom.AffineTransform;
 import java.util.List;
 
 public interface OutputDevice {
-
-	// Required for SVG output.
-	public void saveState();
-	public void restoreState();
-	
 	public void setPaint(Paint paint);
 	public void setAlpha(int alpha);
-	
-	public void setRawClip(Shape s);
-	public void rawClip(Shape s);
-	public Shape getRawClip();
 
 	// Required for CSS transforms.
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/Java2DRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/Java2DRendererBuilder.java
@@ -1,6 +1,5 @@
 package com.openhtmltopdf.simple;
 
-import com.openhtmltopdf.css.parser.property.PrimitivePropertyBuilders;
 import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.layout.LayoutContext;
 import com.openhtmltopdf.render.BlockBox;
@@ -14,9 +13,6 @@ import org.w3c.dom.Element;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Build a Java2D renderer for a given
@@ -35,24 +31,6 @@ public class Java2DRendererBuilder {
 	private FSTextTransformer _unicodeToUpperTransformer;
 	private FSTextTransformer _unicodeToLowerTransformer;
 	private FSTextTransformer _unicodeToTitleTransformer;
-	private List<AddedFont> _fonts = new ArrayList<AddedFont>();
-
-	private static class AddedFont {
-		private final FSSupplier<InputStream> supplier;
-		private final Integer weight;
-		private final String family;
-		private final boolean subset;
-		private final PrimitivePropertyBuilders.FontStyle style;
-
-		private AddedFont(FSSupplier<InputStream> supplier, Integer weight, String family, boolean subset,
-				PrimitivePropertyBuilders.FontStyle style) {
-			this.supplier = supplier;
-			this.weight = weight;
-			this.family = family;
-			this.subset = subset;
-			this.style = style;
-		}
-	}
 
 	/**
 	 * Provides an HttpStreamFactory implementation if the user desires to use
@@ -123,87 +101,6 @@ public class Java2DRendererBuilder {
 	 */
 	public Java2DRendererBuilder useSVGDrawer(SVGDrawer svgImpl) {
 		this._svgImpl = svgImpl;
-		return this;
-	}
-
-	/**
-	 * The replacement text to use if a character is cannot be renderered by any
-	 * of the specified fonts. This is not broken across lines so should be one
-	 * or zero characters for best results. Also, make sure it can be rendered
-	 * by at least one of your specified fonts! The default is the # character.
-	 *
-	 * @param replacement
-	 * @return
-	 */
-	public Java2DRendererBuilder useReplacementText(String replacement) {
-		this._replacementText = replacement;
-		return this;
-	}
-
-	/**
-	 * Specify the line breaker. By default a Java default BreakIterator line
-	 * instance is used with US locale. Additionally, this is wrapped with
-	 * UrlAwareLineBreakIterator to also break before the forward slash (/)
-	 * character so that long URIs can be broken on to multiple lines.
-	 * <p>
-	 * You may want to use a BreakIterator with a different locale (wrapped by
-	 * UrlAwareLineBreakIterator or not) or a more advanced BreakIterator from
-	 * icu4j (see the rtl-support module for an example).
-	 *
-	 * @param breaker
-	 * @return
-	 */
-	public Java2DRendererBuilder useUnicodeLineBreaker(FSTextBreaker breaker) {
-		this._lineBreaker = breaker;
-		return this;
-	}
-
-	/**
-	 * Specify the character breaker. By default a break iterator character
-	 * instance is used with US locale. Currently this is used when
-	 * <code>word-wrap: break-word</code> is in effect.
-	 *
-	 * @param breaker
-	 * @return
-	 */
-	public Java2DRendererBuilder useUnicodeCharacterBreaker(FSTextBreaker breaker) {
-		this._charBreaker = breaker;
-		return this;
-	}
-
-	/**
-	 * Specify a transformer to use to upper case strings. By default
-	 * <code>String::toUpperCase(Locale.US)</code> is used.
-	 *
-	 * @param tr
-	 * @return
-	 */
-	public Java2DRendererBuilder useUnicodeToUpperTransformer(FSTextTransformer tr) {
-		this._unicodeToUpperTransformer = tr;
-		return this;
-	}
-
-	/**
-	 * Specify a transformer to use to lower case strings. By default
-	 * <code>String::toLowerCase(Locale.US)</code> is used.
-	 *
-	 * @param tr
-	 * @return
-	 */
-	public Java2DRendererBuilder useUnicodeToLowerTransformer(FSTextTransformer tr) {
-		this._unicodeToLowerTransformer = tr;
-		return this;
-	}
-
-	/**
-	 * Specify a transformer to title case strings. By default a best effort
-	 * implementation (non locale aware) is used.
-	 *
-	 * @param tr
-	 * @return
-	 */
-	public Java2DRendererBuilder useUnicodeToTitleTransformer(FSTextTransformer tr) {
-		this._unicodeToTitleTransformer = tr;
 		return this;
 	}
 
@@ -372,6 +269,7 @@ public class Java2DRendererBuilder {
 		}
 	}
 
+
 	public static class Java2DReplacedElementFactory extends SwingReplacedElementFactory {
 		private SVGDrawer _svgImpl;
 
@@ -384,12 +282,12 @@ public class Java2DRendererBuilder {
 			}
 
 			String nodeName = e.getNodeName();
-			if (nodeName.equals("svg") && _svgImpl != null) {
+			if (nodeName.equals("svg") && _svgImpl != null)
 				return new Java2DSVGReplacedElement(e, _svgImpl, cssWidth, cssHeight);
-				/*
-				 * Default: Just let the base class handle everything
-				 */
-			}
+
+			/*
+			 * Default: Just let the base class handle everything
+			 */
 			return super.createReplacedElement(context, box, uac, cssWidth, cssHeight);
 		}
 	}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/Java2DRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/Java2DRendererBuilder.java
@@ -15,7 +15,8 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 
 /**
- * Build a Java2D renderer for a given
+ * Build a Java2D renderer for a given HTML. The renderer allows to get a
+ * BufferedImage of the HTML and to render it in components (using Graphics2D).
  */
 public class Java2DRendererBuilder {
 	private HttpStreamFactory _httpStreamFactory;
@@ -268,7 +269,6 @@ public class Java2DRendererBuilder {
 			}
 		}
 	}
-
 
 	public static class Java2DReplacedElementFactory extends SwingReplacedElementFactory {
 		private SVGDrawer _svgImpl;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/Java2DRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/Java2DRendererBuilder.java
@@ -1,0 +1,397 @@
+package com.openhtmltopdf.simple;
+
+import com.openhtmltopdf.css.parser.property.PrimitivePropertyBuilders;
+import com.openhtmltopdf.extend.*;
+import com.openhtmltopdf.layout.LayoutContext;
+import com.openhtmltopdf.render.BlockBox;
+import com.openhtmltopdf.render.RenderingContext;
+import com.openhtmltopdf.simple.extend.XhtmlNamespaceHandler;
+import com.openhtmltopdf.swing.EmptyReplacedElement;
+import com.openhtmltopdf.swing.NaiveUserAgent;
+import com.openhtmltopdf.swing.SwingReplacedElementFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Build a Java2D renderer for a given
+ */
+public class Java2DRendererBuilder {
+	private HttpStreamFactory _httpStreamFactory;
+	private FSCache _cache;
+	private FSUriResolver _resolver;
+	private String _html;
+	private String _baseUri;
+	private Document _document;
+	private SVGDrawer _svgImpl;
+	private String _replacementText;
+	private FSTextBreaker _lineBreaker;
+	private FSTextBreaker _charBreaker;
+	private FSTextTransformer _unicodeToUpperTransformer;
+	private FSTextTransformer _unicodeToLowerTransformer;
+	private FSTextTransformer _unicodeToTitleTransformer;
+	private List<AddedFont> _fonts = new ArrayList<AddedFont>();
+
+	private static class AddedFont {
+		private final FSSupplier<InputStream> supplier;
+		private final Integer weight;
+		private final String family;
+		private final boolean subset;
+		private final PrimitivePropertyBuilders.FontStyle style;
+
+		private AddedFont(FSSupplier<InputStream> supplier, Integer weight, String family, boolean subset,
+				PrimitivePropertyBuilders.FontStyle style) {
+			this.supplier = supplier;
+			this.weight = weight;
+			this.family = family;
+			this.subset = subset;
+			this.style = style;
+		}
+	}
+
+	/**
+	 * Provides an HttpStreamFactory implementation if the user desires to use
+	 * an external HTTP/HTTPS implementation. Uses URL::openStream by default.
+	 *
+	 * @param factory
+	 * @return
+	 */
+	public Java2DRendererBuilder useHttpStreamImplementation(HttpStreamFactory factory) {
+		this._httpStreamFactory = factory;
+		return this;
+	}
+
+	/**
+	 * Provides a uri resolver to resolve relative uris or private uri schemes.
+	 *
+	 * @param resolver
+	 * @return
+	 */
+	public Java2DRendererBuilder useUriResolver(FSUriResolver resolver) {
+		this._resolver = resolver;
+		return this;
+	}
+
+	/**
+	 * Provides an external cache which can choose to cache items between runs,
+	 * such as fonts or logo images.
+	 *
+	 * @param cache
+	 * @return
+	 */
+	public Java2DRendererBuilder useCache(FSCache cache) {
+		this._cache = cache;
+		return this;
+	}
+
+	/**
+	 * Provides a string containing XHTML/XML to convert to PDF.
+	 *
+	 * @param html
+	 * @param baseUri
+	 * @return
+	 */
+	public Java2DRendererBuilder withHtmlContent(String html, String baseUri) {
+		this._html = html;
+		this._baseUri = baseUri;
+		return this;
+	}
+
+	/**
+	 * Provides a w3c DOM Document acquired from an external source.
+	 *
+	 * @param doc
+	 * @param baseUri
+	 * @return
+	 */
+	public Java2DRendererBuilder withW3cDocument(org.w3c.dom.Document doc, String baseUri) {
+		this._document = doc;
+		this._baseUri = baseUri;
+		return this;
+	}
+
+	/**
+	 * Uses the specified SVG drawer implementation.
+	 *
+	 * @param svgImpl
+	 * @return
+	 */
+	public Java2DRendererBuilder useSVGDrawer(SVGDrawer svgImpl) {
+		this._svgImpl = svgImpl;
+		return this;
+	}
+
+	/**
+	 * The replacement text to use if a character is cannot be renderered by any
+	 * of the specified fonts. This is not broken across lines so should be one
+	 * or zero characters for best results. Also, make sure it can be rendered
+	 * by at least one of your specified fonts! The default is the # character.
+	 *
+	 * @param replacement
+	 * @return
+	 */
+	public Java2DRendererBuilder useReplacementText(String replacement) {
+		this._replacementText = replacement;
+		return this;
+	}
+
+	/**
+	 * Specify the line breaker. By default a Java default BreakIterator line
+	 * instance is used with US locale. Additionally, this is wrapped with
+	 * UrlAwareLineBreakIterator to also break before the forward slash (/)
+	 * character so that long URIs can be broken on to multiple lines.
+	 * <p>
+	 * You may want to use a BreakIterator with a different locale (wrapped by
+	 * UrlAwareLineBreakIterator or not) or a more advanced BreakIterator from
+	 * icu4j (see the rtl-support module for an example).
+	 *
+	 * @param breaker
+	 * @return
+	 */
+	public Java2DRendererBuilder useUnicodeLineBreaker(FSTextBreaker breaker) {
+		this._lineBreaker = breaker;
+		return this;
+	}
+
+	/**
+	 * Specify the character breaker. By default a break iterator character
+	 * instance is used with US locale. Currently this is used when
+	 * <code>word-wrap: break-word</code> is in effect.
+	 *
+	 * @param breaker
+	 * @return
+	 */
+	public Java2DRendererBuilder useUnicodeCharacterBreaker(FSTextBreaker breaker) {
+		this._charBreaker = breaker;
+		return this;
+	}
+
+	/**
+	 * Specify a transformer to use to upper case strings. By default
+	 * <code>String::toUpperCase(Locale.US)</code> is used.
+	 *
+	 * @param tr
+	 * @return
+	 */
+	public Java2DRendererBuilder useUnicodeToUpperTransformer(FSTextTransformer tr) {
+		this._unicodeToUpperTransformer = tr;
+		return this;
+	}
+
+	/**
+	 * Specify a transformer to use to lower case strings. By default
+	 * <code>String::toLowerCase(Locale.US)</code> is used.
+	 *
+	 * @param tr
+	 * @return
+	 */
+	public Java2DRendererBuilder useUnicodeToLowerTransformer(FSTextTransformer tr) {
+		this._unicodeToLowerTransformer = tr;
+		return this;
+	}
+
+	/**
+	 * Specify a transformer to title case strings. By default a best effort
+	 * implementation (non locale aware) is used.
+	 *
+	 * @param tr
+	 * @return
+	 */
+	public Java2DRendererBuilder useUnicodeToTitleTransformer(FSTextTransformer tr) {
+		this._unicodeToTitleTransformer = tr;
+		return this;
+	}
+
+	/**
+	 * Built renderer, which can be used to render the document as image or to a
+	 * Graphics2D
+	 */
+	public interface IJava2DRenderer {
+		/**
+		 * Builds an Image
+		 */
+		BufferedImage renderToImage(int width, int bufferedImageType);
+
+		/**
+		 * Layout the HTML for the given width
+		 */
+		void layout(int width);
+
+		/**
+		 * Draw the HTML on the given Graphics2D. It will be drawn on (0,0). So
+		 * if you want the rendering somewhere else you should first apply the
+		 * needed transforms and or clippings on gfx before calling this method.
+		 * 
+		 * Note: You must call layout() at least once before calling this
+		 * method!
+		 * 
+		 * @param gfx
+		 *            graphics 2D to draw to.
+		 */
+		void render(Graphics2D gfx);
+
+	}
+
+	/**
+	 * Build a renderer
+	 *
+	 * @return a renderer which can be used to create images or draw to a
+	 *         Graphics2D
+	 */
+	public IJava2DRenderer build() {
+		final XHTMLPanel panel = new XHTMLPanel();
+		panel.setInteractive(false);
+
+		NaiveUserAgent userAgent = new NaiveUserAgent();
+		userAgent.setBaseURL(_baseUri);
+		if (_httpStreamFactory != null)
+			userAgent.setHttpStreamFactory(_httpStreamFactory);
+
+		if (_resolver != null)
+			userAgent.setUriResolver(_resolver);
+
+		if (_cache != null)
+			userAgent.setExternalCache(_cache);
+
+		panel.getSharedContext().setUserAgentCallback(userAgent);
+		Java2DReplacedElementFactory ref = new Java2DReplacedElementFactory();
+		ref._svgImpl = _svgImpl;
+		panel.getSharedContext().setReplacedElementFactory(ref);
+
+		if (_html != null)
+			panel.setDocumentFromString(_html, _baseUri, new XhtmlNamespaceHandler());
+		if (_document != null)
+			panel.setDocument(_document, _baseUri, new XhtmlNamespaceHandler());
+
+		return new IJava2DRenderer() {
+
+			@Override
+			public BufferedImage renderToImage(int width, int bufferedImageType) {
+				layout(width);
+
+				// get size
+				Rectangle rect;
+				if (panel.getPreferredSize() != null) {
+					rect = new Rectangle(0, 0, (int) panel.getPreferredSize().getWidth(),
+							(int) panel.getPreferredSize().getHeight());
+				} else {
+					rect = new Rectangle(0, 0, panel.getWidth(), panel.getHeight());
+				}
+
+				// render into real buffer
+				BufferedImage buff = new BufferedImage((int) rect.getWidth(), (int) rect.getHeight(),
+						bufferedImageType);
+				Graphics2D g = (Graphics2D) buff.getGraphics();
+				if (buff.getColorModel().hasAlpha()) {
+					g.clearRect(0, 0, (int) rect.getWidth(), (int) rect.getHeight());
+				} else {
+					g.setColor(Color.WHITE);
+					g.fillRect(0, 0, (int) rect.getWidth(), (int) rect.getHeight());
+				}
+				render(g);
+				g.dispose();
+
+				return buff;
+			}
+
+			@Override
+			public void layout(int width) {
+				Dimension dim = new Dimension(width, 100);
+
+				// do layout with temp buffer
+				BufferedImage buff = new BufferedImage((int) dim.getWidth(), (int) dim.getHeight(),
+						BufferedImage.TYPE_3BYTE_BGR);
+				Graphics2D g = (Graphics2D) buff.getGraphics();
+				panel.setSize(dim);
+				panel.doDocumentLayout(g);
+				g.dispose();
+
+			}
+
+			@Override
+			public void render(Graphics2D gfx) {
+				panel.paintComponent(gfx);
+			}
+		};
+	}
+
+	public static abstract class Graphics2DPaintingReplacedElement extends EmptyReplacedElement {
+		protected Graphics2DPaintingReplacedElement(int width, int height) {
+			super(width, height);
+		}
+
+		public abstract void paint(OutputDevice outputDevice, RenderingContext ctx, double x, double y, double width,
+				double height);
+
+		public static double DOTS_PER_INCH = 72.0;
+	}
+
+	private static class Java2DSVGReplacedElement extends Graphics2DPaintingReplacedElement {
+		private final SVGDrawer _svgImpl;
+		private final Element e;
+
+		public Java2DSVGReplacedElement(Element e, SVGDrawer svgImpl, int width, int height) {
+			super(width, height);
+			this.e = e;
+			this._svgImpl = svgImpl;
+		}
+
+		@Override
+		public void paint(OutputDevice outputDevice, RenderingContext ctx, double x, double y, double width,
+				double height) {
+			_svgImpl.drawSVG(e, outputDevice, ctx, x, y, width, height, DOTS_PER_INCH);
+		}
+
+		@Override
+		public int getIntrinsicWidth() {
+			if (super.getIntrinsicWidth() >= 0) {
+				// CSS takes precedence over width and height defined on
+				// element.
+				return super.getIntrinsicWidth();
+			} else {
+				// Seems to need dots rather than pixels.
+				return this._svgImpl.getSVGWidth(e);
+			}
+		}
+
+		@Override
+		public int getIntrinsicHeight() {
+			if (super.getIntrinsicHeight() >= 0) {
+				// CSS takes precedence over width and height defined on
+				// element.
+				return super.getIntrinsicHeight();
+			} else {
+				// Seems to need dots rather than pixels.
+				return this._svgImpl.getSVGHeight(e);
+			}
+		}
+	}
+
+	public static class Java2DReplacedElementFactory extends SwingReplacedElementFactory {
+		private SVGDrawer _svgImpl;
+
+		@Override
+		public ReplacedElement createReplacedElement(LayoutContext context, BlockBox box, UserAgentCallback uac,
+				int cssWidth, int cssHeight) {
+			Element e = box.getElement();
+			if (e == null) {
+				return null;
+			}
+
+			String nodeName = e.getNodeName();
+			if (nodeName.equals("svg") && _svgImpl != null) {
+				return new Java2DSVGReplacedElement(e, _svgImpl, cssWidth, cssHeight);
+				/*
+				 * Default: Just let the base class handle everything
+				 */
+			}
+			return super.createReplacedElement(context, box, uac, cssWidth, cssHeight);
+		}
+	}
+
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
@@ -292,17 +292,6 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 	private Stack<AffineTransform> transformStack = new Stack<AffineTransform>();
     private Stack<Shape> clipStack= new Stack<Shape>();
 
-	@Override
-	public void saveState() {
-		transformStack.push(_graphics.getTransform());
-		clipStack.push(_graphics.getClip());
-	}
-
-	@Override
-	public void restoreState() {
-		_graphics.setTransform(transformStack.pop());
-		_graphics.setClip(clipStack.pop());
-	}
 
 	@Override
 	public void setPaint(Paint paint) {
@@ -313,24 +302,6 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 	public void setAlpha(int alpha) {
 		// TODO Auto-generated method stub
 		
-	}
-
-	@Override
-	public void setRawClip(Shape s) {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	public void rawClip(Shape s) {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	public Shape getRawClip() {
-		// TODO Auto-generated method stub
-		return null;
 	}
 
     @Override

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
@@ -23,17 +23,18 @@ import com.openhtmltopdf.css.parser.FSColor;
 import com.openhtmltopdf.css.parser.FSRGBColor;
 import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.render.*;
+import com.openhtmltopdf.simple.Java2DRendererBuilder;
 
 import javax.swing.*;
-
 import java.awt.*;
 import java.awt.RenderingHints.Key;
 import java.awt.font.GlyphVector;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
-import java.util.*;
+import java.util.Collections;
 import java.util.List;
+import java.util.Stack;
 
 public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDevice {
     private final Graphics2D _graphics;
@@ -179,7 +180,11 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
             Point location = replaced.getLocation();
             _graphics.drawImage(
                     image, (int)location.getX(), (int)location.getY(), null);
-        }
+		} else if (replaced instanceof Java2DRendererBuilder.Graphics2DPaintingReplacedElement) {
+			Rectangle contentBounds = box.getContentAreaEdge(box.getAbsX(), box.getAbsY(), c);
+			((Java2DRendererBuilder.Graphics2DPaintingReplacedElement) replaced).paint(this, c, contentBounds.x,
+					contentBounds.y, contentBounds.width, contentBounds.height);
+		}
     }
     
     public void setColor(FSColor color) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DRenderer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DRenderer.java
@@ -70,7 +70,9 @@ import com.openhtmltopdf.util.ThreadCtx;
  * <p>Not thread-safe.</p>
  *
  * @see ITextRenderer
+ * @deprecated do not use, seems to be broken
  */
+@Deprecated
 public class Java2DRenderer {
 	private static final int DEFAULT_HEIGHT = 1000;
 	private static final int DEFAULT_DOTS_PER_POINT = 1;

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -4,6 +4,7 @@ import com.openhtmltopdf.bidi.support.ICUBidiReorderer;
 import com.openhtmltopdf.bidi.support.ICUBidiSplitter;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.TextDirection;
+import com.openhtmltopdf.simple.Graphics2DRenderer;
 import com.openhtmltopdf.svgsupport.BatikSVGDrawer;
 import com.openhtmltopdf.util.JDKXRLogger;
 import com.openhtmltopdf.util.XRLog;
@@ -11,9 +12,13 @@ import com.openhtmltopdf.util.XRLogger;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.util.Charsets;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.logging.Level;
 
@@ -133,15 +138,26 @@ public class TestcaseRunner {
 		}
 	}
 
+	private static void renderPNG(URL f, OutputStream outputStream) throws IOException {
+		BufferedImage image = Graphics2DRenderer.renderToImageAutoSize(f.toExternalForm(),
+				512, BufferedImage.TYPE_INT_ARGB);
+		ImageIO.write(image,"PNG",outputStream);
+		outputStream.close();
+				
+	}
+
 	public static void runTestCase(String testCaseFile) throws Exception {
-		byte[] htmlBytes = IOUtils.toByteArray(TestcaseRunner.class
-				.getResourceAsStream("/testcases/" + testCaseFile + ".html"));
+		byte[] htmlBytes = IOUtils
+				.toByteArray(TestcaseRunner.class.getResourceAsStream("/testcases/" + testCaseFile + ".html"));
 		String html = new String(htmlBytes, Charsets.UTF_8);
 		String outDir = System.getProperty("OUT_DIRECTORY", ".");
 		String testCaseOutputFile = outDir + "/" + testCaseFile + ".pdf";
+		String testCaseOutputPNGFile = outDir + "/" + testCaseFile + ".png";
 		FileOutputStream outputStream = new FileOutputStream(testCaseOutputFile);
-
 		renderPDF(html, outputStream);
 		System.out.println("Wrote " + testCaseOutputFile);
+
+		FileOutputStream outputStreamPNG = new FileOutputStream(testCaseOutputPNGFile);
+		renderPNG(TestcaseRunner.class.getResource("/testcases/" + testCaseFile + ".html"), outputStreamPNG);
 	}
 }

--- a/openhtmltopdf-examples/src/main/resources/testcases/moonbase.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/moonbase.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de"><body>Moonbase</body></html>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -1486,20 +1486,6 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
     }
     
 
-    // The below methods are for the experimental SVG code and should not be used for other uses.
-    
-    @Override
-    @Deprecated
-    public void saveState() {
-        _cp.saveGraphics();
-        
-    }
-
-    @Override
-    @Deprecated
-    public void restoreState() {
-        _cp.restoreGraphics();
-    }
 
     @Override
     public void setPaint(Paint paint) {
@@ -1514,28 +1500,5 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
     @Override
     public void setAlpha(int alpha) {
         
-    }
-
-    @Override
-    @Deprecated
-    public void setRawClip(Shape s) {
-        _clip = new Area(s);
-        followPath(s, CLIP);
-    }
-
-    @Override
-    @Deprecated
-    public void rawClip(Shape s) {
-        if (_clip == null)
-            _clip = new Area(s);
-        else
-            _clip.intersect(new Area(s));
-        followPath(s, CLIP);
-    }
-    
-    @Override
-    @Deprecated
-    public Shape getRawClip() {
-        return _clip;
     }
 }


### PR DESCRIPTION
I've started to update the Graphics2D support. To do so I've created a Java2DRendererBuilder and called it in the testdriver to write a PNG output beside the PDF output. I also tried to reproduce #63  with this, but I could not. 

The PNG currently shows some missing features and bugs:
 - CMYK colors are not supported at the moment. We should just use some simple hardcoded CMYK->RGB conversion for that as a start. I think using some kind of ICC-based color conversion is overkill here.
- For whatever reason the text in the svg-sample is rendered broken. I think for Java2D the correct fix is to just use TextLayout and let TextLayout do all the rendering. Then Java2D will have as much Bidi support as Java itself has. 
- Also the (partly) unused support for drawing selections is obsolete. If someone wants to display HTML in his application he will likely rather use the JavaFX-WebKit component from the JDK. For me the Java2D support is mostly the ability to render HTML to an image, so selections aren't really needed. I think the selection support should just be deleted.
- The current place where I've put the Java2DRendererBuilder is not the best one. Also the innerclasses should maybe be outerclasses in some other packages. Feel free to suggest a better place.

When I find time again I would like to work on this things. Do you have any objections?