### PR TITLE
Add possibilty to programatically disable logging before first log

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLog.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLog.java
@@ -55,7 +55,7 @@ public class XRLog {
     private static boolean initPending = true;
     private static XRLogger loggerImpl;
 
-    private static boolean loggingEnabled = true;
+    private static Boolean loggingEnabled;
 
     /**
      * Returns a list of all loggers that will be accessed by XRLog. Each entry is a String with a logger
@@ -245,7 +245,9 @@ public class XRLog {
                 return;
             }
 
-            XRLog.setLoggingEnabled(Configuration.isTrue("xr.util-logging.loggingEnabled", true));
+            if (loggingEnabled == null) {
+            	XRLog.setLoggingEnabled(Configuration.isTrue("xr.util-logging.loggingEnabled", true));
+            }
 
             if (loggerImpl == null) {
                 loggerImpl = new JDKXRLogger();

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/XRLogTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/XRLogTest.java
@@ -1,0 +1,16 @@
+package com.openhtmltopdf.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XRLogTest {
+
+	@Test
+	public void testDisableLogBeforeFirstLog() {
+		XRLog.setLoggingEnabled(false);
+		Assert.assertFalse(XRLog.isLoggingEnabled());
+		XRLog.load("First log");
+		Assert.assertFalse(XRLog.isLoggingEnabled());
+	}
+	
+}


### PR DESCRIPTION
Hello!

I was using your nice lib and found out that calling `XRLog.setLoggingEnabled(false)` before any log was not working. In fact the value was always overriden by the configuration or default value when XRLog gets intialized at first log (maybe it's wanted though...)

Here is a quick fix I made, hope it can help!