### PR TITLE
Support all <meta>-data

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -1258,7 +1258,7 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
 
     // Class for storing metadata element name/content pairs from the head
     // section of an xhtml document.
-    private static class Metadata {
+    static class Metadata {
         private String _name;
         private String _content;
 
@@ -1285,6 +1285,14 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
     }
 
     // Metadata end
+
+
+    /**
+     * @return All metadata entries
+     */
+    List<Metadata> getMetadata() {
+        return _metadata;
+    }
 
     public SharedContext getSharedContext() {
         return _sharedContext;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -25,13 +25,7 @@ import com.openhtmltopdf.bidi.BidiSplitterFactory;
 import com.openhtmltopdf.bidi.SimpleBidiReorderer;
 import com.openhtmltopdf.context.StyleReference;
 import com.openhtmltopdf.css.style.CalculatedStyle;
-import com.openhtmltopdf.extend.FSCache;
-import com.openhtmltopdf.extend.FSObjectDrawerFactory;
-import com.openhtmltopdf.extend.FSUriResolver;
-import com.openhtmltopdf.extend.HttpStreamFactory;
-import com.openhtmltopdf.extend.NamespaceHandler;
-import com.openhtmltopdf.extend.SVGDrawer;
-import com.openhtmltopdf.extend.UserInterface;
+import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.layout.BoxBuilder;
 import com.openhtmltopdf.layout.Layer;
 import com.openhtmltopdf.layout.LayoutContext;
@@ -39,6 +33,7 @@ import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.outputdevice.helper.BaseDocument;
 import com.openhtmltopdf.outputdevice.helper.PageDimensions;
 import com.openhtmltopdf.outputdevice.helper.UnicodeImplementation;
+import com.openhtmltopdf.pdfboxout.PdfBoxOutputDevice.Metadata;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.PageBox;
 import com.openhtmltopdf.render.RenderingContext;
@@ -611,28 +606,27 @@ public class PdfBoxRenderer {
 
     // Sets the document information dictionary values from html metadata
     private void setDidValues(PDDocument doc) {
-        String v = _outputDevice.getMetadataByName("title");
-
         PDDocumentInformation info = new PDDocumentInformation();
-        
-        if (v != null) {
-            info.setTitle(v);
-        }
-        v = _outputDevice.getMetadataByName("author");
-        if (v != null) {
-            info.setAuthor(v);
-        }
-        v = _outputDevice.getMetadataByName("subject");
-        if (v != null) {
-            info.setSubject(v);
-        }
-        v = _outputDevice.getMetadataByName("keywords");
-        if (v != null) {
-            info.setKeywords(v);
-        }
         
         info.setCreationDate(Calendar.getInstance());
         info.setProducer("openhtmltopdf.com");
+
+        for (Metadata metadata : _outputDevice.getMetadata()) {
+        	String name = metadata.getName();
+        	String content = metadata.getContent();
+        	if( content == null )
+        	    continue;
+            if( name.equals("title"))
+                info.setTitle(content);
+            else if( name.equals("author"))
+                info.setAuthor(content);
+            else if(name.equals("subject"))
+                info.setSubject(content);
+            else if(name.equals("keywords"))
+                info.setKeywords(content);
+            else
+                info.setCustomMetadataValue(name,content);
+        }
 
         doc.setDocumentInformation(info);
     }


### PR DESCRIPTION
Put the content of all non standard metadata into the Custom-Metadata of
the PDF. This allows to e.g. insert debuginfos into the PDF and also to
create additional metadata for other tools.