### PR TITLE
Upgrade the PDFBox and PDFBox-Graphics2D versions again

### DIFF
--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -50,12 +50,12 @@
     <dependency>
     	<groupId>org.apache.pdfbox</groupId>
     	<artifactId>pdfbox</artifactId>
-    	<version>2.0.7</version>
+    	<version>2.0.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>xmpbox</artifactId>
-      <version>2.0.7</version>
+      <version>2.0.8</version>
     </dependency>
     <dependency>
       <groupId>com.openhtmltopdf</groupId>
@@ -65,7 +65,7 @@
 	  <dependency>
 		  <groupId>de.rototor.pdfbox</groupId>
 		  <artifactId>graphics2d</artifactId>
-		  <version>0.9</version>
+		  <version>0.10</version>
 	  </dependency>
   </dependencies>
 


### PR DESCRIPTION
There was a space wasting bug in pdfbox-graphics2d and the current PDFBox version allows to change the ZLIB compression level.