### PR TITLE
Get ImageMap Shape tessilation right

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ head - 0.0.1-RC13-SNAPSHOT
 ========
 + [Fix for XML loading problems with JBoss,Wildfly](https://github.com/danfickle/openhtmltopdf/issues/54) Thanks @estevandiedrich, @alanhay
 + [Support image maps on img, object and svg](https://github.com/danfickle/openhtmltopdf/pull/163) Uses a kong polygon tesselation implementation by [sunshine2k](https://www.sunshine2k.de/coding/java/Polygon/Kong/Kong.html)
++ BINARY API BREAKING CHANGE: [Support custom shape <=> link maps in object drawers](https://github.com/danfickle/openhtmltopdf/pull/163)
 
 0.0.1-RC12
 ========

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ CHANGELOG
 head - 0.0.1-RC13-SNAPSHOT
 ========
 + [Fix for XML loading problems with JBoss,Wildfly](https://github.com/danfickle/openhtmltopdf/issues/54) Thanks @estevandiedrich, @alanhay
++ [Support image maps on img, object and svg](https://github.com/danfickle/openhtmltopdf/pull/163) Uses a kong polygon tesselation implementation by [sunshine2k](https://www.sunshine2k.de/coding/java/Polygon/Kong/Kong.html)
 
 0.0.1-RC12
 ========

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ head - 0.0.1-RC13-SNAPSHOT
 ========
 + [Fix for XML loading problems with JBoss,Wildfly](https://github.com/danfickle/openhtmltopdf/issues/54) Thanks @estevandiedrich, @alanhay
 + [Support image maps on img, object and svg](https://github.com/danfickle/openhtmltopdf/pull/163) Uses a kong polygon tesselation implementation by [sunshine2k](https://www.sunshine2k.de/coding/java/Polygon/Kong/Kong.html)
-+ BINARY API BREAKING CHANGE: [Support custom shape <=> link maps in object drawers](https://github.com/danfickle/openhtmltopdf/pull/163)
++ API BREAKING CHANGE: [Support custom shape <=> link maps in object drawers](https://github.com/danfickle/openhtmltopdf/pull/163)
+
+Note: Shaped links only work in Acrobat Reader. All other PDF reader seem to ignore them.
 
 0.0.1-RC12
 ========

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSObjectDrawer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSObjectDrawer.java
@@ -3,10 +3,22 @@ package com.openhtmltopdf.extend;
 import com.openhtmltopdf.render.RenderingContext;
 import org.w3c.dom.Element;
 
+import java.awt.*;
+import java.util.Map;
+
 /**
  * Handle the drawing of &lt;object&gt; tags
  */
 public interface FSObjectDrawer {
-	void drawObject(Element e, double x, double y, double width, double height, OutputDevice outputDevice,
+	/**
+	 * Perform your drawing.
+	 * 
+	 * @return null or a map of Shape =&gt; URL-String to annotate the drawing with
+	 *         links. The shapes must be relative to (x,y), i.e. (0,0) is at the
+	 *         corner (x,y). Also they should not extend (width,height). The links
+	 *         are only exported into the PDF and also only respected by Acrobat
+	 *         Reader.
+	 */
+	Map<Shape, String> drawObject(Element e, double x, double y, double width, double height, OutputDevice outputDevice,
 			RenderingContext ctx, int dotsPerPixel);
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageMapParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageMapParser.java
@@ -140,11 +140,11 @@ public class ImageMapParser {
 
 	private static Shape getCoords(String[] coordValues, int length) {
 		if ((-1 == length && 0 == coordValues.length % 2) || length == coordValues.length) {
-			int[] coords = new int[coordValues.length];
+			float[] coords = new float[coordValues.length];
 			int i = 0;
 			for (String coord : coordValues) {
 				try {
-					coords[i++] = Integer.parseInt(coord.trim());
+					coords[i++] = Float.parseFloat(coord.trim());
 				} catch (NumberFormatException e) {
 					XRLog.layout(Level.WARNING, "Error while parsing shape coords", e);
 					return null;
@@ -153,15 +153,15 @@ public class ImageMapParser {
 			if (4 == length) {
 				return new Rectangle2D.Float(coords[0], coords[1], coords[2] - coords[0], coords[3] - coords[1]);
 			} else if (3 == length) {
-				final int radius = coords[2];
+				final float radius = coords[2];
 				return new Ellipse2D.Float(coords[0] - radius, coords[1] - radius, radius * 2, radius * 2);
 			} else if (-1 == length) {
 				final int npoints = coords.length / 2;
 				final int[] xpoints = new int[npoints];
 				final int[] ypoints = new int[npoints];
 				for (int c = 0, p = 0; p < npoints; p++) {
-					xpoints[p] = coords[c++];
-					ypoints[p] = coords[c++];
+					xpoints[p] = (int)coords[c++];
+					ypoints[p] = (int)coords[c++];
 				}
 				return new Polygon(xpoints, ypoints, npoints);
 			} else {

--- a/openhtmltopdf-examples/pom.xml
+++ b/openhtmltopdf-examples/pom.xml
@@ -66,6 +66,12 @@
     <version>0.19.6</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.jfree</groupId>
+      <artifactId>jfreechart</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+
     
     <dependency>
       <groupId>junit</groupId>

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartBarDiagramObjectDrawer.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartBarDiagramObjectDrawer.java
@@ -1,6 +1,7 @@
 package com.openhtmltopdf.testcases;
 
 import java.awt.*;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,8 +25,11 @@ import com.openhtmltopdf.render.RenderingContext;
 
 public class JFreeChartBarDiagramObjectDrawer implements FSObjectDrawer {
 
-	static Map<Shape, String> buildShapeLinkMap(ChartRenderingInfo renderingInfo) {
+	static Map<Shape, String> buildShapeLinkMap(ChartRenderingInfo renderingInfo, double height, int dotsPerPixel) {
 		Map<Shape, String> linkShapes = null;
+		AffineTransform scaleTransform = new AffineTransform();
+		scaleTransform.translate(0, height);
+		scaleTransform.scale(dotsPerPixel, -dotsPerPixel);
 		for (Object entity : renderingInfo.getEntityCollection().getEntities()) {
 			if (!(entity instanceof ChartEntity))
 				continue;
@@ -35,7 +39,7 @@ public class JFreeChartBarDiagramObjectDrawer implements FSObjectDrawer {
 			if (url != null) {
 				if (linkShapes == null)
 					linkShapes = new HashMap<Shape, String>();
-				linkShapes.put(shape, url);
+				linkShapes.put(scaleTransform.createTransformedShape(shape), url);
 			}
 		}
 		return linkShapes;
@@ -80,6 +84,6 @@ public class JFreeChartBarDiagramObjectDrawer implements FSObjectDrawer {
 					}
 				});
 
-		return buildShapeLinkMap(renderingInfo);
+		return buildShapeLinkMap(renderingInfo, height, dotsPerPixel);
 	}
 }

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartBarDiagramObjectDrawer.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartBarDiagramObjectDrawer.java
@@ -25,11 +25,10 @@ import com.openhtmltopdf.render.RenderingContext;
 
 public class JFreeChartBarDiagramObjectDrawer implements FSObjectDrawer {
 
-	static Map<Shape, String> buildShapeLinkMap(ChartRenderingInfo renderingInfo, double height, int dotsPerPixel) {
+	static Map<Shape, String> buildShapeLinkMap(ChartRenderingInfo renderingInfo, int dotsPerPixel) {
 		Map<Shape, String> linkShapes = null;
 		AffineTransform scaleTransform = new AffineTransform();
-		scaleTransform.translate(0, height);
-		scaleTransform.scale(dotsPerPixel, -dotsPerPixel);
+		scaleTransform.scale(dotsPerPixel, dotsPerPixel);
 		for (Object entity : renderingInfo.getEntityCollection().getEntities()) {
 			if (!(entity instanceof ChartEntity))
 				continue;
@@ -84,6 +83,6 @@ public class JFreeChartBarDiagramObjectDrawer implements FSObjectDrawer {
 					}
 				});
 
-		return buildShapeLinkMap(renderingInfo, height, dotsPerPixel);
+		return buildShapeLinkMap(renderingInfo, dotsPerPixel);
 	}
 }

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartBarDiagramObjectDrawer.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartBarDiagramObjectDrawer.java
@@ -1,0 +1,85 @@
+package com.openhtmltopdf.testcases;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.plot.CategoryPlot;
+import org.jfree.chart.urls.CategoryURLGenerator;
+import org.jfree.data.category.CategoryDataset;
+import org.jfree.data.category.DefaultCategoryDataset;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.openhtmltopdf.extend.FSObjectDrawer;
+import com.openhtmltopdf.extend.OutputDevice;
+import com.openhtmltopdf.extend.OutputDeviceGraphicsDrawer;
+import com.openhtmltopdf.render.RenderingContext;
+
+public class JFreeChartBarDiagramObjectDrawer implements FSObjectDrawer {
+
+	static Map<Shape, String> buildShapeLinkMap(ChartRenderingInfo renderingInfo) {
+		Map<Shape, String> linkShapes = null;
+		for (Object entity : renderingInfo.getEntityCollection().getEntities()) {
+			if (!(entity instanceof ChartEntity))
+				continue;
+			ChartEntity chartEntity = (ChartEntity) entity;
+			Shape shape = chartEntity.getArea();
+			String url = chartEntity.getURLText();
+			if (url != null) {
+				if (linkShapes == null)
+					linkShapes = new HashMap<Shape, String>();
+				linkShapes.put(shape, url);
+			}
+		}
+		return linkShapes;
+	}
+
+	@Override
+	public Map<Shape, String> drawObject(Element e, final double x, final double y, final double width,
+			final double height, OutputDevice outputDevice, RenderingContext ctx, final int dotsPerPixel) {
+		DefaultCategoryDataset dataset = new DefaultCategoryDataset();
+		NodeList childNodes = e.getChildNodes();
+		final Map<String, String> urls = new HashMap<String, String>();
+		for (int i = 0; i < childNodes.getLength(); i++) {
+			Node item = childNodes.item(i);
+			if (!(item instanceof Element))
+				continue;
+			Element childElement = (Element) item;
+			if (!((Element) item).getTagName().equals("data"))
+				continue;
+			String series = childElement.getAttribute("series");
+			String categorie = childElement.getAttribute("category");
+			double value = Double.parseDouble(childElement.getAttribute("value"));
+			String url = childElement.getAttribute("url");
+			dataset.setValue(value, series, categorie);
+			urls.put(series + ":" + categorie, url);
+		}
+
+		final JFreeChart chart1 = ChartFactory.createBarChart(e.getAttribute("title"), e.getAttribute("series-label"),
+				e.getAttribute("categories-label"), dataset);
+		((CategoryPlot) chart1.getPlot()).getRenderer().setDefaultItemURLGenerator(new CategoryURLGenerator() {
+			@Override
+			public String generateURL(CategoryDataset dataset, int series, int category) {
+				return urls.get(dataset.getRowKey(series) + ":" + dataset.getColumnKey(category));
+			}
+		});
+		final ChartRenderingInfo renderingInfo = new ChartRenderingInfo();
+		outputDevice.drawWithGraphics((float) x, (float) y, (float) width / dotsPerPixel, (float) height / dotsPerPixel,
+				new OutputDeviceGraphicsDrawer() {
+					@Override
+					public void render(Graphics2D graphics2D) {
+						chart1.draw(graphics2D, new Rectangle2D.Float((float) 0, (float) 0,
+								(float) (width / dotsPerPixel), (float) (height / dotsPerPixel)), renderingInfo);
+					}
+				});
+
+		return buildShapeLinkMap(renderingInfo);
+	}
+}

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartPieDiagramObjectDrawer.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartPieDiagramObjectDrawer.java
@@ -4,8 +4,7 @@ import static com.openhtmltopdf.testcases.JFreeChartBarDiagramObjectDrawer.build
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.jfree.chart.ChartFactory;
@@ -31,7 +30,7 @@ public class JFreeChartPieDiagramObjectDrawer implements FSObjectDrawer {
 			final double height, OutputDevice outputDevice, RenderingContext ctx, final int dotsPerPixel) {
 		DefaultPieDataset dataset = new DefaultPieDataset();
 		NodeList childNodes = e.getChildNodes();
-		final List<String> urls = new ArrayList<String>();
+		final Map<String, String> urls = new HashMap<String, String>();
 		for (int i = 0; i < childNodes.getLength(); i++) {
 			Node item = childNodes.item(i);
 			if (!(item instanceof Element))
@@ -43,14 +42,14 @@ public class JFreeChartPieDiagramObjectDrawer implements FSObjectDrawer {
 			double value = Double.parseDouble(childElement.getAttribute("value"));
 			String url = childElement.getAttribute("url");
 			dataset.setValue(name, value);
-			urls.add(url);
+			urls.put(name, url);
 		}
 
 		final JFreeChart chart1 = ChartFactory.createPieChart(e.getAttribute("title"), dataset, false, false, true);
 		((PiePlot) chart1.getPlot()).setURLGenerator(new PieURLGenerator() {
 			@Override
 			public String generateURL(PieDataset dataset, Comparable key, int pieIndex) {
-				return urls.get(pieIndex);
+				return urls.get(key.toString());
 			}
 		});
 		final ChartRenderingInfo renderingInfo = new ChartRenderingInfo();
@@ -63,6 +62,6 @@ public class JFreeChartPieDiagramObjectDrawer implements FSObjectDrawer {
 					}
 				});
 
-		return buildShapeLinkMap(renderingInfo);
+		return buildShapeLinkMap(renderingInfo, height, dotsPerPixel);
 	}
 }

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartPieDiagramObjectDrawer.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartPieDiagramObjectDrawer.java
@@ -62,6 +62,6 @@ public class JFreeChartPieDiagramObjectDrawer implements FSObjectDrawer {
 					}
 				});
 
-		return buildShapeLinkMap(renderingInfo, height, dotsPerPixel);
+		return buildShapeLinkMap(renderingInfo, dotsPerPixel);
 	}
 }

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartPieDiagramObjectDrawer.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/JFreeChartPieDiagramObjectDrawer.java
@@ -1,0 +1,68 @@
+package com.openhtmltopdf.testcases;
+
+import static com.openhtmltopdf.testcases.JFreeChartBarDiagramObjectDrawer.buildShapeLinkMap;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.PiePlot;
+import org.jfree.chart.urls.PieURLGenerator;
+import org.jfree.data.general.DefaultPieDataset;
+import org.jfree.data.general.PieDataset;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.openhtmltopdf.extend.FSObjectDrawer;
+import com.openhtmltopdf.extend.OutputDevice;
+import com.openhtmltopdf.extend.OutputDeviceGraphicsDrawer;
+import com.openhtmltopdf.render.RenderingContext;
+
+public class JFreeChartPieDiagramObjectDrawer implements FSObjectDrawer {
+
+	@Override
+	public Map<Shape, String> drawObject(Element e, final double x, final double y, final double width,
+			final double height, OutputDevice outputDevice, RenderingContext ctx, final int dotsPerPixel) {
+		DefaultPieDataset dataset = new DefaultPieDataset();
+		NodeList childNodes = e.getChildNodes();
+		final List<String> urls = new ArrayList<String>();
+		for (int i = 0; i < childNodes.getLength(); i++) {
+			Node item = childNodes.item(i);
+			if (!(item instanceof Element))
+				continue;
+			Element childElement = (Element) item;
+			if (!((Element) item).getTagName().equals("data"))
+				continue;
+			String name = childElement.getAttribute("name");
+			double value = Double.parseDouble(childElement.getAttribute("value"));
+			String url = childElement.getAttribute("url");
+			dataset.setValue(name, value);
+			urls.add(url);
+		}
+
+		final JFreeChart chart1 = ChartFactory.createPieChart(e.getAttribute("title"), dataset, false, false, true);
+		((PiePlot) chart1.getPlot()).setURLGenerator(new PieURLGenerator() {
+			@Override
+			public String generateURL(PieDataset dataset, Comparable key, int pieIndex) {
+				return urls.get(pieIndex);
+			}
+		});
+		final ChartRenderingInfo renderingInfo = new ChartRenderingInfo();
+		outputDevice.drawWithGraphics((float) x, (float) y, (float) width / dotsPerPixel, (float) height / dotsPerPixel,
+				new OutputDeviceGraphicsDrawer() {
+					@Override
+					public void render(Graphics2D graphics2D) {
+						chart1.draw(graphics2D, new Rectangle2D.Float((float) 0, (float) 0,
+								(float) (width / dotsPerPixel), (float) (height / dotsPerPixel)), renderingInfo);
+					}
+				});
+
+		return buildShapeLinkMap(renderingInfo);
+	}
+}

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -28,6 +28,7 @@ import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.logging.Level;
 
 public class TestcaseRunner {
@@ -180,6 +181,8 @@ public class TestcaseRunner {
 	private static DefaultObjectDrawerFactory buildObjectDrawerFactory() {
 		DefaultObjectDrawerFactory objectDrawerFactory = new DefaultObjectDrawerFactory();
 		objectDrawerFactory.registerDrawer("custom/binary-tree", new SampleObjectDrawerBinaryTree());
+		objectDrawerFactory.registerDrawer("jfreechart/pie", new JFreeChartPieDiagramObjectDrawer());
+		objectDrawerFactory.registerDrawer("jfreechart/bar", new JFreeChartBarDiagramObjectDrawer());
 		return objectDrawerFactory;
 	}
 
@@ -247,8 +250,8 @@ public class TestcaseRunner {
 		int angle;
 
 		@Override
-		public void drawObject(Element e, double x, double y, final double width, final double height,
-				OutputDevice outputDevice, RenderingContext ctx, final int dotsPerPixel) {
+		public Map<Shape,String> drawObject(Element e, double x, double y, final double width, final double height,
+											OutputDevice outputDevice, RenderingContext ctx, final int dotsPerPixel) {
 			final int depth = Integer.parseInt(e.getAttribute("data-depth"));
 			fanout = Integer.parseInt(e.getAttribute("data-fanout"));
 			angle = Integer.parseInt(e.getAttribute("data-angle"));
@@ -287,6 +290,7 @@ public class TestcaseRunner {
 									(int) (realHeight - titleBottomHeight));
 						}
 					});
+			return null;
 		}
 
 		private void renderTree(Graphics2D gfx, double x, double y, double len, double angleDeg, int depth) {

--- a/openhtmltopdf-examples/src/main/resources/testcases/custom-objects.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/custom-objects.html
@@ -4,6 +4,7 @@
 		object {
 			border: 2px solid black;
 			margin: 1px;
+			page-break-inside: avoid;
 		}
 	</style>
 </head>
@@ -22,12 +23,42 @@
 </object>
 
 <object type="custom/binary-tree" data-fanout="2" data-depth="10" data-angle="30"
-		style="width:400px; height:300px;clear:both;float:left;">
+		style="width:300px; height:200px;clear:both;float:left;">
 	<!-- This is a simple example for a custom object drawer -->
 </object>
 <object type="custom/binary-tree" data-fanout="2" data-depth="6" data-angle="40"
 		style="width:200px; height:300px;float:right;">
 	<!-- This is a simple example for a custom object drawer -->
 </object>
+
+<object type="jfreechart/pie" style="width:400px;height:400px; float:left;" title="Sample Pie Chart">
+	<data name="Series 1" value="23.2" url="https://www.google.de?q=section1"/>
+	<data name="Series 2" value="33.2"/>
+	<data name="Series 3" value="43.2"/>
+	<data name="Series 4" value="53.2" url="https://www.google.de?q=section2"/>
+	<data name="Something else" value="1.2" url="https://www.google.de?q=misc"/>
+</object>
+
+<br style="-fs-page-break-min-height: 10cm;clear:both;"/>
+A pagebreak should happen here!
+
+
+<object type="jfreechart/pie" style="width:400px;height:400px; float:left" title="Fruit Pie Chart">
+	<data name="Apple" value="23.2" url="https://www.google.de?q=apple-pie"/>
+	<data name="Pear" value="43.2" url="https://www.google.de?q=pear-pie"/>
+	<data name="Orange" value="53.2" url="https://www.google.de?q=orange-pie"/>
+</object>
+
+
+<object type="jfreechart/bar" style="width:400px;height:400px; float:left;" title="Fruit Bar Chart"
+		categories-title="Category" series-title="Series">
+	<data series="Value" category="Apple" value="23.2" url="https://www.google.de?q=apple"/>
+	<data series="Value" category="Pear" value="43.2" url="https://www.google.de?q=pear"/>
+	<data series="Value" category="Orange" value="33.2" url="https://www.google.de?q=orange"/>
+	<data series="Price/kg" category="Apple" value="2.2" url="https://www.google.de?q=apple-price"/>
+	<data series="Price/kg" category="Pear" value="4.2" url="https://www.google.de?q=pear-price"/>
+	<data series="Price/kg" category="Orange" value="5.2" url="https://www.google.de?q=orange-price"/>
+</object>
+
 </body>
 </html>

--- a/openhtmltopdf-examples/src/main/resources/testcases/svg-inline.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/svg-inline.html
@@ -22,8 +22,9 @@ Some examples how inline SVG is rendered.
 </svg>
 
 <map name="jsonmap">
-    <area shape="rect" coords="0,0,100,200" href="https://www.google.de?q=left"/>
-	<area shape="rect" coords="100,0,200,200" href="https://www.google.de?q=right"/>
+    <area shape="rect" coords="0,0,50,200" href="https://www.google.de?q=left"/>
+	<area shape="rect" coords="150,0,200,200" href="https://www.google.de?q=right"/>
+	<area shape="circle" coords="100,100,50" href="https://www.google.de?q=inner-circle"/>
 </map>
 
 <h2>Barchart</h2>

--- a/openhtmltopdf-examples/src/main/resources/testcases/svg-inline.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/svg-inline.html
@@ -15,6 +15,12 @@ Some examples how inline SVG is rendered.
 <h2>JSON-Symbol</h2>
 
 <!-- Taken from https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 102" width="200" height="200" usemap="#jsonmap" style="transform:skewX(45deg); rotate(10deg); float:right; margin-right:100px">
+	<radialGradient id="jsongrad" cx="65" cy="90" r="100" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#EEF"/><stop offset="1"/></radialGradient>
+	<path d="M61,02 A 49,49 0,0,0 39,98 C 9,79 10,24 45,25 C 72,24 65,75 50,75 C 93,79 91,21 62,02" id="jsonswirl" fill="url(#jsongrad)"/>
+	<use xlink:href="#jsonswirl" transform="rotate(180 50,50)"/>
+</svg>
+
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 102" width="200" height="200" usemap="#jsonmap">
 	<radialGradient id="jsongrad" cx="65" cy="90" r="100" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#EEF"/><stop offset="1"/></radialGradient>
 	<path d="M61,02 A 49,49 0,0,0 39,98 C 9,79 10,24 45,25 C 72,24 65,75 50,75 C 93,79 91,21 62,02" id="jsonswirl" fill="url(#jsongrad)"/>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImageElement.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImageElement.java
@@ -22,6 +22,7 @@ package com.openhtmltopdf.pdfboxout;
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.extend.ReplacedElement;
 import com.openhtmltopdf.layout.LayoutContext;
+import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.pdfboxout.PdfBoxLinkManager.IPdfBoxElementWithShapedLinks;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.RenderingContext;
@@ -37,9 +38,9 @@ public class PdfBoxImageElement implements PdfBoxReplacedElement, IPdfBoxElement
     private Point _location = new Point(0, 0);
     private final Map<Shape, String> imageMap;
 
-    public PdfBoxImageElement(Element e, FSImage image) {
+    public PdfBoxImageElement(Element e, FSImage image, SharedContext c) {
         _image = image;
-        imageMap = ImageMapParser.findAndParseMap(e);
+        imageMap = ImageMapParser.findAndParseMap(e, c);
     }
 
     public int getIntrinsicWidth() {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
@@ -222,8 +222,6 @@ public class PdfBoxLinkManager {
 		AffineTransform transformForQuads = new AffineTransform();
 		transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());
 		transformForQuads.concatenate(transform);
-		//transformForQuads.scale(transform.getScaleX(),
-				//transform.getScaleY());
 		Area area = new Area(linkShape);
 		PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
 		double[] vals = new double[6];
@@ -269,6 +267,12 @@ public class PdfBoxLinkManager {
 
 		if (ret.length % 8 != 0)
 			throw new IllegalStateException("Not exact 8xn QuadPoints!");
+		for (; i < ret.length; i += 2) {
+			if (ret[i] < targetArea.getMinX() || ret[i] > targetArea.getMaxX())
+				throw new IllegalStateException("Invalid rectangle calculation");
+			if (ret[i + 1] < targetArea.getMinY() || ret[i + 1] > targetArea.getMaxY())
+				throw new IllegalStateException("Invalid rectangle calculation");
+		}
 		return ret;
 	}
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
@@ -194,7 +194,7 @@ public class PdfBoxLinkManager {
 				annot.setRectangle(new PDRectangle((float) targetArea.getMinX(), (float) targetArea.getMinY(),
 						(float) targetArea.getWidth(), (float) targetArea.getHeight()));
 				if (linkShape != null)
-					annot.setQuadPoints(mapShapeToQuadPoints(elem, transform, linkShape, targetArea, c));
+					annot.setQuadPoints(mapShapeToQuadPoints(transform, linkShape, targetArea, c));
 
 				addLinkToPage(page, annot);
 			}
@@ -211,21 +211,19 @@ public class PdfBoxLinkManager {
 			annot.setRectangle(new PDRectangle((float) targetArea.getMinX(), (float) targetArea.getMinY(),
 					(float) targetArea.getWidth(), (float) targetArea.getHeight()));
 			if (linkShape != null)
-				annot.setQuadPoints(mapShapeToQuadPoints(elem, transform, linkShape, targetArea, c));
+				annot.setQuadPoints(mapShapeToQuadPoints(transform, linkShape, targetArea, c));
 
 			addLinkToPage(page, annot);
 		}
 	}
 
-	private float[] mapShapeToQuadPoints(Element elem, AffineTransform transform, Shape linkShape, Rectangle2D targetArea, RenderingContext c) {
+	private float[] mapShapeToQuadPoints(AffineTransform transform, Shape linkShape, Rectangle2D targetArea, RenderingContext c) {
 		List<Point2D.Float> points = new ArrayList<Point2D.Float>();
 		AffineTransform transformForQuads = new AffineTransform();
 		transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());
-		transformForQuads.scale(transform.getScaleX()*c.getDotsPerPixel(), transform.getScaleY()*c.getDotsPerPixel());
+		transformForQuads.scale(transform.getScaleX() * c.getDotsPerPixel(),
+				transform.getScaleY() * c.getDotsPerPixel());
 		Area area = new Area(linkShape);
-		Rectangle2D bounds2D = area.getBounds2D();
-		//transformForQuads.scale(targetArea.getWidth() / bounds2D.getWidth(), targetArea.getHeight() / bounds2D.getHeight());
-		//transformForQuads.scale(_od.getDeviceLength(1), _od.getDeviceLength(1));
 		PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
 		double[] vals = new double[6];
 		while (!pathIterator.isDone()) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
@@ -221,8 +221,9 @@ public class PdfBoxLinkManager {
 		List<Point2D.Float> points = new ArrayList<Point2D.Float>();
 		AffineTransform transformForQuads = new AffineTransform();
 		transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());
-		transformForQuads.scale(transform.getScaleX() * c.getDotsPerPixel(),
-				transform.getScaleY() * c.getDotsPerPixel());
+		transformForQuads.concatenate(transform);
+		//transformForQuads.scale(transform.getScaleX(),
+				//transform.getScaleY());
 		Area area = new Area(linkShape);
 		PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
 		double[] vals = new double[6];

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
@@ -249,8 +249,8 @@ public class PdfBoxLinkManager {
 	}
 
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
-	private boolean placeAnnotation(AffineTransform transform, Shape linkShape,
-									Rectangle2D targetArea, PDAnnotationLink annot) {
+	private boolean placeAnnotation(AffineTransform transform, Shape linkShape, Rectangle2D targetArea,
+			PDAnnotationLink annot) {
 		annot.setRectangle(new PDRectangle((float) targetArea.getMinX(), (float) targetArea.getMinY(),
 				(float) targetArea.getWidth(), (float) targetArea.getHeight()));
 		if (linkShape != null) {
@@ -269,6 +269,9 @@ public class PdfBoxLinkManager {
 		List<Point2D.Float> points = new ArrayList<Point2D.Float>();
 		AffineTransform transformForQuads = new AffineTransform();
 		transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());
+		// We must flip the whole thing upside down
+		transformForQuads.translate(0, targetArea.getHeight());
+		transformForQuads.scale(1, -1);
 		transformForQuads.concatenate(transform);
 		Area area = new Area(linkShape);
 		PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
@@ -282,7 +285,7 @@ public class PdfBoxLinkManager {
 				points.add(new Point2D.Float((float) vals[0], (float) vals[1]));
 				break;
 			case PathIterator.SEG_MOVETO:
-					points.add(new Point2D.Float((float) vals[0], (float) vals[1]));
+				points.add(new Point2D.Float((float) vals[0], (float) vals[1]));
 				break;
 			case PathIterator.SEG_QUADTO:
 				throw new RuntimeException("Invalid State, Area should never give us a curve here!");

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxObjectDrawerReplacedElement.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxObjectDrawerReplacedElement.java
@@ -2,6 +2,7 @@ package com.openhtmltopdf.pdfboxout;
 
 import com.openhtmltopdf.extend.FSObjectDrawer;
 import com.openhtmltopdf.layout.LayoutContext;
+import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.pdfboxout.PdfBoxLinkManager.IPdfBoxElementWithShapedLinks;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.RenderingContext;
@@ -24,13 +25,13 @@ public class PdfBoxObjectDrawerReplacedElement implements PdfBoxReplacedElement,
 	private final Map<Shape, String> imageMap;
 
 	public PdfBoxObjectDrawerReplacedElement(Element e, FSObjectDrawer drawer, int cssWidth, int cssHeight,
-			int dotsPerPixel) {
+											 SharedContext c) {
 		this.e = e;
-		imageMap = ImageMapParser.findAndParseMap(e);
+		imageMap = ImageMapParser.findAndParseMap(e, c);
 		this.drawer = drawer;
 		this.width = cssWidth;
 		this.height = cssHeight;
-		this.dotsPerPixel = dotsPerPixel;
+		this.dotsPerPixel = c.getDotsPerPixel();
 	}
 
 	@Override

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxObjectDrawerReplacedElement.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxObjectDrawerReplacedElement.java
@@ -22,7 +22,7 @@ public class PdfBoxObjectDrawerReplacedElement implements PdfBoxReplacedElement,
 	private final int width;
 	private final int height;
 	private final int dotsPerPixel;
-	private final Map<Shape, String> imageMap;
+	private Map<Shape, String> imageMap;
 
 	public PdfBoxObjectDrawerReplacedElement(Element e, FSObjectDrawer drawer, int cssWidth, int cssHeight,
 											 SharedContext c) {
@@ -75,7 +75,9 @@ public class PdfBoxObjectDrawerReplacedElement implements PdfBoxReplacedElement,
 
 	@Override
 	public void paint(RenderingContext c, PdfBoxOutputDevice outputDevice, BlockBox box) {
-		drawer.drawObject(e, point.getX(), point.getY(), getIntrinsicWidth(), getIntrinsicHeight(), outputDevice, c, dotsPerPixel);
+		Map<Shape, String> shapeStringMap = drawer.drawObject(e, point.getX(), point.getY(), getIntrinsicWidth(), getIntrinsicHeight(), outputDevice, c, dotsPerPixel);
+		if(shapeStringMap != null )
+			imageMap = shapeStringMap;
 	}
 
 	@Override

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
@@ -50,7 +50,7 @@ public class PdfBoxReplacedElementFactory implements ReplacedElementFactory {
             int cssMaxWidth = CalculatedStyle.getCSSMaxWidth(c, box);
             int cssMaxHeight = CalculatedStyle.getCSSMaxHeight(c, box);
             
-            return new PdfBoxSVGReplacedElement(e, _svgImpl, cssWidth, cssHeight, cssMaxWidth, cssMaxHeight, c.getSharedContext().getDotsPerPixel());
+            return new PdfBoxSVGReplacedElement(e, _svgImpl, cssWidth, cssHeight, cssMaxWidth, cssMaxHeight, c.getSharedContext());
         } else if (nodeName.equals("img")) {
             String srcAttr = e.getAttribute("src");
             if (srcAttr != null && srcAttr.length() > 0) {
@@ -96,34 +96,11 @@ public class PdfBoxReplacedElementFactory implements ReplacedElementFactory {
                             fsImage.scale(cssWidth, cssHeight);
                         }
                     }
-                    return new PdfBoxImageElement(e,fsImage);
+                    return new PdfBoxImageElement(e,fsImage,c.getSharedContext());
                 }
             }
         } else if (nodeName.equals("input")) {
             /* We do nothing here. Form Elements are handled special in PdfBoxOutputDevice.paintBackground() */
-            String type = e.getAttribute("type");
-// TODO: Implement form fields.
-//            if (type.equals("hidden")) {
-//                return new EmptyReplacedElement(1, 1);
-//            } else if (type.equals("checkbox")) {
-//                return new CheckboxFormField(c, box, cssWidth, cssHeight);
-//            } else if (type.equals("radio")) {
-//                //TODO finish support for Radio button
-//                //RadioButtonFormField result = new RadioButtonFormField(
-//                //			this, c, box, cssWidth, cssHeight);
-//                //		saveResult(e, result);
-//                //return result;
-//                return new EmptyReplacedElement(0, 0);
-//
-//            } else {
-//                return new TextFormField(c, box, cssWidth, cssHeight);
-//            }
-//            /*
-//             } else if (nodeName.equals("select")) {//TODO Support select
-//             return new SelectFormField(c, box, cssWidth, cssHeight);
-//             } else if (isTextarea(e)) {//TODO Review if this is needed the textarea item prints fine currently
-//             return new TextAreaFormField(c, box, cssWidth, cssHeight);
-//             */
         } else if (nodeName.equals("bookmark")) {
             // HACK Add box as named anchor and return placeholder
             BookmarkElement result = new BookmarkElement();
@@ -137,7 +114,7 @@ public class PdfBoxReplacedElementFactory implements ReplacedElementFactory {
 			FSObjectDrawer drawer = _objectDrawerFactory.createDrawer(e);
 			if (drawer != null)
 				return new PdfBoxObjectDrawerReplacedElement(e, drawer, cssWidth, cssHeight,
-						c.getSharedContext().getDotsPerPixel());
+						c.getSharedContext());
         }
 
         return null;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSVGReplacedElement.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSVGReplacedElement.java
@@ -3,6 +3,7 @@ package com.openhtmltopdf.pdfboxout;
 import com.openhtmltopdf.extend.SVGDrawer;
 import com.openhtmltopdf.extend.SVGDrawer.SVGImage;
 import com.openhtmltopdf.layout.LayoutContext;
+import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.pdfboxout.PdfBoxLinkManager.IPdfBoxElementWithShapedLinks;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.RenderingContext;
@@ -17,9 +18,9 @@ public class PdfBoxSVGReplacedElement implements PdfBoxReplacedElement, IPdfBoxE
     private final Map<Shape, String> imageMap;
     private Point point = new Point(0, 0);
     
-    public PdfBoxSVGReplacedElement(Element e, SVGDrawer svgImpl, int cssWidth, int cssHeight, int cssMaxWidth, int cssMaxHeight, int dotsPerPixel) {       
-        this.svgImage = svgImpl.buildSVGImage(e, cssWidth, cssHeight, cssMaxWidth, cssMaxHeight, dotsPerPixel);
-        imageMap = ImageMapParser.findAndParseMap(e);
+    public PdfBoxSVGReplacedElement(Element e, SVGDrawer svgImpl, int cssWidth, int cssHeight, int cssMaxWidth, int cssMaxHeight, SharedContext c) {
+        this.svgImage = svgImpl.buildSVGImage(e, cssWidth, cssHeight, cssMaxWidth, cssMaxHeight, c.getDotsPerPixel());
+        imageMap = ImageMapParser.findAndParseMap(e, c);
     }
 
     @Override

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/KongAlgo.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/KongAlgo.java
@@ -37,8 +37,12 @@ public class KongAlgo {
 	 */
 	private void calcNonConvexPoints() {
 		// safety check, with less than 4 points we have to do nothing
-		if (points.size() <= 3)
+		if (points.size() <= 3) {
+			if (points.size() == 3) {
+				triangles.add(new Triangle(points.get(0), points.get(1), points.get(2)));
+			}
 			return;
+		}
 
 		// actual three points
 		Point2D.Float p;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/KongAlgo.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/KongAlgo.java
@@ -1,0 +1,203 @@
+package com.openhtmltopdf.pdfboxout.quads;
+
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 
+ * @author Sunshine Source:
+ *         https://www.sunshine2k.de/coding/java/Polygon/Kong/Kong.html
+ */
+public class KongAlgo {
+	private static boolean isDebug = false;
+
+	private List<Point2D.Float> points;
+	private List<Point2D.Float> nonconvexPoints;
+	private List<Triangle> triangles;
+
+	// orientation of polygon - true = clockwise, false = counterclockwise
+	private boolean isCw;
+
+	public KongAlgo(List<Point2D.Float> points) {
+		// we have to copy the point vector as we modify it
+		this.points = new ArrayList<Point2D.Float>();
+		for (Point2D.Float point : points)
+			this.points.add(new Point2D.Float(point.x, point.y));
+
+		nonconvexPoints = new ArrayList<Point2D.Float>();
+		triangles = new ArrayList<Triangle>();
+
+		calcPolyOrientation();
+		calcNonConvexPoints();
+	}
+
+	/*
+	 * This determines all concave vertices of the polygon.
+	 */
+	private void calcNonConvexPoints() {
+		// safety check, with less than 4 points we have to do nothing
+		if (points.size() <= 3)
+			return;
+
+		// actual three points
+		Point2D.Float p;
+		Point2D.Float v;
+		Point2D.Float u;
+		// result value of test function
+		float res;
+		for (int i = 0; i < points.size() - 1; i++) {
+			p = points.get(i);
+			Point2D.Float tmp = points.get(i + 1);
+			v = new Point2D.Float(); // interpret v as vector from i to i+1
+			v.x = tmp.x - p.x;
+			v.y = tmp.y - p.y;
+
+			// ugly - last polygon segment goes from last point to first point
+			if (i == points.size() - 2)
+				u = points.get(0);
+			else
+				u = points.get(i + 2);
+
+			res = u.x * v.y - u.y * v.x + v.x * p.y - v.y * p.x;
+			// note: cw means res/newres is <= 0
+			if ((res > 0 && isCw) || (res <= 0 && !isCw)) {
+				nonconvexPoints.add(tmp);
+				if (isDebug)
+					System.out.println("konkav point #" + (i + 1) + "  Coords: " + tmp.x + "/" + tmp.y);
+			}
+
+		}
+	}
+
+	/*
+	 * Get the orientation of the polygon - clockwise (cw) or counter-clockwise
+	 * (ccw)
+	 */
+	private void calcPolyOrientation() {
+		if (points.size() < 3)
+			return;
+
+		// first find point with minimum x-coord - if there are several ones take
+		// the one with maximal y-coord
+		int index = 0; // index of point in vector to find
+		Point2D.Float pointOfIndex = points.get(0);
+		for (int i = 1; i < points.size(); i++) {
+			if (points.get(i).x < pointOfIndex.x) {
+				pointOfIndex = points.get(i);
+				index = i;
+			} else if (points.get(i).x == pointOfIndex.x && points.get(i).y > pointOfIndex.y) {
+				pointOfIndex = points.get(i);
+				index = i;
+			}
+		}
+
+		// get vector from index-1 to index
+		Point2D.Float prevPointOfIndex;
+		if (index == 0)
+			prevPointOfIndex = points.get(points.size() - 1);
+		else
+			prevPointOfIndex = points.get(index - 1);
+		Point2D.Float v1 = new Point2D.Float(pointOfIndex.x - prevPointOfIndex.x, pointOfIndex.y - prevPointOfIndex.y);
+		// get next point
+		Point2D.Float succPointOfIndex;
+		if (index == points.size() - 1)
+			succPointOfIndex = points.get(0);
+		else
+			succPointOfIndex = points.get(index + 1);
+
+		// get orientation
+		float res = succPointOfIndex.x * v1.y - succPointOfIndex.y * v1.x + v1.x * prevPointOfIndex.y
+				- v1.y * prevPointOfIndex.x;
+
+		isCw = (res <= 0);
+		if (isDebug)
+			System.out.println("isCw : " + isCw);
+	}
+
+	/*
+	 * Returns true if the triangle formed by the three given points is an ear
+	 * considering the polygon - thus if no other point is inside and it is convex.
+	 * Otherwise false.
+	 */
+	private boolean isEar(Point2D.Float p1, Point2D.Float p2, Point2D.Float p3) {
+		// not convex, bye
+		if (!(isConvex(p1, p2, p3)))
+			return false;
+
+		// iterate over all konkav points and check if one of them lies inside the given
+		// triangle
+		for (Point2D.Float nonconvexPoint : nonconvexPoints) {
+			if (Triangle.isInside(p1, p2, p3, nonconvexPoint))
+				return false;
+		}
+		return true;
+	}
+
+	/*
+	 * Returns true if the point p2 is convex considered the actual polygon. p1, p2
+	 * and p3 are three consecutive points of the polygon.
+	 */
+	private boolean isConvex(Point2D.Float p1, Point2D.Float p2, Point2D.Float p3) {
+		Point2D.Float v = new Point2D.Float(p2.x - p1.x, p2.y - p1.y);
+		float res = p3.x * v.y - p3.y * v.x + v.x * p1.y - v.y * p1.x;
+		return !((res > 0 && isCw) || (res <= 0 && !isCw));
+	}
+
+	/*
+	 * This is a helper function for accessing consecutive points of the polygon
+	 * vector. It ensures that no IndexOutofBoundsException occurs.
+	 * 
+	 * @param index is the base index of the point to be accessed
+	 * 
+	 * @param offset to be added/subtracted to the index value
+	 */
+	private int getIndex(int index, int offset) {
+		int newindex;
+		if (isDebug)
+			System.out.println("size " + points.size() + " index:" + index + " offset:" + offset);
+		if (index + offset >= points.size())
+			newindex = points.size() - (index + offset);
+		else {
+			if (index + offset < 0)
+				newindex = points.size() + (index + offset);
+			else
+				newindex = index + offset;
+		}
+		if (isDebug)
+			System.out.println("new index = " + newindex);
+		return newindex;
+	}
+
+	/*
+	 * The actual Kong's Triangulation Algorithm
+	 */
+	public void runKong() {
+		if (points.size() <= 3)
+			return;
+
+		triangles.clear();
+		int index = 1;
+
+		while (points.size() > 3) {
+			if (isEar(points.get(getIndex(index, -1)), points.get(index), points.get(getIndex(index, 1)))) {
+				// cut ear
+				triangles.add(new Triangle(points.get(getIndex(index, -1)), points.get(index),
+						points.get(getIndex(index, 1))));
+				points.remove(points.get(index));
+				index = getIndex(index, -1);
+
+			} else {
+				index = getIndex(index, 1);
+			}
+		}
+		// add last triangle
+		triangles.add(new Triangle(points.get(0), points.get(1), points.get(2)));
+
+	}
+
+	public List<Triangle> getTriangles() {
+		return triangles;
+	}
+
+}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/Triangle.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/Triangle.java
@@ -1,0 +1,37 @@
+package com.openhtmltopdf.pdfboxout.quads;
+
+import java.awt.geom.Point2D;
+
+/**
+ *
+ * @author Sunshine A class to represent a triangle Note that all three points
+ *         should be different in order to work properly
+ * 
+ *         Source: https://www.sunshine2k.de/coding/java/Polygon/Kong/Kong.html
+ */
+public class Triangle {
+
+	// coordinates
+	public final Point2D.Float a;
+	public final Point2D.Float b;
+	public final Point2D.Float c;
+
+	Triangle(Point2D.Float a, Point2D.Float b, Point2D.Float c) {
+		this.a = a;
+		this.b = b;
+		this.c = c;
+	}
+
+	public static boolean isInside(Point2D.Float x, Point2D.Float y, Point2D.Float z, Point2D.Float p) {
+		Point2D.Float v1 = new Point2D.Float(y.x - x.x, y.y - x.y);
+		Point2D.Float v2 = new Point2D.Float(z.x - x.x, z.y - x.y);
+
+		double det = v1.x * v2.y - v2.x * v1.y;
+		Point2D.Float tmp = new Point2D.Float(p.x - x.x, p.y - x.y);
+		double lambda = (tmp.x * v2.y - v2.x * tmp.y) / det;
+		double mue = (v1.x * tmp.y - tmp.x * v1.y) / det;
+
+		return (lambda > 0 && mue > 0 && (lambda + mue) < 1);
+	}
+
+}


### PR DESCRIPTION
Using https://www.sunshine2k.de/coding/java/Polygon/Kong/Kong.html 

I've adapted the class for this use case. In the readme provided with the java sources the author says "please give me some credits". IANAL but I think it should be save to include the files here. But I will check back with the author. 

From the given transform only the scale is used, as I could not get the concatination of the transform working correctly. This should only affect images affected by CSS-transform. Feel free to fix this, to make this work correctly with CSS-transforms.

In the sample svg-inline there is now a image map using two rectangles and a circle. Those work with Acrobat Reader with this changes. Mac OS X preview seems to ignore the quad points.