### PR TITLE
#187 Specifying default DocumentBuilderFactory implementation and add…

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
@@ -123,6 +123,7 @@ public class SharedContext {
 	private FSTextTransformer _unicodeToTitleTransformer = new TextUtil.DefaultToTitleTransformer();
 
 	public String _preferredTransformerFactoryImplementationClass = null;
+	public String _preferredDocumentBuilderFactoryImplementationClass = null;
     
     public SharedContext() {
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
@@ -46,6 +46,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	protected short _pagingMode = Layer.PAGED_MODE_PRINT;
 	protected FSObjectDrawerFactory _objectDrawerFactory;
 	protected String _preferredTransformerFactoryImplementationClass = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
+	protected String _preferredDocumentBuilderFactoryImplementationClass = "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl";
 
 	/**
 	 * Add a DOM mutator to this builder. DOM mutators allow to modify the DOM
@@ -78,6 +79,23 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 		this._preferredTransformerFactoryImplementationClass = transformerFactoryClass;
 		return (TFinalClass) this;
 	}
+
+	/**
+	 * This method should be considered advanced and is not required for most
+	 * setups. Set a preferred implementation class for use as
+	 * javax.xml.parsers.DocumentBuilderFactory. Use null to let a default
+	 * implementation class be used. The default is
+	 * "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl".
+	 * If the default does not work you can use null to let the container use whatever
+	 * DocumentBuilderFactory it has available.
+	 *
+	 * @param documentBuilderFactoryClass
+	 * @return this for method chaining
+	 */
+		public final TFinalClass useDocumentBuilderFactoryImplementationClass(String documentBuilderFactoryClass) {
+				this._preferredDocumentBuilderFactoryImplementationClass = documentBuilderFactoryClass;
+				return (TFinalClass) this;
+		}
 
 	/**
 	 * The default text direction of the document. LTR by default.

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/XMLResource.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/XMLResource.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.FactoryConfigurationError;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -214,6 +215,15 @@ public class XMLResource extends AbstractResource {
             }
     	}
     	
+    	private DocumentBuilderFactory loadPreferredDocumentBuilderFactory(String preferredImpl) {
+            try {
+            	return preferredImpl == null ? DocumentBuilderFactory.newInstance() : DocumentBuilderFactory.newInstance(preferredImpl, null);
+            } catch (FactoryConfigurationError e) {
+            	XRLog.load(Level.SEVERE, "Could not load preferred XML document builder, using default which may not be secure.");
+            	return DocumentBuilderFactory.newInstance();
+            }
+    	}
+
     	private XMLResource createXMLResource(XMLResource target) {
             Source input = null;
             DOMResult output = null;
@@ -232,7 +242,8 @@ public class XMLResource extends AbstractResource {
             try {
                 input = new SAXSource(xmlReader, target.getResourceInputSource());
                 
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                String preferredDocumentBuilderFactory = ThreadCtx.get().sharedContext()._preferredDocumentBuilderFactoryImplementationClass;
+                DocumentBuilderFactory dbf = loadPreferredDocumentBuilderFactory(preferredDocumentBuilderFactory);
                 
                 setDocumentBuilderSecurityFeatures(dbf);
                 dbf.setNamespaceAware(true);

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
@@ -81,7 +81,9 @@ public class Java2DRenderer implements IJava2DRenderer, Closeable {
 			Graphics2D layoutGraphics,
 			int initialPageNumber, short pagingMode,
 			FSObjectDrawerFactory objectDrawerFactory,
-			String preferredTransformerFactoryImplementationClass, List<FSDOMMutator> _domMutators) {
+			String preferredTransformerFactoryImplementationClass,
+			String preferredDocumentBuilderFactoryImplementationClass,
+			List<FSDOMMutator> _domMutators) {
 
 	    _pagingMode = pagingMode;
 		_pageProcessor = pageProcessor;
@@ -110,6 +112,7 @@ public class Java2DRenderer implements IJava2DRenderer, Closeable {
         _sharedContext.registerWithThread();
         
         _sharedContext._preferredTransformerFactoryImplementationClass = preferredTransformerFactoryImplementationClass;
+        _sharedContext._preferredDocumentBuilderFactoryImplementationClass = preferredDocumentBuilderFactoryImplementationClass;
         
         _sharedContext.setUserAgentCallback(uac);
         _sharedContext.setCss(new StyleReference(uac));

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -158,7 +158,8 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 
 		return new Java2DRenderer(doc, unicode, _httpStreamFactory, _resolver, _cache, _svgImpl, _mathmlImpl, pageSize,
 				_replacementText, _testMode, _pageProcessor, _layoutGraphics, _initialPageNumber, _pagingMode,
-				_objectDrawerFactory, _preferredTransformerFactoryImplementationClass, _domMutators);
+				_objectDrawerFactory, _preferredTransformerFactoryImplementationClass,
+				_preferredDocumentBuilderFactoryImplementationClass,_domMutators);
 	}
 
 	private static class AddedFont {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -112,6 +112,7 @@ public class PdfBoxRenderer implements Closeable {
                    OutputStream os, FSUriResolver resolver, FSCache cache, SVGDrawer svgImpl,
                    PageDimensions pageSize, float pdfVersion, String replacementText, boolean testMode,
                    FSObjectDrawerFactory objectDrawerFactory, String preferredTransformerFactoryImplementationClass,
+                   String preferredDocumentBuilderFactoryImplementationClass,
                    String producer, SVGDrawer mathmlImpl, List<FSDOMMutator> domMutators, PDDocument pdocument) {
         
         _pdfDoc = pdocument != null ? pdocument : new PDDocument();
@@ -144,6 +145,7 @@ public class PdfBoxRenderer implements Closeable {
         _sharedContext.registerWithThread();
         
         _sharedContext._preferredTransformerFactoryImplementationClass = preferredTransformerFactoryImplementationClass;
+        _sharedContext._preferredDocumentBuilderFactoryImplementationClass = preferredDocumentBuilderFactoryImplementationClass;
         
         _sharedContext.setUserAgentCallback(userAgent);
         _sharedContext.setCss(new StyleReference(userAgent));

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -58,7 +58,8 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 
 		PdfBoxRenderer renderer = new PdfBoxRenderer(doc, unicode, _httpStreamFactory, _os, _resolver, _cache, _svgImpl,
 				pageSize, _pdfVersion, _replacementText, _testMode, _objectDrawerFactory,
-				_preferredTransformerFactoryImplementationClass, _producer, _mathmlImpl, _domMutators, pddocument);
+				_preferredTransformerFactoryImplementationClass,  _preferredDocumentBuilderFactoryImplementationClass,
+				_producer, _mathmlImpl, _domMutators, pddocument);
 
 		/*
 		 * Register all Fonts


### PR DESCRIPTION
…ing a way to bypass it

Specifying "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl" as the default DocumentBuilderFactory, in BaseRendererBuilder. (This is the factory that is used by default, but an application may depend on an other parser which could provide an incompatible builder factory).

Adding method useDocumentBuilderFactoryImplementationClass(), to be able to use another implementation (or the DocumentBuilderFactory currently available in the application, if null is passed) if necessary.