### PR TITLE
Use fonts for graphics 2d

### DIFF
--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -238,12 +238,21 @@ public class TestcaseRunner {
 							renderTree(graphics2D, realWidth / 2f, realHeight - titleBottomHeight, realHeight / depth,
 									-90, depth);
 
-							Font dialog = Font.decode("Dialog").deriveFont(10f);
-							graphics2D.setFont(dialog);
-							String txt = "FanOut " + fanout + " Angle " + angle;
-							Rectangle2D textBounds = dialog.getStringBounds(txt,
+							Font font = Font.decode("Times New Roman").deriveFont(10f);
+							if (depth == 10)
+								font = Font.decode("Arial");
+							if (angle == 35)
+								font = Font.decode("Courier");
+							if (depth == 6)
+								font = Font.decode("Dialog"); /* Gets mapped to Helvetica */
+							graphics2D.setFont(font);
+							String txt = "FanOut " + fanout + " Angle " + angle + " Depth " + depth;
+							Rectangle2D textBounds = font.getStringBounds(txt,
 									graphics2D.getFontRenderContext());
-							graphics2D.setPaint(Color.GREEN);
+							graphics2D.setPaint(new Color(16, 133, 30));
+							GradientPaint gp = new GradientPaint(10.0f, 25.0f, Color.blue, (float) textBounds.getWidth(), (float) textBounds.getHeight(), Color.red);
+							if (angle == 35)
+								graphics2D.setPaint(gp);
 							graphics2D.drawString(txt, (int)((realWidth - textBounds.getWidth()) / 2), (int)(realHeight - titleBottomHeight));
 						}
 					});

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -238,13 +238,16 @@ public class TestcaseRunner {
 							renderTree(graphics2D, realWidth / 2f, realHeight - titleBottomHeight, realHeight / depth,
 									-90, depth);
 
+							/*
+							 * Now draw some text using different fonts to exercise all different font mappings
+							 */
 							Font font = Font.decode("Times New Roman").deriveFont(10f);
 							if (depth == 10)
-								font = Font.decode("Arial");
+								font = Font.decode("Arial"); // Does not get mapped
 							if (angle == 35)
-								font = Font.decode("Courier");
+								font = Font.decode("Courier"); // Would get mapped to Courier
 							if (depth == 6)
-								font = Font.decode("Dialog"); /* Gets mapped to Helvetica */
+								font = Font.decode("Dialog"); // Gets mapped to Helvetica
 							graphics2D.setFont(font);
 							String txt = "FanOut " + fanout + " Angle " + angle + " Depth " + depth;
 							Rectangle2D textBounds = font.getStringBounds(txt,

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -2,15 +2,15 @@ package com.openhtmltopdf.testcases;
 
 import com.openhtmltopdf.bidi.support.ICUBidiReorderer;
 import com.openhtmltopdf.bidi.support.ICUBidiSplitter;
+import com.openhtmltopdf.extend.FSObjectDrawer;
+import com.openhtmltopdf.extend.OutputDevice;
+import com.openhtmltopdf.extend.OutputDeviceGraphicsDrawer;
 import com.openhtmltopdf.java2d.api.BufferedImagePageProcessor;
 import com.openhtmltopdf.java2d.api.DefaultPageProcessor;
 import com.openhtmltopdf.java2d.api.FSPageOutputStreamSupplier;
 import com.openhtmltopdf.java2d.api.Java2DRendererBuilder;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.TextDirection;
-import com.openhtmltopdf.extend.FSObjectDrawer;
-import com.openhtmltopdf.extend.OutputDevice;
-import com.openhtmltopdf.extend.OutputDeviceGraphicsDrawer;
 import com.openhtmltopdf.render.DefaultObjectDrawerFactory;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.svgsupport.BatikSVGDrawer;
@@ -24,6 +24,7 @@ import org.w3c.dom.Element;
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.geom.Line2D;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
@@ -35,10 +36,9 @@ import java.util.logging.Level;
 public class TestcaseRunner {
 
 	/**
-	 * Runs our set of manual test cases. You can specify an output directory
-	 * with -DOUT_DIRECTORY=./output for example. Otherwise, the current working
-	 * directory is used. Test cases must be placed in
-	 * src/main/resources/testcases/
+	 * Runs our set of manual test cases. You can specify an output directory with
+	 * -DOUT_DIRECTORY=./output for example. Otherwise, the current working
+	 * directory is used. Test cases must be placed in src/main/resources/testcases/
 	 *
 	 * @param args
 	 * @throws Exception
@@ -49,8 +49,7 @@ public class TestcaseRunner {
 		 * Note: The RepeatedTableSample optionally requires the font file
 		 * NotoSans-Regular.ttf to be placed in the resources directory.
 		 * 
-		 * This sample demonstrates the failing repeated table header on each
-		 * page.
+		 * This sample demonstrates the failing repeated table header on each page.
 		 */
 		runTestCase("RepeatedTableSample");
 
@@ -81,12 +80,12 @@ public class TestcaseRunner {
 		 * Custom Objects
 		 */
 		runTestCase("custom-objects");
-		
+
 		/*
 		 * CSS3 multi-column layout
 		 */
 		runTestCase("multi-column-layout");
-		
+
 		/* Add additional test cases here. */
 	}
 
@@ -234,8 +233,18 @@ public class TestcaseRunner {
 						public void render(Graphics2D graphics2D) {
 							double realWidth = width / dotsPerPixel;
 							double realHeight = height / dotsPerPixel;
+							double titleBottomHeight = 10;
 
-							renderTree(graphics2D, realWidth / 2f, realHeight, realHeight / depth, -90, depth);
+							renderTree(graphics2D, realWidth / 2f, realHeight - titleBottomHeight, realHeight / depth,
+									-90, depth);
+
+							Font dialog = Font.decode("Dialog").deriveFont(10f);
+							graphics2D.setFont(dialog);
+							String txt = "FanOut " + fanout + " Angle " + angle;
+							Rectangle2D textBounds = dialog.getStringBounds(txt,
+									graphics2D.getFontRenderContext());
+							graphics2D.setPaint(Color.GREEN);
+							graphics2D.drawString(txt, (int)((realWidth - textBounds.getWidth()) / 2), (int)(realHeight - titleBottomHeight));
 						}
 					});
 		}

--- a/openhtmltopdf-examples/src/main/resources/testcases/custom-objects.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/custom-objects.html
@@ -3,6 +3,7 @@
 	<style>
 		object {
 			border: 2px solid black;
+			margin: 1px;
 		}
 	</style>
 </head>
@@ -11,12 +12,21 @@
 <h1>Some binary trees</h1>
 
 <object type="custom/binary-tree" data-fanout="3" data-depth="5" data-angle="20"
-		style="width:200px; height:300px;">
+		style="width:200px; height:300px;float:left;">
+	<!-- This is a simple example for a custom object drawer -->
+</object>
+
+<object type="custom/binary-tree" data-fanout="2" data-depth="12" data-angle="35"
+		style="width:280px; height:300px;float:right;">
 	<!-- This is a simple example for a custom object drawer -->
 </object>
 
 <object type="custom/binary-tree" data-fanout="2" data-depth="10" data-angle="30"
-		style="width:400px; height:300px;">
+		style="width:400px; height:300px;clear:both;float:left;">
+	<!-- This is a simple example for a custom object drawer -->
+</object>
+<object type="custom/binary-tree" data-fanout="2" data-depth="6" data-angle="40"
+		style="width:200px; height:300px;float:right;">
 	<!-- This is a simple example for a custom object drawer -->
 </object>
 </body>

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
     	<groupId>org.apache.pdfbox</groupId>
     	<artifactId>pdfbox</artifactId>
-    	<version>2.0.6</version>
+    	<version>2.0.7</version>
     </dependency>
     <dependency>
       <groupId>com.openhtmltopdf</groupId>
@@ -54,7 +54,7 @@
 	  <dependency>
 		  <groupId>de.rototor.pdfbox</groupId>
 		  <artifactId>graphics2d</artifactId>
-		  <version>0.5</version>
+		  <version>0.6-SNAPSHOT</version>
 	  </dependency>
   </dependencies>
 

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -54,7 +54,7 @@
 	  <dependency>
 		  <groupId>de.rototor.pdfbox</groupId>
 		  <artifactId>graphics2d</artifactId>
-		  <version>0.6-SNAPSHOT</version>
+		  <version>0.7-SNAPSHOT</version>
 	  </dependency>
   </dependencies>
 

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -54,7 +54,7 @@
 	  <dependency>
 		  <groupId>de.rototor.pdfbox</groupId>
 		  <artifactId>graphics2d</artifactId>
-		  <version>0.7-SNAPSHOT</version>
+		  <version>0.7</version>
 	  </dependency>
   </dependencies>
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -22,11 +22,13 @@ package com.openhtmltopdf.pdfboxout;
 import com.openhtmltopdf.bidi.BidiReorderer;
 import com.openhtmltopdf.bidi.SimpleBidiReorderer;
 import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.css.parser.FSCMYKColor;
 import com.openhtmltopdf.css.parser.FSColor;
 import com.openhtmltopdf.css.parser.FSRGBColor;
 import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.css.style.CssContext;
+import com.openhtmltopdf.css.value.FontSpecification;
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.extend.OutputDevice;
 import com.openhtmltopdf.extend.OutputDeviceGraphicsDrawer;
@@ -36,9 +38,8 @@ import com.openhtmltopdf.pdfboxout.PdfBoxForm.CheckboxStyle;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.util.Configuration;
 import com.openhtmltopdf.util.XRLog;
-
 import de.rototor.pdfbox.graphics2d.PdfBoxGraphics2D;
-
+import de.rototor.pdfbox.graphics2d.PdfBoxGraphics2DFontTextDrawer;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -63,7 +64,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import javax.imageio.ImageIO;
-
 import java.awt.*;
 import java.awt.RenderingHints.Key;
 import java.awt.geom.*;
@@ -218,6 +218,9 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
     // The bidi reorderer is responsible for shaping Arabic text, deshaping and 
     // converting RTL text into its visual order.
     private BidiReorderer _reorderer = new SimpleBidiReorderer();
+
+    // Font Mapping for the Graphics2D output
+    private PdfBoxGraphics2DFontTextDrawer _fontTextDrawer;
 
     public PdfBoxOutputDevice(float dotsPerPoint, boolean testMode) {
         _dotsPerPoint = dotsPerPoint;
@@ -1335,6 +1338,30 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
              * We *could* customize the PDF mapping here. But for now the default is enough.
              * TODO: Font mapping.
              */
+            /*
+             * Register the fonts
+             */
+            if( _fontTextDrawer == null ) {
+                _fontTextDrawer = new PdfBoxGraphics2DFontTextDrawer(){
+                    @Override
+                    protected PDFont mapFont(Font font, IFontTextDrawerEnv env) throws IOException, FontFormatException {
+						FontSpecification spec = new FontSpecification();
+						spec.size = font.getSize();
+						spec.families = new String[] { font.getFamily() };
+						spec.fontStyle = IdentValue.NORMAL;
+						spec.fontWeight = IdentValue.NORMAL;
+						spec.variant = IdentValue.NORMAL;
+						PdfBoxFSFont fsFont = (PdfBoxFSFont) getSharedContext().getFontResolver()
+								.resolveFont(getSharedContext(), spec);
+						if (fsFont == null)
+							return super.mapFont(font, env);
+						return fsFont.getFontDescription().get(0).getFont();
+                    }
+                };
+                // Register a dummy font to activate the font lookups
+                _fontTextDrawer.registerFont("dummy", (PDFont)null);
+            }
+            pdfBoxGraphics2D.setFontTextDrawer(_fontTextDrawer);
 
             /*
              * Do rendering

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -771,6 +771,7 @@ public class PdfBoxRenderer {
      * Cleanup thread resources. MUST be called after finishing with the renderer.
      */
     public void cleanup() {
+        _outputDevice.close();
         _sharedContext.removeFromThread();
         ThreadCtx.cleanup();
     }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -374,7 +374,7 @@ public class PdfRendererBuilder
     
     /**
      * Add a font programmatically. If the font is NOT subset, it will be downloaded when the renderer is run, otherwise
-     * the font will only be donwnloaded if needed. Therefore, the user could add many fonts, confidant that only those
+     * the font will only be downloaded if needed. Therefore, the user could add many fonts, confidant that only those
      * that are used will be downloaded and processed. 
      * 
      * The InputStream returned by the supplier will be closed by the caller. Fonts should generally be subset, except

--- a/openhtmltopdf-rtl-support/pom.xml
+++ b/openhtmltopdf-rtl-support/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
 	<groupId>com.ibm.icu</groupId>
 	<artifactId>icu4j</artifactId>
-	<version>58.1</version>
+	<version>59.1</version>
    </dependency>
     <dependency>
         <groupId>com.openhtmltopdf</groupId>

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
@@ -128,7 +128,7 @@ public class PDFTranscoder extends SVGAbstractTranscoder {
 	            String fontFamilyNameOverride, IdentValue fontWeightOverride, IdentValue fontStyleOverride, String uri, byte[] font1)
 	            throws FontFormatException {
 			
-			OpenHtmlGvtFontFamily family = null;
+			OpenHtmlGvtFontFamily family;
 			
 			if (families.containsKey(fontFamilyNameOverride))
 				family = families.get(fontFamilyNameOverride);


### PR DESCRIPTION
This pull request does the following things:

- Upgrade PDFBox to 2.0.7
- Upgrade ICU to 59.1
- Upgrade PDFBox-Graphics2D to 0.7
- Try to use fonts when rendering text with drawWithGraphics().

Should I split the version changes into a separate pull request or is this ok?