### PR TITLE
Support for image-rendering: pixelated.

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -1471,6 +1471,19 @@ public final class CSSName implements Comparable {
             );
 
     /**
+     * Unique CSSName instance for CSS3 property.
+     */
+    public final static CSSName IMAGE_RENDERING =
+            addProperty(
+                    "image-rendering",
+                    PRIMITIVE,
+                    "auto",
+                    INHERITS,
+                    new PrimitivePropertyBuilders.ImageRenderingBuilder()
+            );
+
+
+    /**
      * Unique CSSName instance for CSS2 property.
      */
     public final static CSSName BACKGROUND_SHORTHAND =
@@ -1720,7 +1733,6 @@ public final class CSSName implements Comparable {
                     CSSName.BORDER_RIGHT_COLOR,
                     CSSName.BORDER_BOTTOM_COLOR,
                     CSSName.BORDER_LEFT_COLOR);
-
     /**
      * Constructor for the CSSName object
      *

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
@@ -242,6 +242,12 @@ public class IdentValue implements FSDerivedValue {
     public static final IdentValue SKEW_X = addValue("skewX");
     public static final IdentValue SKEW_Y = addValue("skewY");
 
+    /*
+     * image-rendering
+     */
+    public static final IdentValue PIXELATED = addValue("pixelated");
+    public static final IdentValue CRISP_EDGES = addValue("crisp-edges");
+
 
     /**
      * Description of the Field

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
@@ -1826,4 +1826,16 @@ public class PrimitivePropertyBuilders {
             );
         }
     }
+
+    public static class ImageRenderingBuilder extends SingleIdent {
+        // left | right | center | justify | inherit
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] {
+                        IdentValue.AUTO, IdentValue.PIXELATED,
+                        IdentValue.CRISP_EDGES });
+
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -1140,6 +1140,13 @@ public class CalculatedStyle {
         return isIdent(CSSName.MAX_HEIGHT, IdentValue.NONE);
     }
 
+    public boolean isImageRenderingPixelated() {
+        return isIdent(CSSName.IMAGE_RENDERING, IdentValue.PIXELATED) || isIdent(CSSName.IMAGE_RENDERING, IdentValue.CRISP_EDGES);
+    }
+    public boolean isImageRenderingInterpolate(){
+        return !isImageRenderingPixelated();
+    }
+
     public int getMinWidth(CssContext c, int cbWidth) {
         return (int) getFloatPropertyProportionalTo(CSSName.MIN_WIDTH, cbWidth, c);
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -78,7 +78,7 @@ public interface OutputDevice {
     
     public void drawBorderLine(Shape bounds, int side, int width, boolean solid);
     
-    public void drawImage(FSImage image, int x, int y);
+    public void drawImage(FSImage image, int x, int y, boolean interpolate);
 
     public void draw(Shape s);
     public void fill(Shape s);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -274,7 +274,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
             if (! hrepeat && ! vrepeat) {
                 Rectangle imageBounds = new Rectangle(xoff, yoff, (int)imageWidth, (int)imageHeight);
                 if (imageBounds.intersects(backgroundBounds)) {
-                    drawImage(backgroundImage, xoff, yoff);
+                    drawImage(backgroundImage, xoff, yoff, style.isImageRenderingInterpolate());
                 }
             } else if (hrepeat && vrepeat) {
                 paintTiles(
@@ -282,7 +282,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
                         adjustTo(backgroundBounds.x, xoff, (int)imageWidth),
                         adjustTo(backgroundBounds.y, yoff, (int)imageHeight),
                         backgroundBounds.x + backgroundBounds.width,
-                        backgroundBounds.y + backgroundBounds.height);
+                        backgroundBounds.y + backgroundBounds.height, style.isImageRenderingInterpolate());
             } else if (hrepeat) {
                 xoff = adjustTo(backgroundBounds.x, xoff, (int)imageWidth);
                 Rectangle imageBounds = new Rectangle(xoff, yoff, (int)imageWidth, (int)imageHeight);
@@ -291,7 +291,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
                             backgroundImage,
                             xoff,
                             yoff,
-                            backgroundBounds.x + backgroundBounds.width);
+                            backgroundBounds.x + backgroundBounds.width, style.isImageRenderingInterpolate());
                 }
             } else if (vrepeat) {
                 yoff = adjustTo(backgroundBounds.y, yoff, (int)imageHeight);
@@ -301,7 +301,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
                             backgroundImage,
                             xoff,
                             yoff,
-                            backgroundBounds.y + backgroundBounds.height);
+                            backgroundBounds.y + backgroundBounds.height, style.isImageRenderingInterpolate());
                 }
             }
 
@@ -326,30 +326,30 @@ public abstract class AbstractOutputDevice implements OutputDevice {
         return result;
     }
 
-    private void paintTiles(FSImage image, int left, int top, int right, int bottom) {
+    private void paintTiles(FSImage image, int left, int top, int right, int bottom, boolean interpolate) {
         int width = image.getWidth();
         int height = image.getHeight();
 
         for (int x = left; x < right; x+= width) {
             for (int y = top; y < bottom; y+= height) {
-                drawImage(image, x, y);
+                drawImage(image, x, y, interpolate);
             }
         }
     }
 
-    private void paintVerticalBand(FSImage image, int left, int top, int bottom) {
+    private void paintVerticalBand(FSImage image, int left, int top, int bottom, boolean interpolate) {
         int height = image.getHeight();
 
         for (int y = top; y < bottom; y+= height) {
-            drawImage(image, left, y);
+            drawImage(image, left, y, interpolate);
         }
     }
 
-    private void paintHorizontalBand(FSImage image, int left, int top, int right) {
+    private void paintHorizontalBand(FSImage image, int left, int top, int right, boolean interpolate) {
         int width = image.getWidth();
 
         for (int x = left; x < right; x+= width) {
-            drawImage(image, x, top);
+            drawImage(image, x, top, interpolate);
         }
     }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/ListItemPainter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/ListItemPainter.java
@@ -68,7 +68,7 @@ public class ListItemPainter {
             c.getOutputDevice().drawImage(img, 
                     x,
                     (int)(getReferenceBaseline(c, box)
-                        - strutMetrics.getAscent() / 2 - img.getHeight() / 2));
+                        - strutMetrics.getAscent() / 2 - img.getHeight() / 2), box.getStyle().isImageRenderingInterpolate());
         }
     }
     

--- a/openhtmltopdf-examples/src/main/resources/freemarker/featuredocumentation.ftl
+++ b/openhtmltopdf-examples/src/main/resources/freemarker/featuredocumentation.ftl
@@ -188,13 +188,13 @@ Example:
 
 [@h2]Pixelated Images[/@h2]
 
-OpenHTMLToPdf supports the standart "image-rendering" CSS property:
+OpenHTMLToPdf supports the standard "image-rendering" CSS property:
 
 [@htmlCodeAndExec]
 This image is interpolated and blured:
 	<img src="../images/go-home.png"
 		 style="width:64px;height:64px;" />
-And this one is not interpolated and crips:
+And this one is not interpolated and crisp:
 	<img src="../images/go-home.png"
 		 style="width:64px;height:64px;image-rendering: pixelated" />
 [/@htmlCodeAndExec]

--- a/openhtmltopdf-examples/src/main/resources/freemarker/featuredocumentation.ftl
+++ b/openhtmltopdf-examples/src/main/resources/freemarker/featuredocumentation.ftl
@@ -186,6 +186,19 @@ Example:
 </div>
 [/@htmlCode]
 
+[@h2]Pixelated Images[/@h2]
+
+OpenHTMLToPdf supports the standart "image-rendering" CSS property:
+
+[@htmlCodeAndExec]
+This image is interpolated and blured:
+	<img src="../images/go-home.png"
+		 style="width:64px;height:64px;" />
+And this one is not interpolated and crips:
+	<img src="../images/go-home.png"
+		 style="width:64px;height:64px;image-rendering: pixelated" />
+[/@htmlCodeAndExec]
+
 [@h2]MathML &amp; LaTeX[/@h2]
 To display math you can use MathML and latex. To do so you need the dependencies:
 

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
@@ -176,8 +176,16 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
     }
     
     @Override
-    public void drawImage(FSImage image, int x, int y) {
+    public void drawImage(FSImage image, int x, int y, boolean interpolate) {
+		Object oldInterpolation = _graphics.getRenderingHint(RenderingHints.KEY_INTERPOLATION);
+		if (interpolate)
+			_graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+		else
+			_graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+					RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+			
         _graphics.drawImage(((AWTFSImage)image).getImage(), x, y, null);
+		_graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, oldInterpolation);
     }
     
     @Override

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImageElement.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImageElement.java
@@ -34,12 +34,14 @@ import java.util.Map;
 
 public class PdfBoxImageElement implements PdfBoxReplacedElement, IPdfBoxElementWithShapedLinks {
     private final FSImage _image;
+    private final boolean interpolate;
 
     private Point _location = new Point(0, 0);
     private final Map<Shape, String> imageMap;
 
-    public PdfBoxImageElement(Element e, FSImage image, SharedContext c) {
+    public PdfBoxImageElement(Element e, FSImage image, SharedContext c, boolean interpolate) {
         _image = image;
+        this.interpolate = interpolate;
         imageMap = ImageMapParser.findAndParseMap(e, c);
     }
 
@@ -82,7 +84,7 @@ public class PdfBoxImageElement implements PdfBoxReplacedElement, IPdfBoxElement
                 box.getAbsY(), c);
         ReplacedElement element = box.getReplacedElement();
         outputDevice.drawImage(((PdfBoxImageElement) element).getImage(),
-                contentBounds.x, contentBounds.y);
+                contentBounds.x, contentBounds.y, interpolate);
     }
 
     public int getBaseline() {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
@@ -98,7 +98,7 @@ public class PdfBoxReplacedElementFactory implements ReplacedElementFactory {
                             fsImage.scale(cssWidth, cssHeight);
                         }
                     }
-                    return new PdfBoxImageElement(e,fsImage,c.getSharedContext());
+                    return new PdfBoxImageElement(e,fsImage,c.getSharedContext(), box.getStyle().isImageRenderingInterpolate());
                 }
             }
         } else if (nodeName.equals("input")) {


### PR DESCRIPTION

Related to #173: Allow image-rendering: pixelated to work in PDF. We must clone the image for now to make this work...

Result:
![image](https://user-images.githubusercontent.com/711674/38455322-c745733a-3a76-11e8-9f4b-29d326e47b9b.png)

We treat pixelated and crisp-edges as equal for now. Only visible in Acrobat Reader and PDFBox Debugger. Not visible in Mac OS Preview. (i.e. its always interpolated their...)