### PR TITLE
Fix font filehandle leak

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
@@ -34,7 +34,6 @@ import com.openhtmltopdf.util.XRLog;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import java.awt.*;
 import java.text.BreakIterator;
@@ -165,10 +164,6 @@ public class SharedContext {
      */
     public FontResolver getFontResolver() {
         return fontResolver;
-    }
-
-    public void flushFonts() {
-        fontResolver.flushCache();
     }
 
     /**

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -70,15 +70,17 @@ public class PdfBoxFontResolver implements FontResolver {
      */
 	public void close() {
 		for (FontDescription fontDescription : _fontCache.values()) {
-			// If the font is not yet subset, we must subset it, otherwise we may leak a file handle
-            // because the PDType0Font may still have the font file open.
+			/*
+			 * If the font is not yet subset, we must subset it, otherwise we may leak a
+			 * file handle because the PDType0Font may still have the font file open.
+			 */
 			if (fontDescription._font != null && fontDescription._font.willBeSubset()) {
-                try {
-                    fontDescription._font.subset();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
+				try {
+					fontDescription._font.subset();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
 		}
 		_fontCache.clear();
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -65,9 +65,10 @@ public class PdfBoxFontResolver implements FontResolver {
         return resolveFont(renderingContext, spec.families, spec.size, spec.fontWeight, spec.fontStyle, spec.variant);
     }
 
-    /**
-     * Free all font resources (i.e. open files), the document should already be closed.
-     */
+	/**
+	 * Free all font resources (i.e. open files), the document should already be
+	 * closed.
+	 */
 	public void close() {
 		for (FontDescription fontDescription : _fontCache.values()) {
 			/*
@@ -92,6 +93,7 @@ public class PdfBoxFontResolver implements FontResolver {
 				e.printStackTrace();
 			}
 		}
+		_collectionsToClose.clear();
 	}
 
     @Deprecated

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -834,7 +834,10 @@ public class PdfBoxRenderer implements Closeable {
         _outputDevice.close();
         _sharedContext.removeFromThread();
         ThreadCtx.cleanup();
-        
+
+        // Close all still open font files
+        ((PdfBoxFontResolver)getSharedContext().getFontResolver()).close();
+
         if (_svgImpl != null) {
             try {
                 _svgImpl.close();


### PR DESCRIPTION
We've got a file handle leak in production which caused our Tomcat to stop working after some days, and were able to track this down to fonts files which were not closed. After the user generated enough reports the 2048 file descriptors were exhausted and everything stopped working ..

If a font file was registered but not used in the PDF, those font files would leak their file handles. 