### PR TITLE
make it possible to set a producer

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -85,6 +85,8 @@ public class PdfBoxRenderer {
     
     private PDEncryption _pdfEncryption;
 
+    private String _producer;
+
     // Usually 1.7
     private float _pdfVersion;
     
@@ -170,10 +172,13 @@ public class PdfBoxRenderer {
             HttpStreamFactory httpStreamFactory, 
             OutputStream os, FSUriResolver resolver, FSCache cache, SVGDrawer svgImpl,
             PageDimensions pageSize, float pdfVersion, String replacementText, boolean testMode,
-            FSObjectDrawerFactory objectDrawerFactory, String preferredTransformerFactoryImplementationClass) {
+            FSObjectDrawerFactory objectDrawerFactory, String preferredTransformerFactoryImplementationClass,
+            String producer) {
         
         _pdfDoc = new PDDocument();
         _pdfDoc.setVersion(pdfVersion);
+
+        _producer = producer;
 
         _svgImpl = svgImpl;
         _dotsPerPoint = DEFAULT_DOTS_PER_POINT;
@@ -615,7 +620,12 @@ public class PdfBoxRenderer {
         PDDocumentInformation info = new PDDocumentInformation();
         
         info.setCreationDate(Calendar.getInstance());
-        info.setProducer("openhtmltopdf.com");
+
+        if (_producer == null) {
+            info.setProducer("openhtmltopdf.com");
+        } else {
+            info.setProducer(_producer);
+        }
 
         for (Metadata metadata : _outputDevice.getMetadata()) {
         	String name = metadata.getName();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -47,6 +47,7 @@ public class PdfRendererBuilder
     private boolean _isPageSizeInches;
     private float _pdfVersion = 1.7f;
     private String _replacementText;
+    private String _producer;
     private FSTextBreaker _lineBreaker;
     private FSTextBreaker _charBreaker;
     private FSTextTransformer _unicodeToUpperTransformer;
@@ -107,7 +108,8 @@ public class PdfRendererBuilder
         PdfBoxRenderer renderer = new PdfBoxRenderer(
                 doc, unicode, _httpStreamFactory, _os, _resolver,
                 _cache, _svgImpl, pageSize, _pdfVersion, _replacementText,
-                _testMode, _objectDrawerFactory, _preferredTransformerFactoryImplementationClass);
+                _testMode, _objectDrawerFactory, _preferredTransformerFactoryImplementationClass,
+                _producer);
 
         /*
          * Register all Fonts
@@ -449,4 +451,16 @@ public class PdfRendererBuilder
         this._preferredTransformerFactoryImplementationClass = transformerFactoryClass;
         return this;
     }
+
+    /**
+     * Set a producer on the output document
+     *
+     * @param producer the name of the producer to set defaults to openhtmltopdf.com
+     * @return this for method chaining
+     */
+    public PdfRendererBuilder withProducer(String producer) {
+        this._producer = producer;
+        return this;
+    }
+
 }


### PR DESCRIPTION
currently the producer defaults to `openhtmltopdf.com` while I think that is sane in the most cases. it's sometimes not wished to actually "show" which library was used to produce pdfs.
