### PR TITLE
#38 Fix css3 transform

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -19,38 +19,23 @@
  */
 package com.openhtmltopdf.css.parser;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-
-import org.w3c.dom.css.CSSPrimitiveValue;
-
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.MarginBoxName;
 import com.openhtmltopdf.css.extend.TreeResolver;
 import com.openhtmltopdf.css.newmatch.Selector;
 import com.openhtmltopdf.css.parser.property.PropertyBuilder;
-import com.openhtmltopdf.css.sheet.FontFaceRule;
-import com.openhtmltopdf.css.sheet.MediaRule;
-import com.openhtmltopdf.css.sheet.PageRule;
-import com.openhtmltopdf.css.sheet.PropertyDeclaration;
-import com.openhtmltopdf.css.sheet.Ruleset;
-import com.openhtmltopdf.css.sheet.RulesetContainer;
-import com.openhtmltopdf.css.sheet.Stylesheet;
-import com.openhtmltopdf.css.sheet.StylesheetInfo;
+import com.openhtmltopdf.css.sheet.*;
 import com.openhtmltopdf.util.ThreadCtx;
 import com.openhtmltopdf.util.XRLog;
+import org.w3c.dom.css.CSSPrimitiveValue;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.logging.Level;
 
 public class CSSParser {
     private static final Set SUPPORTED_PSEUDO_ELEMENTS;
@@ -1363,7 +1348,7 @@ public class CSSParser {
 //    ;
     private List expr(boolean literal) throws IOException {
         //System.out.println("expr()");
-        List result = new ArrayList(10);
+        List<PropertyValue> result = new ArrayList<PropertyValue>(10);
         result.add(term(literal));
         LOOP: while (true) {
             Token t = la();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/FSFunction.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/FSFunction.java
@@ -19,14 +19,13 @@
  */
 package com.openhtmltopdf.css.parser;
 
-import java.util.Iterator;
 import java.util.List;
 
 public class FSFunction {
     private String _name;
-    private List _parameters;
+    private List<PropertyValue> _parameters;
     
-    public FSFunction(String name, List parameters) {
+    public FSFunction(String name, List<PropertyValue> parameters) {
         _name = name;
         _parameters = parameters;
     }
@@ -35,16 +34,16 @@ public class FSFunction {
         return _name;
     }
     
-    public List getParameters() {
+    public List<PropertyValue> getParameters() {
         return _parameters;
     }
     
     public String toString() {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         result.append(_name);
         result.append('(');
-        for (Iterator i = _parameters.iterator(); i.hasNext(); ) {
-            result.append(i.next());  // HACK
+        for (PropertyValue _parameter : _parameters) {
+            result.append(_parameter);  // HACK
             result.append(',');
         }
         result.append(')');

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/PropertyValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/PropertyValue.java
@@ -19,18 +19,13 @@
  */
 package com.openhtmltopdf.css.parser;
 
-import java.util.List;
-import java.util.ArrayList;
-
-import org.w3c.dom.DOMException;
-import org.w3c.dom.css.CSSPrimitiveValue;
-import org.w3c.dom.css.CSSValue;
-import org.w3c.dom.css.Counter;
-import org.w3c.dom.css.RGBColor;
-import org.w3c.dom.css.Rect;
-
 import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.util.ArrayUtil;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.css.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PropertyValue implements CSSPrimitiveValue {
     public static final short VALUE_TYPE_NUMBER = 1;
@@ -58,7 +53,7 @@ public class PropertyValue implements CSSPrimitiveValue {
     
     private Token _operator;
     
-    private List _values;
+    private List<?> _values;
     private FSFunction _function;
 
     public PropertyValue(short type, float floatValue, String cssText) {
@@ -108,7 +103,7 @@ public class PropertyValue implements CSSPrimitiveValue {
         _identValue = ident;
     }
     
-    public PropertyValue(List values) {
+    public PropertyValue(List<?> values) {
         _type = CSSPrimitiveValue.CSS_UNKNOWN; // HACK
         _cssValueType = CSSValue.CSS_CUSTOM;
         _cssText = values.toString(); // HACK
@@ -210,8 +205,8 @@ public class PropertyValue implements CSSPrimitiveValue {
         return _cssText;
     }
     
-    public List getValues() {
-        return new ArrayList(_values);
+    public List<Object> getValues() {
+        return new ArrayList<Object>(_values);
     }
     
     public FSFunction getFunction() {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
@@ -19,22 +19,13 @@
  */
 package com.openhtmltopdf.css.parser.property;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import org.w3c.dom.css.CSSPrimitiveValue;
-
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.IdentValue;
-import com.openhtmltopdf.css.parser.CSSParseException;
-import com.openhtmltopdf.css.parser.FSFunction;
-import com.openhtmltopdf.css.parser.FSRGBColor;
-import com.openhtmltopdf.css.parser.PropertyValue;
-import com.openhtmltopdf.css.parser.Token;
+import com.openhtmltopdf.css.parser.*;
 import com.openhtmltopdf.css.sheet.PropertyDeclaration;
+import org.w3c.dom.css.CSSPrimitiveValue;
+
+import java.util.*;
 
 public class PrimitivePropertyBuilders {
     // none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset
@@ -1713,6 +1704,8 @@ public class PrimitivePropertyBuilders {
             		for (Object p : value.getFunction().getParameters()) {
             			checkNumberType(cssName, (CSSPrimitiveValue) p);
             		}
+                    if (value.getFunction().getParameters().size() == 1)
+                        expected = 1;
             	} else if (fName.equalsIgnoreCase("scaleX")) {
             		expected = 1;
             		for (Object p : value.getFunction().getParameters()) {
@@ -1723,6 +1716,23 @@ public class PrimitivePropertyBuilders {
             		for (Object p : value.getFunction().getParameters()) {
             			checkNumberType(cssName, (CSSPrimitiveValue) p);
             		}
+                } else if (fName.equalsIgnoreCase("skew")) {
+                    expected = 2;
+                    for (Object p : value.getFunction().getParameters()) {
+                        checkAngleType(cssName, (CSSPrimitiveValue) p);
+                    }
+                    if (value.getFunction().getParameters().size() == 1)
+                        expected = 1;
+                } else if (fName.equalsIgnoreCase("skewX")) {
+                    expected = 1;
+                    for (Object p : value.getFunction().getParameters()) {
+                        checkAngleType(cssName, (CSSPrimitiveValue) p);
+                    }
+                } else if (fName.equalsIgnoreCase("skewY")) {
+                    expected = 1;
+                    for (Object p : value.getFunction().getParameters()) {
+                        checkAngleType(cssName, (CSSPrimitiveValue) p);
+                    }
             	} else if (fName.equalsIgnoreCase("rotate")) {
             		expected = 1;
             		for (Object p : value.getFunction().getParameters()) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/ListValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/ListValue.java
@@ -19,15 +19,14 @@
  */
 package com.openhtmltopdf.css.style.derived;
 
-import java.util.Iterator;
-import java.util.List;
-
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.parser.PropertyValue;
 import com.openhtmltopdf.css.style.DerivedValue;
 
+import java.util.List;
+
 public class ListValue extends DerivedValue {
-    private List _values;
+    private List<?> _values;
     
     public ListValue(CSSName name, PropertyValue value) {
         super(name, value.getPrimitiveType(), value.getCssText(), value.getCssText());
@@ -35,7 +34,7 @@ public class ListValue extends DerivedValue {
         _values = value.getValues();
     }
     
-    public List getValues() {
+    public List<?> getValues() {
         return _values;
     }
     
@@ -46,9 +45,9 @@ public class ListValue extends DerivedValue {
         
         String[] arr = new String[_values.size()];
         int i = 0;
-        
-        for (Iterator iter = _values.iterator(); iter.hasNext();) {
-            arr[i++] = iter.next().toString();
+
+        for (Object _value : _values) {
+            arr[i++] = _value.toString();
         }
         
         return arr;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -31,7 +31,6 @@ import java.util.List;
 
 public interface OutputDevice {
 	public void setPaint(Paint paint);
-	public void setAlpha(int alpha);
 
 	// Required for CSS transforms.
 
@@ -106,5 +105,10 @@ public interface OutputDevice {
      * Draw something using a Graphics2D at the given rectangle.
      */
     public void drawWithGraphics(float x, float y, float width, float height, OutputDeviceGraphicsDrawer renderer);
+
+    /**
+     * @return 1 or -1 to compensate for output device specific flips
+     */
+    public float getTransformRotationFlipFactor();
 
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -106,9 +106,6 @@ public interface OutputDevice {
      */
     public void drawWithGraphics(float x, float y, float width, float height, OutputDeviceGraphicsDrawer renderer);
 
-    /**
-     * @return 1 or -1 to compensate for output device specific flips
-     */
-    public float getTransformRotationFlipFactor();
+    public boolean isPDF();
 
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -38,7 +38,7 @@ public interface OutputDevice {
 	/**
 	 * Apply the given transform on top of the current one in the PDF graphics stream.
 	 * This is a cumulative operation. You should popTransform after the box and children are painted.
-	 * @return 
+	 * @return the list of inverse transforms to undo the effect of this transform
 	 */
 	public List<AffineTransform> pushTransforms(List<AffineTransform> transforms);
 	public void popTransforms(List<AffineTransform> inverse);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
@@ -29,6 +29,7 @@ import com.openhtmltopdf.css.style.CssContext;
 import com.openhtmltopdf.css.style.EmptyStyle;
 import com.openhtmltopdf.css.style.FSDerivedValue;
 import com.openhtmltopdf.css.style.derived.ListValue;
+import com.openhtmltopdf.css.style.derived.RectPropertySet;
 import com.openhtmltopdf.newtable.TableCellBox;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.util.XRLog;
@@ -386,6 +387,14 @@ public class Layer {
 
 		float relTranslateX = absTranslateX - c.getOutputDevice().getAbsoluteTransformOriginX();
 		float relTranslateY = absTranslateY - c.getOutputDevice().getAbsoluteTransformOriginY();
+		/*
+		 * FlipFactor is -1 for PDF output. We must handle the page margin in this case.
+		 */
+		if (flipFactor == -1) {
+			RectPropertySet margin = c.getPage().getMargin(c);
+			relTranslateX += margin.left();
+			relTranslateY += margin.top();
+		}
 
 		List<PropertyValue> transformList = (List<PropertyValue>) ((ListValue) transforms).getValues();
 		List<AffineTransform> resultTransforms = new ArrayList<AffineTransform>();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
@@ -380,7 +380,7 @@ public class Layer {
 		float relOriginY = box.getStyle().getFloatPropertyProportionalHeight(CSSName.FS_TRANSFORM_ORIGIN_Y,
 				box.getHeight(), c);
 
-		float flipFactor = c.getOutputDevice().getTransformRotationFlipFactor();
+		float flipFactor = c.getOutputDevice().isPDF() ? -1 : 1;
 
 		float absTranslateX = relOriginX + box.getAbsX();
 		float absTranslateY = relOriginY + box.getAbsY();
@@ -390,7 +390,7 @@ public class Layer {
 		/*
 		 * FlipFactor is -1 for PDF output. We must handle the page margin in this case.
 		 */
-		if (flipFactor == -1) {
+		if (c.getOutputDevice().isPDF()) {
 			RectPropertySet margin = c.getPage().getMargin(c);
 			relTranslateX += margin.left();
 			relTranslateY += margin.top();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
@@ -414,7 +414,7 @@ public class Layer {
 				resultTransforms.add(AffineTransform.getScaleInstance(scaleX, scaleY));
 			} else if ("skew".equalsIgnoreCase(fName)) {
 				float radiansX = flipFactor * this.convertAngleToRadians(params.get(0));
-				float radiansY = flipFactor * this.convertAngleToRadians(params.get(0));
+				float radiansY = 0;
 				if (params.size() > 1)
 					radiansY = this.convertAngleToRadians(params.get(1));
 				resultTransforms.add(AffineTransform.getShearInstance(Math.tan(radiansX), Math.tan(radiansY)));

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -19,14 +19,6 @@
  */
 package com.openhtmltopdf.render;
 
-import java.awt.Rectangle;
-import java.awt.Shape;
-import java.awt.geom.Area;
-import java.util.Iterator;
-import java.util.List;
-
-import org.w3c.dom.css.CSSPrimitiveValue;
-
 import com.openhtmltopdf.bidi.BidiReorderer;
 import com.openhtmltopdf.bidi.BidiSplitter;
 import com.openhtmltopdf.css.constants.CSSName;
@@ -43,9 +35,14 @@ import com.openhtmltopdf.css.style.derived.LengthValue;
 import com.openhtmltopdf.css.value.FontSpecification;
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.extend.OutputDevice;
-import com.openhtmltopdf.swing.Java2DOutputDevice;
 import com.openhtmltopdf.util.Configuration;
 import com.openhtmltopdf.util.Uu;
+import org.w3c.dom.css.CSSPrimitiveValue;
+
+import java.awt.*;
+import java.awt.geom.Area;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * An abstract implementation of an {@link OutputDevice}.  It provides complete
@@ -434,5 +431,9 @@ public abstract class AbstractOutputDevice implements OutputDevice {
      */
     public void setFontSpecification(FontSpecification fs) {
 	_fontSpec = fs;
+    }
+
+    public float getTransformRotationFlipFactor() {
+        return 1;
     }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -433,7 +433,8 @@ public abstract class AbstractOutputDevice implements OutputDevice {
 	_fontSpec = fs;
     }
 
-    public float getTransformRotationFlipFactor() {
-        return 1;
+    @Override
+    public boolean isPDF() {
+        return false;
     }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/Box.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/Box.java
@@ -20,20 +20,6 @@
  */
 package com.openhtmltopdf.render;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import java.awt.Shape;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.logging.Level;
-
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.css.parser.FSColor;
@@ -47,6 +33,17 @@ import com.openhtmltopdf.layout.LayoutContext;
 import com.openhtmltopdf.layout.PaintingInfo;
 import com.openhtmltopdf.layout.Styleable;
 import com.openhtmltopdf.util.XRLog;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import java.awt.*;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
 
 public abstract class Box implements Styleable {
     protected static final String LINE_SEPARATOR = System.getProperty("line.separator");
@@ -497,8 +494,8 @@ public abstract class Box implements Styleable {
         }
     }
 
-    public List getElementBoxes(Element elem) {
-        List result = new ArrayList();
+    public List<Box> getElementBoxes(Element elem) {
+        List<Box> result = new ArrayList<Box>();
         for (int i = 0; i < getChildCount(); i++) {
             Box child = getChild(i);
             if (child.getElement() == elem) {
@@ -608,7 +605,7 @@ public abstract class Box implements Styleable {
                 page = (PageBox)c.getRootLayer().getPages().get(page.getPageNo()+1);
                 delta += page.getContentHeight(c);
 
-                if (pageBreakCount == 2 && pendingPageName) {
+                if (pendingPageName) {
                     c.setPageName(c.getPendingPageName());
                 }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/PageBox.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/PageBox.java
@@ -312,11 +312,13 @@ public class PageBox {
         
         c.getOutputDevice().paintBackground(c, getStyle(), bounds, bounds, getStyle().getBorder(c));
     }
-    
+
+    private MarginAreaContainer currentMarginAreaContainer;
     public void paintMarginAreas(RenderingContext c, int additionalClearance, short mode) {
         for (int i = 0; i < MARGIN_AREA_DEFS.length; i++) {
             MarginAreaContainer container = _marginAreas[i];
             if (container != null) {
+                currentMarginAreaContainer = container;
                 TableBox table = _marginAreas[i].getTable();
                 Point p = container.getArea().getPaintingPosition(
                         c, this, additionalClearance, mode);
@@ -326,6 +328,13 @@ public class PageBox {
                 c.getOutputDevice().translate(-p.x, -p.y);
             }
         }
+        currentMarginAreaContainer = null;
+    }
+
+    public MarginBoxName[] getCurrentMarginBoxNames() {
+        if( currentMarginAreaContainer == null )
+            return null;
+        return currentMarginAreaContainer.getArea().getMarginBoxNames();
     }
 
     public int getPageNo() {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
@@ -26,17 +26,19 @@ import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.render.*;
 
 import javax.swing.*;
-
 import java.awt.*;
 import java.awt.RenderingHints.Key;
 import java.awt.font.GlyphVector;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
-import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
 
+/**
+ * Do not use. Old and unmaintained. Subject to be deleted.
+ */
+@Deprecated
 public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDevice {
     private final Graphics2D _graphics;
     private AWTFSFont _font;
@@ -303,39 +305,30 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 
     @Override
     public List<AffineTransform> pushTransforms(List<AffineTransform> transforms) {
-//		AffineTransform currentTransform  = _graphics.getTransform();
-//		currentTransform.concatenate(transform);
-//        _graphics.setTransform(currentTransform);
-// TODO
-    	return Collections.emptyList();
+		return null;
     }
 
 	@Override
 	public void popTransforms(List<AffineTransform> inverse) {
-		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
 	public float getAbsoluteTransformOriginX() {
-		// TODO Auto-generated method stub
 		return 0;
 	}
 
 	@Override
 	public float getAbsoluteTransformOriginY() {
-		// TODO Auto-generated method stub
 		return 0;
 	}
 
 	public void setBidiReorderer(BidiReorderer _reorderer) {
-		// TODO Auto-generated method stub
-		
+
 	}
 
 	public void setRenderingContext(RenderingContext result) {
-		// TODO Auto-generated method stub
-		
+
 	}
 
 	public void setRoot(BlockBox _root) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/Java2DOutputDevice.java
@@ -297,12 +297,6 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 		_graphics.setPaint(paint);
 	}
 
-	@Override
-	public void setAlpha(int alpha) {
-		// TODO Auto-generated method stub
-		
-	}
-
     @Override
     public List<AffineTransform> pushTransforms(List<AffineTransform> transforms) {
 		return null;

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -90,6 +90,11 @@ public class TestcaseRunner {
 		 */
 		runTestCase("adobe-borderstyle-bugs");
 
+		/*
+		 * CSS Transform Test
+		 */
+		runTestCase("transform");
+
 		/* Add additional test cases here. */
 	}
 

--- a/openhtmltopdf-examples/src/main/resources/testcases/transform.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/transform.html
@@ -27,6 +27,8 @@
 	<div style="transform:rotate(90deg)"> 90</div>
 	<div style="transform:rotate(180deg)"> 180</div>
 	<div style="transform:rotate(270deg)"> 270</div>
+	<div style="transform:rotate(45deg)"> 45</div>
+	<div style="transform:rotate(135deg)"> 135</div>
 </div>
 
 <br/>
@@ -36,6 +38,8 @@
 	<div style="transform:scale(2) rotate(90deg)"> 90 S</div>
 	<div style="transform:scaleX(2) rotate(180deg)"> 180 S</div>
 	<div style="transform:scaleY(2) rotate(270deg)"> 270 S</div>
+	<div style="transform:scaleX(2) rotate(45deg)"> 45 S</div>
+	<div style="transform:scaleY(2) rotate(135deg)"> 135 S</div>
 </div>
 <br/>
 
@@ -44,6 +48,8 @@
 	<div style="transform:skew(10deg) rotate(90deg)"> 90 SK</div>
 	<div style="transform:skewX(10deg) rotate(180deg)"> 180 SK</div>
 	<div style="transform:skewY(10deg) rotate(270deg)"> 270 SK</div>
+	<div style="transform:skewX(-10deg) rotate(45deg)"> 45 S</div>
+	<div style="transform:skewY(10deg) rotate(135deg)"> 135 S</div>
 </div>
 <br/>
 

--- a/openhtmltopdf-examples/src/main/resources/testcases/transform.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/transform.html
@@ -53,5 +53,15 @@
 </div>
 <br/>
 
+<div class="block">
+	<div style="transform:scale(2) skewX(10deg)"> 0</div>
+	<div style="transform:scale(2) skew(10deg) rotate(90deg)"> 90 SK</div>
+	<div style="transform:scaleX(2) skewX(10deg) rotate(180deg)"> 180 SK</div>
+	<div style="transform:scaleX(2) skewY(10deg) rotate(270deg)"> 270 SK</div>
+	<div style="transform:scaleY(2) skewX(-10deg) rotate(45deg)"> 45 S</div>
+	<div style="transform:scaleY(2) skewY(10deg) rotate(135deg)"> 135 S</div>
+</div>
+<br/>
+
 </body>
 </html>

--- a/openhtmltopdf-examples/src/main/resources/testcases/transform.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/transform.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+	<style>
+		body {
+			margin: 1cm;
+		}
+
+		div.block > div {
+			border: 1px solid blue;
+			display: inline-block;
+			padding:5px;
+		}
+
+		div.block {
+			width: 100%;
+			border: 1px solid green;
+			margin-bottom:3cm;
+		}
+	</style>
+</head>
+<body>
+
+<h1>Sample to demonstrate CSS Transform</h1>
+
+<div class="block">
+	<div> 0</div>
+	<div style="transform:rotate(90deg)"> 90</div>
+	<div style="transform:rotate(180deg)"> 180</div>
+	<div style="transform:rotate(270deg)"> 270</div>
+</div>
+
+<br/>
+
+<div class="block">
+	<div style="transform:scale(2)"> 0 S</div>
+	<div style="transform:scale(2) rotate(90deg)"> 90 S</div>
+	<div style="transform:scaleX(2) rotate(180deg)"> 180 S</div>
+	<div style="transform:scaleY(2) rotate(270deg)"> 270 S</div>
+</div>
+<br/>
+
+<div class="block">
+	<div style="transform:skewX(10deg)"> 0</div>
+	<div style="transform:skew(10deg) rotate(90deg)"> 90 SK</div>
+	<div style="transform:skewX(10deg) rotate(180deg)"> 180 SK</div>
+	<div style="transform:skewY(10deg) rotate(270deg)"> 270 SK</div>
+</div>
+<br/>
+
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/testcases/transform.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/transform.html
@@ -8,17 +8,118 @@
 		div.block > div {
 			border: 1px solid blue;
 			display: inline-block;
-			padding:5px;
+			padding: 5px;
 		}
 
 		div.block {
 			width: 100%;
 			border: 1px solid green;
-			margin-bottom:3cm;
+			margin-bottom: 3cm;
+		}
+
+		@page {
+			size: A4;
+			margin: 2.5cm 1.8cm 2cm 1.9cm;
+			@bottom-left {
+				content: element(footer);
+				font-size: 9px;
+			}
+			@top-left {
+				font-size: 9px;
+				content: element(header);
+			}
+			@top-left-corner {
+				content: element(topleftcorner);
+			}
+			@top-right-corner {
+				content: element(toprightcorner);
+			}
+			@bottom-left-corner {
+				content: element(bottomleftcorner);
+			}
+			@bottom-right-corner {
+				content: element(bottomrightcorner);
+			}
+			@left-middle {
+				font-size: 9px;
+				content: element(left);
+			}
+			@right-middle {
+				font-size: 9px;
+				content: element(right);
+			}
+		}
+
+		#bottomleftcorner {
+			position: running(bottomleftcorner);
+		}
+
+		#bottomrightcorner {
+			position: running(bottomrightcorner);
+		}
+
+		#topleftcorner {
+			position: running(topleftcorner);
+		}
+
+		#toprightcorner {
+			position: running(toprightcorner);
+		}
+
+		#header {
+			position: running(header);
+			border-bottom: 1px solid black;
+		}
+
+		#footer {
+			position: running(footer);
+			border-top: 1px solid black;
+		}
+
+		#left {
+			position: running(left);
+			width: 10cm;
+		}
+
+		#right {
+			position: running(right);
+			width: 10cm;
 		}
 	</style>
 </head>
 <body>
+
+<div id="header">
+	Sample Header Top
+	<div style="display:inline-block; transform:rotate(180deg)">Sample Header Top -</div>
+</div>
+<div id="footer">
+	Some nice footer
+	<div style="display:inline-block; transform:rotate(180deg)">with rotated text.</div>
+</div>
+<div id="left">
+	<div style="transform: rotate(90deg); text-transform: uppercase">
+		the left border
+	</div>
+</div>
+<div id="right">
+	R
+	<div style="transform: scale(5) rotate(-9deg); text-transform: uppercase">
+		the right border
+	</div>
+</div>
+<div id="topleftcorner" style="transform:rotate(45deg)">
+	TLC
+</div>
+<div id="toprightcorner" style="transform:rotate(-45deg)">
+	TRC
+</div>
+<div id="bottomleftcorner" style="transform:rotate(-5deg)">
+	BLC
+</div>
+<div id="bottomrightcorner" style="transform:rotate(5deg)">
+	BRC
+</div>
 
 <h1>Sample to demonstrate CSS Transform</h1>
 

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
@@ -22,19 +22,25 @@ package com.openhtmltopdf.java2d;
 import com.openhtmltopdf.bidi.BidiReorderer;
 import com.openhtmltopdf.css.parser.FSColor;
 import com.openhtmltopdf.css.parser.FSRGBColor;
-import com.openhtmltopdf.extend.*;
+import com.openhtmltopdf.extend.FSImage;
+import com.openhtmltopdf.extend.OutputDevice;
+import com.openhtmltopdf.extend.OutputDeviceGraphicsDrawer;
+import com.openhtmltopdf.extend.ReplacedElement;
 import com.openhtmltopdf.java2d.api.Java2DRendererBuilder;
 import com.openhtmltopdf.render.*;
-import com.openhtmltopdf.swing.AWTFSFont;
 import com.openhtmltopdf.swing.AWTFSImage;
 import com.openhtmltopdf.swing.ImageReplacedElement;
+import com.openhtmltopdf.util.XRLog;
 
 import java.awt.*;
 import java.awt.RenderingHints.Key;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.NoninvertibleTransformException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
+import java.util.logging.Level;
 
 public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDevice {
     private Graphics2D _graphics;
@@ -206,19 +212,32 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 		
 	}
 
-    @Override
-    public List<AffineTransform> pushTransforms(List<AffineTransform> transforms) {
-//		AffineTransform currentTransform  = _graphics.getTransform();
-//		currentTransform.concatenate(transform);
-//        _graphics.setTransform(currentTransform);
-// TODO
-    	return Collections.emptyList();
-    }
+	@Override
+	public List<AffineTransform> pushTransforms(List<AffineTransform> transforms) {
+		List<AffineTransform> inverse = new ArrayList<AffineTransform>(transforms.size());
+		AffineTransform gfxTransform = _graphics.getTransform();
+		try {
+			for (AffineTransform transform : transforms) {
+				inverse.add(transform.createInverse());
+				transformStack.push(transform);
+				gfxTransform.concatenate(transform);
+			}
+		} catch (NoninvertibleTransformException e) {
+			XRLog.render(Level.WARNING, "Tried to set a non-invertible CSS transform. Ignored.");
+		}
+		_graphics.setTransform(gfxTransform);
+		return inverse;
+	}
 
 	@Override
 	public void popTransforms(List<AffineTransform> inverse) {
-		// TODO Auto-generated method stub
-		
+		AffineTransform gfxTransform = _graphics.getTransform();
+		Collections.reverse(inverse);
+		for (AffineTransform transform : inverse) {
+			gfxTransform.concatenate(transform);
+			transformStack.pop();
+		}
+		_graphics.setTransform(gfxTransform);
 	}
 
 	@Override

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
@@ -207,12 +207,6 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 	}
 
 	@Override
-	public void setAlpha(int alpha) {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
 	public List<AffineTransform> pushTransforms(List<AffineTransform> transforms) {
 		List<AffineTransform> inverse = new ArrayList<AffineTransform>(transforms.size());
 		AffineTransform gfxTransform = _graphics.getTransform();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -1531,6 +1531,11 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
         }
     }
 
+    @Override
+    public boolean isPDF() {
+        return true;
+    }
+
     /**
      * Perform any internal cleanup needed
      */
@@ -1538,12 +1543,5 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
         if (_fontTextDrawer != null) {
             _fontTextDrawer.close();
         }
-    }
-
-    public float getTransformRotationFlipFactor() {
-        /*
-         * We must flip the angles for the PDF when applying a CSS transform
-         */
-        return -1;
     }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -1531,11 +1531,6 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
         }
     }
 
-    @Override
-    public void setAlpha(int alpha) {
-        
-    }
-
     /**
      * Perform any internal cleanup needed
      */
@@ -1545,4 +1540,10 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
         }
     }
 
+    public float getTransformRotationFlipFactor() {
+        /*
+         * We must flip the angles for the PDF when applying a CSS transform
+         */
+        return -1;
+    }
 }


### PR DESCRIPTION
The current CSS3 transform support is still broken. In this branch I was ably to fix it mostly for Java2D. But nothing has changed with the PDF output.

I've created a sample file to test this. The sample file renders this in Safari:

![image](https://user-images.githubusercontent.com/711674/34007100-e71f05f6-e100-11e7-8846-2fbead2b4846.png)

This way using Java2D:
![image](https://user-images.githubusercontent.com/711674/34007118-f8f82762-e100-11e7-9276-697b4d4a0f12.png)
You may note that in the second line (scaled and rotated) the resulting div for 180 degree and 45 degree has some strange offset, but everything else is fine.

But it is still broken when generating a PDF:
![image](https://user-images.githubusercontent.com/711674/34007132-025dad4a-e101-11e7-8569-6aecd96c0ab4.png)

@danfickle I tried around all different things, but I currently have no idea what offset is applied wrong here for the PDF output. Could you please take a look into that?

I did add some generic parameters to some lists. I hope you don't mind.

Thanks.
P.S.: Can we just remove the old Java2DOutputDevice stuff? i.e. com.openhtmltopdf.swing.Java2DRenderer and com.openhtmltopdf.swing.Java2DOutputDevice?
