### PR TITLE
Ignore metadata entries with empty ("") names because Acrobat Reader

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -616,6 +616,8 @@ public class PdfBoxRenderer {
 
         for (Metadata metadata : _outputDevice.getMetadata()) {
         	String name = metadata.getName();
+			if (name.isEmpty())
+				continue;
         	String content = metadata.getContent();
         	if( content == null )
         	    continue;


### PR DESCRIPTION
really does not like them and wont show any metadata at all...

These can be created when specify such things as ```<meta charset='UTF-8'>```.