### PR TITLE
use true type font loading instead of PDType0Font

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -40,8 +40,9 @@ import org.apache.fontbox.ttf.TrueTypeFont;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
-import org.apache.pdfbox.pdmodel.font.PDType0Font;
+import org.apache.pdfbox.pdmodel.font.PDTrueTypeFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.encoding.WinAnsiEncoding;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -158,7 +159,7 @@ public class PdfBoxFontResolver implements FontResolver {
                         Integer fontWeightOverride, IdentValue fontStyleOverride, boolean subset) throws IOException {
 
 
-        PDFont font = PDType0Font.load(_doc, trueTypeFont, subset);
+        PDFont font = PDTrueTypeFont.load(_doc, trueTypeFont, WinAnsiEncoding.INSTANCE);
 
         addFont(font, fontFamilyNameOverride, fontWeightOverride, fontStyleOverride, subset);
     }
@@ -235,7 +236,8 @@ public class PdfBoxFontResolver implements FontResolver {
 		/*
 		 * We load the font using the file.
 		 */
-		addFont(PDType0Font.load(_doc, fontFile), fontFamilyNameOverride, fontWeightOverride, fontStyleOverride, subset);
+        addFont(PDTrueTypeFont.load(_doc, fontFile, WinAnsiEncoding.INSTANCE), fontFamilyNameOverride,
+                fontWeightOverride, fontStyleOverride, subset);
 	}
 
 
@@ -561,7 +563,7 @@ public class PdfBoxFontResolver implements FontResolver {
                 }
                 
                 try {
-                    _font = PDType0Font.load(_doc, is, subset);
+                    _font = PDTrueTypeFont.load(_doc, is, WinAnsiEncoding.INSTANCE);
                 } catch (IOException e) {
                     XRLog.exception("Couldn't load font. Please check that it is a valid truetype font.");
                     return false;


### PR DESCRIPTION
actually this is important to actually have PDF/A support.

See https://github.com/danfickle/openhtmltopdf/issues/92#issuecomment-324269602