### PR TITLE
Fix #136: positive strikethrough offset for max comparision

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/LineMetricsAdapter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/LineMetricsAdapter.java
@@ -68,10 +68,10 @@ public class LineMetricsAdapter implements FSFontMetrics {
     	float max = Float.MIN_VALUE;
     	
     	for (LineMetrics met : _lineMetrics) {
-    		max = Math.max(max, met.getStrikethroughOffset());
+    		max = Math.max(max, Math.abs(met.getStrikethroughOffset()));
     	}
     	
-    	return max;
+    	return -1 * max;
     }
 
     public float getStrikethroughThickness() {

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -56,6 +56,7 @@ public class TestcaseRunner {
 		runTestCase("FSPageBreakMinHeightSample");
 
 		runTestCase("color");
+		runTestCase("text-decoration");
 		runTestCase("background-color");
 		runTestCase("background-image");
 		runTestCase("invalid-url-background-image");

--- a/openhtmltopdf-examples/src/main/resources/testcases/text-decoration.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/text-decoration.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+    <title>Test: Text Alignment</title>
+    <style type="text/css">
+            .test1 { text-decoration: none; }
+            .test2 { text-decoration: underline; }
+            .test3 { text-decoration: overline; }
+            .test4 { text-decoration: line-through; }
+			i { text-decoration: line-through; }
+		</style>
+</head>
+<body>
+    <p class="test1">none</p>
+    <p class="test2">underline</p>
+    <p class="test3">overline</p>
+    <p class="test4">line-through</p>
+    <p>asdf<u>asdf</u> asdf <i>asdf</i></p>
+</body>
+
+</html>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxTextRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxTextRenderer.java
@@ -72,10 +72,10 @@ public class PdfBoxTextRenderer implements TextRenderer {
             
             for (FontDescription des : descrs) {
                 float loopAscent = des.getFont().getBoundingBox().getUpperRightY();
-                float loopDescent = -des.getFont().getBoundingBox().getLowerLeftY();
-                float loopStrikethroughOffset = -des.getYStrikeoutPosition();
+                float loopDescent = des.getFont().getBoundingBox().getLowerLeftY();
+                float loopStrikethroughOffset = des.getYStrikeoutPosition();
                 float loopStrikethroughThickness = des.getYStrikeoutSize();
-                float loopUnderlinePosition = -des.getUnderlinePosition();
+                float loopUnderlinePosition = des.getUnderlinePosition();
                 float loopUnderlineThickness = des.getUnderlineThickness();
                 
                 if (loopAscent > largestAscent) {
@@ -104,8 +104,8 @@ public class PdfBoxTextRenderer implements TextRenderer {
             }
             
             result.setAscent(largestAscent / 1000f * size);
-            result.setDescent(largestDescent / 1000f * size);
-            result.setStrikethroughOffset(largestStrikethroughOffset / 1000f * size);
+            result.setDescent(-1 * largestDescent / 1000f * size);
+            result.setStrikethroughOffset(-1 * largestStrikethroughOffset / 1000f * size);
             
             if (largestStrikethroughThickness > 0) {
                 result.setStrikethroughThickness(largestStrikethroughThickness / 1000f * size);
@@ -113,7 +113,7 @@ public class PdfBoxTextRenderer implements TextRenderer {
                 result.setStrikethroughThickness(size / 12.0f);
             }
             
-            result.setUnderlineOffset(largestUnderlinePosition / 1000f * size);
+            result.setUnderlineOffset(-1 * largestUnderlinePosition / 1000f * size);
             result.setUnderlineThickness(largestUnderlineThickness / 1000f * size);
         } catch (IOException e) {
             throw new PdfContentStreamAdapter.PdfException("getFSFontMetrics", e);


### PR DESCRIPTION
This PR will fix the #136.
Basically the offset should be negative but when the code looks for the biggest one, it should use a positive value, because Float.MIN_VALUE is always positive.