### PR TITLE
check data:image type against revolved url

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
@@ -76,8 +76,8 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
             return new ImageResource(resource.getImageUri(), copy);
         }
         
-        if (ImageUtil.isEmbeddedBase64Image(uriStr)) {
-            resource = loadEmbeddedBase64ImageResource(uriStr);
+        if (ImageUtil.isEmbeddedBase64Image(uriResolved)) {
+            resource = loadEmbeddedBase64ImageResource(uriResolved);
             _outputDevice.realizeImage((PdfBoxImage) resource.getImage());
             _imageCache.put(uriResolved, resource);
         } else {


### PR DESCRIPTION
Using URI Resolver we can change the uri and therefore my guess is that the check on image should be on the URI resolved. 

For instance I have an uri with "cid" scheme which I transform into data:image as they are both kind of embedded images ...

