### PR TITLE
UNICODE font justification support

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -542,16 +542,36 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
         _cp.setTextMatrix((float) mx[0], b, c, (float) mx[3], (float) mx[4], (float) mx[5]);
 
         if (info != null ) {
-            // The JustificationInfo numbers need to be normalized using the current document DPI
-            _cp.setTextSpacing(info.getNonSpaceAdjust() / _dotsPerPoint);
-            _cp.setSpaceSpacing(info.getSpaceAdjust() / _dotsPerPoint);
+            // Justification must be done through TJ rendering because Tw param is not working for UNICODE fonts
+            Object[] array = makeJustificationArray(s, info);
+            _cp.drawArray(array);
         } else {
             _cp.setTextSpacing(0.0f);
             _cp.setSpaceSpacing(0.0f);
+            _cp.drawString(s);
         }
-        
-        _cp.drawString(s);
+
         _cp.endText();
+    }
+
+    private Object[] makeJustificationArray(String s, JustificationInfo info) {
+        List data = new ArrayList();
+
+        int len = s.length();
+        for (int i = 0; i < len; i++) {
+            char c = s.charAt(i);
+            data.add(Character.toString(c));
+            if (i != len - 1) {
+                float offset;
+                if (c == ' ' || c == '\u00a0' || c == '\u3000') {
+                    offset = info.getSpaceAdjust();
+                } else {
+                    offset = info.getNonSpaceAdjust();
+                }
+                data.add((-offset / _dotsPerPoint) * 1000 / (_font.getSize2D() / _dotsPerPoint));
+            }
+        }
+        return data.toArray();
     }
     
     public static class FontRun {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
@@ -273,6 +273,32 @@ public class PdfContentStreamAdapter {
         }
     }
 
+    public void drawArray(Object[] array) {
+        try {
+            cs.appendRawCommands("[");
+
+            boolean lastWasNumber = false;
+            for (Object obj : array) {
+                if (obj instanceof String) {
+                    drawString((String) obj);
+                    lastWasNumber = false;
+                } else {
+                    if (lastWasNumber) {
+                        cs.appendRawCommands(' ');
+                    } else {
+                        lastWasNumber = true;
+                    }
+
+                    cs.appendRawCommands((Float) obj);
+                }
+            }
+            cs.appendRawCommands("]TJ");
+            cs.appendRawCommands('\n');
+        } catch (IOException e) {
+            logAndThrow("drawArray", e);
+        }
+    }
+
     public void drawImage(PDImageXObject xobject, float x, float y, float w,
             float h) {
         try {


### PR DESCRIPTION
Text justification implemented in https://github.com/danfickle/openhtmltopdf/issues/3 will not work if using UNICODE fonts. 

The reason is that Tw parameter (word spacing) is ignored for non simple fonts as defined in pdf standard at https://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#651 page 253.

Therefore I reused the code from old iText output device which solved this problem.  