### PR TITLE
Builder State to transfer parameters

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
@@ -24,7 +24,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @internal
 	 */
 	public abstract static class BaseRendererBuilderState {
-		public List<FSDOMMutator> _domMutators = new ArrayList<FSDOMMutator>();
+		public final List<FSDOMMutator> _domMutators = new ArrayList<FSDOMMutator>();
 		public HttpStreamFactory _httpStreamFactory;
 		public FSCache _cache;
 		public FSUriResolver _resolver;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
@@ -18,7 +18,12 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	public static final float PAGE_SIZE_LETTER_WIDTH = 8.5f;
 	public static final float PAGE_SIZE_LETTER_HEIGHT = 11.0f;
 	public static final PageSizeUnits PAGE_SIZE_LETTER_UNITS = PageSizeUnits.INCHES;
-	protected final List<FSDOMMutator> _domMutators = new ArrayList<FSDOMMutator>();
+	/**
+	 * Has this Builder been used to build a Renderer and should not be changed anymore?
+	 */
+	boolean sealed = false;
+	
+	protected List<FSDOMMutator> _domMutators = new ArrayList<FSDOMMutator>();
 	protected HttpStreamFactory _httpStreamFactory;
 	protected FSCache _cache;
 	protected FSUriResolver _resolver;
@@ -58,6 +63,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public TFinalClass addDOMMutator(FSDOMMutator domMutator) {
+		assertNotSealed();
 		_domMutators.add(domMutator);
 		return (TFinalClass) this;
 	}
@@ -76,6 +82,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass useTransformerFactoryImplementationClass(String transformerFactoryClass) {
+		assertNotSealed();
 		this._preferredTransformerFactoryImplementationClass = transformerFactoryClass;
 		return (TFinalClass) this;
 	}
@@ -92,10 +99,11 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @param documentBuilderFactoryClass
 	 * @return this for method chaining
 	 */
-		public final TFinalClass useDocumentBuilderFactoryImplementationClass(String documentBuilderFactoryClass) {
-				this._preferredDocumentBuilderFactoryImplementationClass = documentBuilderFactoryClass;
-				return (TFinalClass) this;
-		}
+	public final TFinalClass useDocumentBuilderFactoryImplementationClass(String documentBuilderFactoryClass) {
+		assertNotSealed();
+		this._preferredDocumentBuilderFactoryImplementationClass = documentBuilderFactoryClass;
+		return (TFinalClass) this;
+	}
 
 	/**
 	 * The default text direction of the document. LTR by default.
@@ -104,6 +112,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass defaultTextDirection(TextDirection textDirection) {
+		assertNotSealed();
 		this._textDirection = textDirection == TextDirection.RTL;
 		return (TFinalClass) this;
 	}
@@ -116,6 +125,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass testMode(boolean mode) {
+		assertNotSealed();
 		this._testMode = mode;
 		return (TFinalClass) this;
 	}
@@ -125,9 +135,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * external HTTP/HTTPS implementation. Uses URL::openStream by default.
 	 *
 	 * @param factory
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass useHttpStreamImplementation(HttpStreamFactory factory) {
+		assertNotSealed();
 		this._httpStreamFactory = factory;
 		return (TFinalClass) this;
 	}
@@ -136,9 +147,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * Provides a uri resolver to resolve relative uris or private uri schemes.
 	 *
 	 * @param resolver
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass useUriResolver(FSUriResolver resolver) {
+		assertNotSealed();
 		this._resolver = resolver;
 		return (TFinalClass) this;
 	}
@@ -148,9 +160,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * as fonts or logo images.
 	 *
 	 * @param cache
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass useCache(FSCache cache) {
+		assertNotSealed();
 		this._cache = cache;
 		return (TFinalClass) this;
 	}
@@ -160,9 +173,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * default.
 	 *
 	 * @param splitter
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass useUnicodeBidiSplitter(BidiSplitterFactory splitter) {
+		assertNotSealed();
 		this._splitter = splitter;
 		return (TFinalClass) this;
 	}
@@ -171,9 +185,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * Provides a reorderer to properly reverse RTL text. No-op by default.
 	 *
 	 * @param reorderer
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass useUnicodeBidiReorderer(BidiReorderer reorderer) {
+		assertNotSealed();
 		this._reorderer = reorderer;
 		return (TFinalClass) this;
 	}
@@ -183,9 +198,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 *
 	 * @param html
 	 * @param baseUri
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass withHtmlContent(String html, String baseUri) {
+		assertNotSealed();
 		this._html = html;
 		this._baseUri = baseUri;
 		return (TFinalClass) this;
@@ -196,9 +212,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 *
 	 * @param doc
 	 * @param baseUri
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass withW3cDocument(org.w3c.dom.Document doc, String baseUri) {
+		assertNotSealed();
 		this._document = doc;
 		this._baseUri = baseUri;
 		return (TFinalClass) this;
@@ -209,9 +226,10 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * document.
 	 *
 	 * @param uri
-	 * @return
+	 * @return this for method chaining
 	 */
 	public final TFinalClass withUri(String uri) {
+		assertNotSealed();
 		this._uri = uri;
 		return (TFinalClass) this;
 	}
@@ -224,6 +242,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass withFile(File file) {
+		assertNotSealed();
 		this._file = file;
 		return (TFinalClass) this;
 	}
@@ -235,6 +254,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass useSVGDrawer(SVGDrawer svgImpl) {
+		assertNotSealed();
 		this._svgImpl = svgImpl;
 		return (TFinalClass) this;
 	}
@@ -246,6 +266,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass useMathMLDrawer(SVGDrawer mathMlImpl) {
+		assertNotSealed();
 		this._mathmlImpl = mathMlImpl;
 		return (TFinalClass) this;
 	}
@@ -260,6 +281,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass useReplacementText(String replacement) {
+		assertNotSealed();
 		this._replacementText = replacement;
 		return (TFinalClass) this;
 	}
@@ -278,6 +300,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return
 	 */
 	public final TFinalClass useUnicodeLineBreaker(FSTextBreaker breaker) {
+		assertNotSealed();
 		this._lineBreaker = breaker;
 		return (TFinalClass)this;
 	}
@@ -291,6 +314,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return
 	 */
 	public final TFinalClass useUnicodeCharacterBreaker(FSTextBreaker breaker) {
+		assertNotSealed();
 		this._charBreaker = breaker;
 		return (TFinalClass)this;
 	}
@@ -303,6 +327,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return
 	 */
 	public final TFinalClass useUnicodeToUpperTransformer(FSTextTransformer tr) {
+		assertNotSealed();
 		this._unicodeToUpperTransformer = tr;
 		return (TFinalClass)this;
 	}
@@ -315,6 +340,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return
 	 */
 	public final TFinalClass useUnicodeToLowerTransformer(FSTextTransformer tr) {
+		assertNotSealed();
 		this._unicodeToLowerTransformer = tr;
 		return (TFinalClass)this;
 	}
@@ -327,6 +353,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return
 	 */
 	public final TFinalClass useUnicodeToTitleTransformer(FSTextTransformer tr) {
+		assertNotSealed();
 		this._unicodeToTitleTransformer = tr;
 		return (TFinalClass)this;
 	}
@@ -343,6 +370,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return
 	 */
 	public final TFinalClass useDefaultPageSize(float pageWidth, float pageHeight, PageSizeUnits units) {
+		assertNotSealed();
 		this._pageWidth = pageWidth;
 		this._pageHeight = pageHeight;
 		this._isPageSizeInches = (units == PageSizeUnits.INCHES);
@@ -357,17 +385,51 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 	 * @return this for method chaining
 	 */
 	public final TFinalClass useObjectDrawerFactory(FSObjectDrawerFactory objectDrawerFactory) {
+		assertNotSealed();
 		this._objectDrawerFactory = objectDrawerFactory;
 		return (TFinalClass)this;
 	}
 
 	public enum TextDirection {
-		RTL, LTR;
+		RTL, LTR
 	}
+
 	public enum PageSizeUnits {
 		MM, INCHES
 	}
 	public enum FontStyle {
 		NORMAL, ITALIC, OBLIQUE
+	}
+	
+	/**
+	 * Call this when you using this builder to construct a renderer. After that the
+	 * builder should not be modified any more.
+	 */
+	protected final void seal() {
+		this.sealed = true;
+	}
+
+	/**
+	 * Check that this instance is not sealed
+	 */
+	protected final void assertNotSealed() {
+		if (sealed)
+			throw new IllegalStateException("You can not modify the builder after using it to build a renderer. Use clone() if you need a copy.");
+	}
+
+	/**
+	 * Clone this builder. The cloned builder is unsealed and can be modified.
+	 * @return a unsealed clone of this builder
+	 */
+	protected TFinalClass clone(){
+		try {
+			TFinalClass clone = (TFinalClass) super.clone();
+			clone._domMutators = new ArrayList(_domMutators);
+			clone.sealed = false;
+			return clone;
+		} catch (CloneNotSupportedException e) {
+			/* Should not be possible to happen */
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -39,6 +39,7 @@ import com.openhtmltopdf.util.XRLogger;
 
 public class TestcaseRunner {
 
+
 	/**
 	 * Runs our set of manual test cases. You can specify an output directory with
 	 * -DOUT_DIRECTORY=./output for example. Otherwise, the current working
@@ -215,6 +216,8 @@ public class TestcaseRunner {
 		FileOutputStream output = new FileOutputStream(filename);
 		ImageIO.write(image, "PNG", output);
 		output.close();
+
+		builder = builder.clone();
 
 		/*
 		 * Render Multipage Image Files

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -217,8 +217,6 @@ public class TestcaseRunner {
 		ImageIO.write(image, "PNG", output);
 		output.close();
 
-		builder = builder.clone();
-
 		/*
 		 * Render Multipage Image Files
 		 */

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/TestcaseRunnerTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/TestcaseRunnerTest.java
@@ -1,0 +1,16 @@
+package com.openhtmltopdf.testcases;
+
+import org.junit.Test;
+
+import java.io.File;
+
+public class TestcaseRunnerTest {
+
+	@Test
+	public void runTestcaseRunner() throws Exception {
+		File targetDirectory = new File("target/test/testcaseRunnerResult");
+		targetDirectory.mkdirs();
+		System.setProperty("OUT_DIRECTORY", targetDirectory.getAbsolutePath());
+		TestcaseRunner.main(new String[] {});
+	}
+}

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
@@ -185,7 +185,8 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 					RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
 			
         _graphics.drawImage(((AWTFSImage)image).getImage(), x, y, null);
-		_graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, oldInterpolation);
+		if (oldInterpolation != null)
+			_graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, oldInterpolation);
     }
     
     @Override

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
@@ -5,6 +5,7 @@ import java.awt.geom.Rectangle2D;
 import java.io.*;
 import java.util.List;
 
+import com.openhtmltopdf.java2d.api.Java2DRendererBuilderState;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -62,56 +63,38 @@ public class Java2DRenderer implements Closeable {
 
     /**
 	 * Subject to change. Not public API. Used exclusively by the Java2DRendererBuilder class. 
-	 * @param _svgImpl
-	 * @param preferredTransformerFactoryImplementationClass
-	 * @param _domMutators
 	 */
-	public Java2DRenderer(
-			BaseDocument doc,
-			UnicodeImplementation unicode,
-			HttpStreamFactory httpStreamFactory,
-			FSUriResolver resolver,
-			FSCache cache,
-			SVGDrawer _svgImpl, SVGDrawer _mathMLImpl,
-			PageDimensions pageSize,
-			String replacementText,
-			boolean testMode,
-			FSPageProcessor pageProcessor,
-			Graphics2D layoutGraphics,
-			int initialPageNumber, short pagingMode,
-			FSObjectDrawerFactory objectDrawerFactory,
-			String preferredTransformerFactoryImplementationClass,
-			String preferredDocumentBuilderFactoryImplementationClass,
-			List<FSDOMMutator> _domMutators) {
+	public Java2DRenderer(BaseDocument doc, UnicodeImplementation unicode, PageDimensions pageSize,
+			Java2DRendererBuilderState state) {
 
-	    _pagingMode = pagingMode;
-		_pageProcessor = pageProcessor;
-		_initialPageNo = initialPageNumber;		
-		this._svgImpl = _svgImpl;
-        this._mathMLImpl = _mathMLImpl;
-        this._domMutators = _domMutators;
-        _objectDrawerFactory = objectDrawerFactory;
-		_outputDevice = new Java2DOutputDevice(layoutGraphics);
+	    _pagingMode = state._pagingMode;
+		_pageProcessor = state._pageProcessor;
+		_initialPageNo = state._initialPageNumber;		
+		this._svgImpl = state._svgImpl;
+        this._mathMLImpl = state._mathmlImpl;
+        this._domMutators = state._domMutators;
+        _objectDrawerFactory = state._objectDrawerFactory;
+		_outputDevice = new Java2DOutputDevice(state._layoutGraphics);
 		
 		NaiveUserAgent uac = new NaiveUserAgent();
 		
-		if (httpStreamFactory != null) {
-			uac.setHttpStreamFactory(httpStreamFactory);
+		if (state._httpStreamFactory != null) {
+			uac.setHttpStreamFactory(state._httpStreamFactory);
 		}
 		
-		if (resolver != null) {
-			uac.setUriResolver(resolver);
+		if (state._resolver != null) {
+			uac.setUriResolver(state._resolver);
 		}
 		
-		if (cache != null) {
-			uac.setExternalCache(cache);
+		if (state._cache != null) {
+			uac.setExternalCache(state._cache);
 		}
 		
         _sharedContext = new SharedContext();
         _sharedContext.registerWithThread();
         
-        _sharedContext._preferredTransformerFactoryImplementationClass = preferredTransformerFactoryImplementationClass;
-        _sharedContext._preferredDocumentBuilderFactoryImplementationClass = preferredDocumentBuilderFactoryImplementationClass;
+        _sharedContext._preferredTransformerFactoryImplementationClass = state._preferredTransformerFactoryImplementationClass;
+        _sharedContext._preferredDocumentBuilderFactoryImplementationClass = state._preferredDocumentBuilderFactoryImplementationClass;
         
         _sharedContext.setUserAgentCallback(uac);
         _sharedContext.setCss(new StyleReference(uac));
@@ -132,8 +115,8 @@ public class Java2DRenderer implements Closeable {
         _sharedContext.setInteractive(false);
         _sharedContext.setDefaultPageSize(pageSize.w, pageSize.h, pageSize.isSizeInches);
 
-        if (replacementText != null) {
-            _sharedContext.setReplacementText(replacementText);
+        if (state._replacementText != null) {
+            _sharedContext.setReplacementText(state._replacementText);
         }
         
         if (unicode.splitterFactory != null) {

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
@@ -17,7 +17,6 @@ import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.java2d.api.FSPage;
 import com.openhtmltopdf.java2d.api.FSPageProcessor;
-import com.openhtmltopdf.java2d.api.IJava2DRenderer;
 import com.openhtmltopdf.layout.BoxBuilder;
 import com.openhtmltopdf.layout.Layer;
 import com.openhtmltopdf.layout.LayoutContext;
@@ -37,7 +36,7 @@ import com.openhtmltopdf.util.Configuration;
 import com.openhtmltopdf.util.ThreadCtx;
 import com.openhtmltopdf.util.XRLog;
 
-public class Java2DRenderer implements IJava2DRenderer, Closeable {
+public class Java2DRenderer implements Closeable {
     private final List<FSDOMMutator> _domMutators;
     private final SVGDrawer _mathMLImpl;
 	private BlockBox _root;

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/IJava2DRenderer.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/IJava2DRenderer.java
@@ -1,5 +1,0 @@
-package com.openhtmltopdf.java2d.api;
-
-public interface IJava2DRenderer {
-
-}

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -21,10 +21,10 @@ import com.openhtmltopdf.swing.EmptyReplacedElement;
  * Build a Java2D renderer for a given HTML. The renderer allows to get a
  * BufferedImage of the HTML and to render it in components (using Graphics2D).
  */
-public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBuilder> implements Cloneable{
-	protected Graphics2D _layoutGraphics;
-	protected FSPageProcessor _pageProcessor;
-	private List<AddedFont> _fonts = new ArrayList<AddedFont>();
+public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBuilder, Java2DRendererBuilderState> {
+	public Java2DRendererBuilder() {
+		super(new Java2DRendererBuilderState());
+	}
 
 	/**
 	 * Compulsory method. The layout graphics are used to measure text and should be
@@ -35,8 +35,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder useLayoutGraphics(Graphics2D g2d) {
-		assertNotSealed();
-		this._layoutGraphics = g2d;
+		state._layoutGraphics = g2d;
 		return this;
 	}
 
@@ -56,8 +55,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 */
 	public Java2DRendererBuilder useFont(FSSupplier<InputStream> supplier, String fontFamily, Integer fontWeight,
 			FontStyle fontStyle) {
-		assertNotSealed();
-		this._fonts.add(new AddedFont(supplier, fontWeight, fontFamily, fontStyle));
+		state._fonts.add(new AddedFont(supplier, fontWeight, fontFamily, fontStyle));
 		return this;
 	}
 
@@ -69,7 +67,6 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder useFont(FSSupplier<InputStream> supplier, String fontFamily) {
-		assertNotSealed();
 		return this.useFont(supplier, fontFamily, 400, FontStyle.NORMAL);
 	}
 
@@ -80,8 +77,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder useInitialPageNumber(int pageNumberInitial) {
-		assertNotSealed();
-		this._initialPageNumber = pageNumberInitial;
+		state._initialPageNumber = pageNumberInitial;
 		return this;
 	}
 
@@ -90,9 +86,8 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * pagebreak will be done. The page is only as height as needed.
 	 */
 	public Java2DRendererBuilder toSinglePage(FSPageProcessor pageProcessor) {
-		assertNotSealed();
-		this._pagingMode = Layer.PAGED_MODE_SCREEN;
-		this._pageProcessor = pageProcessor;
+		state._pagingMode = Layer.PAGED_MODE_SCREEN;
+		state._pageProcessor = pageProcessor;
 		return this;
 	}
 
@@ -105,9 +100,8 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder toPageProcessor(FSPageProcessor pageProcessor) {
-		assertNotSealed();
-		this._pagingMode = Layer.PAGED_MODE_PRINT;
-		this._pageProcessor = pageProcessor;
+		state._pagingMode = Layer.PAGED_MODE_PRINT;
+		state._pageProcessor = pageProcessor;
 		return this;
 	}
 
@@ -122,7 +116,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	public void runPaged() throws Exception {
 		Java2DRenderer renderer = this.buildJava2DRenderer();
 		renderer.layout();
-		if (_pagingMode == Layer.PAGED_MODE_PRINT)
+		if (state._pagingMode == Layer.PAGED_MODE_PRINT)
 			renderer.writePages();
 		else
 			renderer.writeSinglePage();
@@ -139,38 +133,37 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	public void runFirstPage() throws Exception {
 		Java2DRenderer renderer = this.buildJava2DRenderer();
 		renderer.layout();
-		if (_pagingMode == Layer.PAGED_MODE_PRINT)
+		if (state._pagingMode == Layer.PAGED_MODE_PRINT)
 			renderer.writePage(0);
 		else
 			renderer.writeSinglePage();
 	}
 
 	public Java2DRenderer buildJava2DRenderer() {
-		seal();
 
-		UnicodeImplementation unicode = new UnicodeImplementation(_reorderer, _splitter, _lineBreaker,
-				_unicodeToLowerTransformer, _unicodeToUpperTransformer, _unicodeToTitleTransformer, _textDirection,
-				_charBreaker);
+		UnicodeImplementation unicode = new UnicodeImplementation(state._reorderer, state._splitter, state._lineBreaker,
+				state._unicodeToLowerTransformer, state._unicodeToUpperTransformer, state._unicodeToTitleTransformer, state._textDirection,
+				state._charBreaker);
 
-		PageDimensions pageSize = new PageDimensions(_pageWidth, _pageHeight, _isPageSizeInches);
+		PageDimensions pageSize = new PageDimensions(state._pageWidth, state._pageHeight, state._isPageSizeInches);
 
-		BaseDocument doc = new BaseDocument(_baseUri, _html, _document, _file, _uri);
+		BaseDocument doc = new BaseDocument(state._baseUri, state._html, state._document, state._file, state._uri);
 
 		/*
 		 * If no layout graphics is provied, just use a sane default
 		 */
-		if (_layoutGraphics == null) {
+		if (state._layoutGraphics == null) {
 			BufferedImage bf = new BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR);
-			_layoutGraphics = bf.createGraphics();
+			state._layoutGraphics = bf.createGraphics();
 		}
 
-		return new Java2DRenderer(doc, unicode, _httpStreamFactory, _resolver, _cache, _svgImpl, _mathmlImpl, pageSize,
-				_replacementText, _testMode, _pageProcessor, _layoutGraphics, _initialPageNumber, _pagingMode,
-				_objectDrawerFactory, _preferredTransformerFactoryImplementationClass,
-				_preferredDocumentBuilderFactoryImplementationClass,_domMutators);
+		return new Java2DRenderer(doc, unicode, state._httpStreamFactory, state._resolver, state._cache, state._svgImpl, state._mathmlImpl, pageSize,
+				state._replacementText, state._testMode, state._pageProcessor, state._layoutGraphics, state._initialPageNumber, state._pagingMode,
+				state._objectDrawerFactory, state._preferredTransformerFactoryImplementationClass,
+				state._preferredDocumentBuilderFactoryImplementationClass, state._domMutators);
 	}
 
-	private static class AddedFont {
+	static class AddedFont {
 		private final FSSupplier<InputStream> supplier;
 		private final Integer weight;
 		private final String family;
@@ -198,11 +191,5 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 
 		public static double DOTS_PER_INCH = 72.0;
 	}
-
-	@Override
-	public Java2DRendererBuilder clone() {
-		Java2DRendererBuilder clone = super.clone();
-		clone._fonts = new ArrayList<AddedFont>(_fonts);
-		return clone;
-	}
 }
+

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -157,10 +157,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 			state._layoutGraphics = bf.createGraphics();
 		}
 
-		return new Java2DRenderer(doc, unicode, state._httpStreamFactory, state._resolver, state._cache, state._svgImpl, state._mathmlImpl, pageSize,
-				state._replacementText, state._testMode, state._pageProcessor, state._layoutGraphics, state._initialPageNumber, state._pagingMode,
-				state._objectDrawerFactory, state._preferredTransformerFactoryImplementationClass,
-				state._preferredDocumentBuilderFactoryImplementationClass, state._domMutators);
+		return new Java2DRenderer(doc, unicode,  pageSize, state);
 	}
 
 	static class AddedFont {

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -21,7 +21,7 @@ import com.openhtmltopdf.swing.EmptyReplacedElement;
  * Build a Java2D renderer for a given HTML. The renderer allows to get a
  * BufferedImage of the HTML and to render it in components (using Graphics2D).
  */
-public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBuilder> {
+public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBuilder> implements Cloneable{
 	protected Graphics2D _layoutGraphics;
 	protected FSPageProcessor _pageProcessor;
 	private List<AddedFont> _fonts = new ArrayList<AddedFont>();
@@ -35,6 +35,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder useLayoutGraphics(Graphics2D g2d) {
+		assertNotSealed();
 		this._layoutGraphics = g2d;
 		return this;
 	}
@@ -55,6 +56,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 */
 	public Java2DRendererBuilder useFont(FSSupplier<InputStream> supplier, String fontFamily, Integer fontWeight,
 			FontStyle fontStyle) {
+		assertNotSealed();
 		this._fonts.add(new AddedFont(supplier, fontWeight, fontFamily, fontStyle));
 		return this;
 	}
@@ -67,6 +69,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder useFont(FSSupplier<InputStream> supplier, String fontFamily) {
+		assertNotSealed();
 		return this.useFont(supplier, fontFamily, 400, FontStyle.NORMAL);
 	}
 
@@ -77,6 +80,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder useInitialPageNumber(int pageNumberInitial) {
+		assertNotSealed();
 		this._initialPageNumber = pageNumberInitial;
 		return this;
 	}
@@ -86,6 +90,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * pagebreak will be done. The page is only as height as needed.
 	 */
 	public Java2DRendererBuilder toSinglePage(FSPageProcessor pageProcessor) {
+		assertNotSealed();
 		this._pagingMode = Layer.PAGED_MODE_SCREEN;
 		this._pageProcessor = pageProcessor;
 		return this;
@@ -100,6 +105,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @return
 	 */
 	public Java2DRendererBuilder toPageProcessor(FSPageProcessor pageProcessor) {
+		assertNotSealed();
 		this._pagingMode = Layer.PAGED_MODE_PRINT;
 		this._pageProcessor = pageProcessor;
 		return this;
@@ -140,6 +146,8 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	}
 
 	public Java2DRenderer buildJava2DRenderer() {
+		seal();
+
 		UnicodeImplementation unicode = new UnicodeImplementation(_reorderer, _splitter, _lineBreaker,
 				_unicodeToLowerTransformer, _unicodeToUpperTransformer, _unicodeToTitleTransformer, _textDirection,
 				_charBreaker);
@@ -176,6 +184,10 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 		}
 	}
 
+	/**
+	 * This class is internal to this library, please do not use or override it!
+	 * @internal
+	 */
 	public static abstract class Graphics2DPaintingReplacedElement extends EmptyReplacedElement {
 		protected Graphics2DPaintingReplacedElement(int width, int height) {
 			super(width, height);
@@ -185,5 +197,12 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 				double height);
 
 		public static double DOTS_PER_INCH = 72.0;
+	}
+
+	@Override
+	public Java2DRendererBuilder clone() {
+		Java2DRendererBuilder clone = super.clone();
+		clone._fonts = new ArrayList<AddedFont>(_fonts);
+		return clone;
 	}
 }

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
@@ -1,0 +1,19 @@
+package com.openhtmltopdf.java2d.api;
+
+import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is an internal implementation detail. This class is only public
+ * because there are no friend classes in Java. DO NOT USE!
+ * 
+ * @internal
+ */
+public class Java2DRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
+	public Graphics2D _layoutGraphics;
+	public FSPageProcessor _pageProcessor;
+	public List<Java2DRendererBuilder.AddedFont> _fonts = new ArrayList<Java2DRendererBuilder.AddedFont>();
+}

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
@@ -13,6 +13,10 @@ import java.util.List;
  * @internal
  */
 public class Java2DRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
+	/* Internal! */
+	Java2DRendererBuilderState() {
+	}
+
 	public Graphics2D _layoutGraphics;
 	public FSPageProcessor _pageProcessor;
 	public final List<Java2DRendererBuilder.AddedFont> _fonts = new ArrayList<Java2DRendererBuilder.AddedFont>();

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
@@ -15,5 +15,5 @@ import java.util.List;
 public class Java2DRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
 	public Graphics2D _layoutGraphics;
 	public FSPageProcessor _pageProcessor;
-	public List<Java2DRendererBuilder.AddedFont> _fonts = new ArrayList<Java2DRendererBuilder.AddedFont>();
+	public final List<Java2DRendererBuilder.AddedFont> _fonts = new ArrayList<Java2DRendererBuilder.AddedFont>();
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -108,44 +108,39 @@ public class PdfBoxRenderer implements Closeable {
      * This method is constantly changing as options are added to the builder.
      */
     PdfBoxRenderer(BaseDocument doc, UnicodeImplementation unicode,
-                   HttpStreamFactory httpStreamFactory,
-                   OutputStream os, FSUriResolver resolver, FSCache cache, SVGDrawer svgImpl,
-                   PageDimensions pageSize, float pdfVersion, String replacementText, boolean testMode,
-                   FSObjectDrawerFactory objectDrawerFactory, String preferredTransformerFactoryImplementationClass,
-                   String preferredDocumentBuilderFactoryImplementationClass,
-                   String producer, SVGDrawer mathmlImpl, List<FSDOMMutator> domMutators, PDDocument pdocument) {
-        
-        _pdfDoc = pdocument != null ? pdocument : new PDDocument();
-        _pdfDoc.setVersion(pdfVersion);
+            PageDimensions pageSize, PdfRendererBuilderState state) {
 
-        _producer = producer;
+        _pdfDoc = state.pddocument != null ? state.pddocument : new PDDocument();
+        _pdfDoc.setVersion(state._pdfVersion);
 
-        _svgImpl = svgImpl;
-        _mathmlImpl = mathmlImpl;
+        _producer = state._producer;
+
+        _svgImpl = state._svgImpl;
+        _mathmlImpl = state._mathmlImpl;
         _dotsPerPoint = DEFAULT_DOTS_PER_POINT;
-        _testMode = testMode;
-        _outputDevice = new PdfBoxOutputDevice(DEFAULT_DOTS_PER_POINT, testMode);
+        _testMode = state._testMode;
+        _outputDevice = new PdfBoxOutputDevice(DEFAULT_DOTS_PER_POINT, _testMode);
         _outputDevice.setWriter(_pdfDoc);
         
         PdfBoxUserAgent userAgent = new PdfBoxUserAgent(_outputDevice);
 
-        if (httpStreamFactory != null) {
-            userAgent.setHttpStreamFactory(httpStreamFactory);
+        if (state._httpStreamFactory != null) {
+            userAgent.setHttpStreamFactory(state._httpStreamFactory);
         }
         
-        if (resolver != null) {
-            userAgent.setUriResolver(resolver);
+        if (state._resolver != null) {
+            userAgent.setUriResolver(state._resolver);
         }
         
-        if (cache != null) {
-            userAgent.setExternalCache(cache);
+        if (state._cache != null) {
+            userAgent.setExternalCache(state._cache);
         }
         
         _sharedContext = new SharedContext();
         _sharedContext.registerWithThread();
         
-        _sharedContext._preferredTransformerFactoryImplementationClass = preferredTransformerFactoryImplementationClass;
-        _sharedContext._preferredDocumentBuilderFactoryImplementationClass = preferredDocumentBuilderFactoryImplementationClass;
+        _sharedContext._preferredTransformerFactoryImplementationClass = state._preferredTransformerFactoryImplementationClass;
+        _sharedContext._preferredDocumentBuilderFactoryImplementationClass = state._preferredDocumentBuilderFactoryImplementationClass;
         
         _sharedContext.setUserAgentCallback(userAgent);
         _sharedContext.setCss(new StyleReference(userAgent));
@@ -155,7 +150,7 @@ public class PdfBoxRenderer implements Closeable {
         PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc);
         _sharedContext.setFontResolver(fontResolver);
 
-        PdfBoxReplacedElementFactory replacedElementFactory = new PdfBoxReplacedElementFactory(_outputDevice, svgImpl, objectDrawerFactory, mathmlImpl);
+        PdfBoxReplacedElementFactory replacedElementFactory = new PdfBoxReplacedElementFactory(_outputDevice, state._svgImpl, state._objectDrawerFactory, state._mathmlImpl);
         _sharedContext.setReplacedElementFactory(replacedElementFactory);
 
         _sharedContext.setTextRenderer(new PdfBoxTextRenderer());
@@ -166,8 +161,8 @@ public class PdfBoxRenderer implements Closeable {
         
         this.getSharedContext().setDefaultPageSize(pageSize.w, pageSize.h, pageSize.isSizeInches);
         
-        if (replacementText != null) {
-            this.getSharedContext().setReplacementText(replacementText);
+        if (state._replacementText != null) {
+            this.getSharedContext().setReplacementText(state._replacementText);
         }
         
         if (unicode.splitterFactory != null) {
@@ -201,7 +196,7 @@ public class PdfBoxRenderer implements Closeable {
         
         this._defaultTextDirection = unicode.textDirection ? BidiSplitter.RTL : BidiSplitter.LTR;
 
-        this._domMutators = domMutators;
+        this._domMutators = state._domMutators;
 
         if (doc.html != null) {
             this.setDocumentFromStringP(doc.html, doc.baseUri);
@@ -221,7 +216,7 @@ public class PdfBoxRenderer implements Closeable {
             }
         }
         
-        this._os = os;
+        this._os = state._os;
     }
 
     public Document getDocument() {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -12,8 +12,6 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Level;
 
 public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, PdfRendererBuilderState> {
@@ -55,10 +53,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 
 		BaseDocument doc = new BaseDocument(state._baseUri, state._html, state._document, state._file, state._uri);
 
-		PdfBoxRenderer renderer = new PdfBoxRenderer(doc, unicode, state._httpStreamFactory, state._os, state._resolver, state._cache, state._svgImpl,
-				pageSize, state._pdfVersion, state._replacementText, state._testMode, state._objectDrawerFactory,
-				state._preferredTransformerFactoryImplementationClass,  state._preferredDocumentBuilderFactoryImplementationClass,
-				state._producer, state._mathmlImpl, state._domMutators, state.pddocument);
+		PdfBoxRenderer renderer = new PdfBoxRenderer(doc, unicode, pageSize, state);
 
 		/*
 		 * Register all Fonts
@@ -221,11 +216,3 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	}
 }
 
-class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
-
-	public List<PdfRendererBuilder.AddedFont> _fonts = new ArrayList<PdfRendererBuilder.AddedFont>();
-	public OutputStream _os;
-	public float _pdfVersion = 1.7f;
-	public String _producer;
-	public PDDocument pddocument;
-}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.logging.Level;
 
 public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> {
-	private final List<AddedFont> _fonts = new ArrayList<AddedFont>();
+	private List<AddedFont> _fonts = new ArrayList<AddedFont>();
 	private OutputStream _os;
 	private float _pdfVersion = 1.7f;
 	private String _producer;
@@ -48,6 +48,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return
 	 */
 	public PdfBoxRenderer buildPdfRenderer() {
+		seal();
 		UnicodeImplementation unicode = new UnicodeImplementation(_reorderer, _splitter, _lineBreaker,
 				_unicodeToLowerTransformer, _unicodeToUpperTransformer, _unicodeToTitleTransformer, _textDirection,
 				_charBreaker);
@@ -98,6 +99,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return
 	 */
 	public PdfRendererBuilder toStream(OutputStream out) {
+		assertNotSealed();
 		this._os = out;
 		return this;
 	}
@@ -110,6 +112,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return
 	 */
 	public PdfRendererBuilder usePdfVersion(float version) {
+		assertNotSealed();
 		this._pdfVersion = version;
 		return this;
 	}
@@ -123,6 +126,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return this for method chaining
 	 */
 	public PdfRendererBuilder usePDDocument(PDDocument doc) {
+		assertNotSealed();
 	    this.pddocument = doc;
 	    return this;
 	}
@@ -148,6 +152,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 */
 	public PdfRendererBuilder useFont(FSSupplier<InputStream> supplier, String fontFamily, Integer fontWeight,
 			FontStyle fontStyle, boolean subset) {
+		assertNotSealed();
 		this._fonts.add(new AddedFont(supplier, null, fontWeight, fontFamily, subset, fontStyle));
 		return this;
 	}
@@ -172,6 +177,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 */
 	public PdfRendererBuilder useFont(File fontFile, String fontFamily, Integer fontWeight, FontStyle fontStyle,
 			boolean subset) {
+		assertNotSealed();
 		this._fonts.add(new AddedFont(null, fontFile, fontWeight, fontFamily, subset, fontStyle));
 		return this;
 	}
@@ -197,6 +203,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return this for method chaining
 	 */
 	public PdfRendererBuilder withProducer(String producer) {
+		assertNotSealed();
 		this._producer = producer;
 		return this;
 	}
@@ -219,6 +226,14 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 			this.subset = subset;
 			this.style = style;
 		}
+	}
+
+	@Override
+	public PdfRendererBuilder clone() {
+		PdfRendererBuilder clone = super.clone();
+		clone._fonts = new ArrayList<AddedFont>(_fonts);
+		clone.pddocument = null; /* We must reset this */
+		return clone;
 	}
 
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -16,12 +16,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
-public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> {
-	private List<AddedFont> _fonts = new ArrayList<AddedFont>();
-	private OutputStream _os;
-	private float _pdfVersion = 1.7f;
-	private String _producer;
-	private PDDocument pddocument;
+public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, PdfRendererBuilderState> {
+
+	public PdfRendererBuilder() {
+		super(new PdfRendererBuilderState());
+	}
 
 	/**
 	 * Run the XHTML/XML to PDF conversion and output to an output stream set by
@@ -48,25 +47,24 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return
 	 */
 	public PdfBoxRenderer buildPdfRenderer() {
-		seal();
-		UnicodeImplementation unicode = new UnicodeImplementation(_reorderer, _splitter, _lineBreaker,
-				_unicodeToLowerTransformer, _unicodeToUpperTransformer, _unicodeToTitleTransformer, _textDirection,
-				_charBreaker);
+		UnicodeImplementation unicode = new UnicodeImplementation(state._reorderer, state._splitter, state._lineBreaker,
+				state._unicodeToLowerTransformer, state._unicodeToUpperTransformer, state._unicodeToTitleTransformer, state._textDirection,
+				state._charBreaker);
 
-		PageDimensions pageSize = new PageDimensions(_pageWidth, _pageHeight, _isPageSizeInches);
+		PageDimensions pageSize = new PageDimensions(state._pageWidth, state._pageHeight, state._isPageSizeInches);
 
-		BaseDocument doc = new BaseDocument(_baseUri, _html, _document, _file, _uri);
+		BaseDocument doc = new BaseDocument(state._baseUri, state._html, state._document, state._file, state._uri);
 
-		PdfBoxRenderer renderer = new PdfBoxRenderer(doc, unicode, _httpStreamFactory, _os, _resolver, _cache, _svgImpl,
-				pageSize, _pdfVersion, _replacementText, _testMode, _objectDrawerFactory,
-				_preferredTransformerFactoryImplementationClass,  _preferredDocumentBuilderFactoryImplementationClass,
-				_producer, _mathmlImpl, _domMutators, pddocument);
+		PdfBoxRenderer renderer = new PdfBoxRenderer(doc, unicode, state._httpStreamFactory, state._os, state._resolver, state._cache, state._svgImpl,
+				pageSize, state._pdfVersion, state._replacementText, state._testMode, state._objectDrawerFactory,
+				state._preferredTransformerFactoryImplementationClass,  state._preferredDocumentBuilderFactoryImplementationClass,
+				state._producer, state._mathmlImpl, state._domMutators, state.pddocument);
 
 		/*
 		 * Register all Fonts
 		 */
 		PdfBoxFontResolver resolver = renderer.getFontResolver();
-		for (AddedFont font : _fonts) {
+		for (AddedFont font : state._fonts) {
 			IdentValue fontStyle = null;
 
 			if (font.style == FontStyle.NORMAL) {
@@ -99,8 +97,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return
 	 */
 	public PdfRendererBuilder toStream(OutputStream out) {
-		assertNotSealed();
-		this._os = out;
+		state._os = out;
 		return this;
 	}
 
@@ -112,8 +109,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return
 	 */
 	public PdfRendererBuilder usePdfVersion(float version) {
-		assertNotSealed();
-		this._pdfVersion = version;
+		state._pdfVersion = version;
 		return this;
 	}
 	
@@ -126,8 +122,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return this for method chaining
 	 */
 	public PdfRendererBuilder usePDDocument(PDDocument doc) {
-		assertNotSealed();
-	    this.pddocument = doc;
+	    state.pddocument = doc;
 	    return this;
 	}
 
@@ -152,8 +147,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 */
 	public PdfRendererBuilder useFont(FSSupplier<InputStream> supplier, String fontFamily, Integer fontWeight,
 			FontStyle fontStyle, boolean subset) {
-		assertNotSealed();
-		this._fonts.add(new AddedFont(supplier, null, fontWeight, fontFamily, subset, fontStyle));
+		state._fonts.add(new AddedFont(supplier, null, fontWeight, fontFamily, subset, fontStyle));
 		return this;
 	}
 
@@ -177,8 +171,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 */
 	public PdfRendererBuilder useFont(File fontFile, String fontFamily, Integer fontWeight, FontStyle fontStyle,
 			boolean subset) {
-		assertNotSealed();
-		this._fonts.add(new AddedFont(null, fontFile, fontWeight, fontFamily, subset, fontStyle));
+		state._fonts.add(new AddedFont(null, fontFile, fontWeight, fontFamily, subset, fontStyle));
 		return this;
 	}
 
@@ -203,13 +196,12 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 	 * @return this for method chaining
 	 */
 	public PdfRendererBuilder withProducer(String producer) {
-		assertNotSealed();
-		this._producer = producer;
+		state._producer = producer;
 		return this;
 	}
 
 
-	private static class AddedFont {
+	static class AddedFont {
 		private final FSSupplier<InputStream> supplier;
 		private final File fontFile;
 		private final Integer weight;
@@ -227,13 +219,13 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder> 
 			this.style = style;
 		}
 	}
+}
 
-	@Override
-	public PdfRendererBuilder clone() {
-		PdfRendererBuilder clone = super.clone();
-		clone._fonts = new ArrayList<AddedFont>(_fonts);
-		clone.pddocument = null; /* We must reset this */
-		return clone;
-	}
+class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
 
+	public List<PdfRendererBuilder.AddedFont> _fonts = new ArrayList<PdfRendererBuilder.AddedFont>();
+	public OutputStream _os;
+	public float _pdfVersion = 1.7f;
+	public String _producer;
+	public PDDocument pddocument;
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
@@ -9,9 +9,14 @@ import java.util.List;
 
 /**
  * This class is internal. DO NOT USE! Just ignore it!
+ * 
  * @internal
  */
 public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
+	/* Internal! */
+	PdfRendererBuilderState() {
+	}
+
 	public final List<PdfRendererBuilder.AddedFont> _fonts = new ArrayList<PdfRendererBuilder.AddedFont>();
 	public OutputStream _os;
 	public float _pdfVersion = 1.7f;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
@@ -1,0 +1,20 @@
+package com.openhtmltopdf.pdfboxout;
+
+import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is internal. DO NOT USE! Just ignore it!
+ * @internal
+ */
+public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
+	public final List<PdfRendererBuilder.AddedFont> _fonts = new ArrayList<PdfRendererBuilder.AddedFont>();
+	public OutputStream _os;
+	public float _pdfVersion = 1.7f;
+	public String _producer;
+	public PDDocument pddocument;
+}


### PR DESCRIPTION
The item, that the *Renderers take way to much arguments in #196 is valid. To solve this I extracted the builder state in its own class, which is then passed to the renderer.

This allows to get more state / parameters into the builder without extending the constructors all the time. That those state classes are public is a pity, but we don't have C++ friend classes at hand here...

This also adds the TestcaseRunner to the regression tests, just as a "smoke" test.