### PR TITLE
#80 Fix and sample multihtmldoc pdf

### DIFF
--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -192,7 +192,7 @@ public class TestcaseRunner {
 		}
 	}
 
-	private static DefaultObjectDrawerFactory buildObjectDrawerFactory() {
+	static DefaultObjectDrawerFactory buildObjectDrawerFactory() {
 		DefaultObjectDrawerFactory objectDrawerFactory = new StandardObjectDrawerFactory();
 		objectDrawerFactory.registerDrawer("custom/binary-tree", new SampleObjectDrawerBinaryTree());
 		return objectDrawerFactory;

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -103,6 +103,8 @@ public class TestcaseRunner {
 		 */
 		runTestCase("transform");
 
+		runTestCase("simplerotate");
+
 		runTestCase("quoting");
 
 		runTestCase("math-ml");

--- a/openhtmltopdf-examples/src/main/resources/testcases/FSPageBreakMinHeightSample.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/FSPageBreakMinHeightSample.html
@@ -1,5 +1,13 @@
 <html xmlns="http://www.w3.org/1999/html">
 <head>
+	<bookmarks>
+		<bookmark href="#werkstattAnschrift" name="In document Bookmark 1"/>
+		<bookmark href="#table_to_bookmark" name="table_to_bookmark"/>
+		<bookmark name="OpenHTMLToPDF">
+			<bookmark href="https://github.com/danfickle/openhtmltopdf" name="Github Homepage"/>
+			<bookmark href="https://github.com/danfickle/openhtmltopdf/issues/80" name="An random issue"/>
+		</bookmark>
+	</bookmarks>
 <!--suppress CssUnknownProperty -->
 <style>
 
@@ -280,7 +288,7 @@ Lines<br/>
 <br/>
 
 
-<table class="framed_table framed_cells" cellspacing="0" cellpadding="0">
+<table class="framed_table framed_cells" cellspacing="0" cellpadding="0" id="table_to_bookmark">
 	<tr class="table_repeat_header">
 		<td colspan="9">XYZABCDEFGZX</td>
 	</tr>

--- a/openhtmltopdf-examples/src/main/resources/testcases/simplerotate.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/simplerotate.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+	<style>@page {size: 520px 820px;margin: 0px;padding: 0px;}body {margin: 0;}</style>
+</head>
+<body>
+<div style="left:0px;top:0px;width:50px;transform: rotate(50deg);">
+	asdasdasd
+</div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/testcases/svg-sizes.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/svg-sizes.html
@@ -1,15 +1,28 @@
     <html>
+    <head>
+        <bookmarks>
+            <bookmark name="Text" href="#text"></bookmark>
+			<bookmark name="SVG" href="#svg">
+                <bookmark name="Width 25%" href="#w25"/>
+				<bookmark name="Width 10%" href="#w10"/>
+				<bookmark name="Width 8cm" href="#w8"/>
+				<bookmark name="Width 4cm" href="#w4"/>
+				<bookmark name="Height 50%" href="#h50"/>
+				<bookmark name="Height 4cm" href="#h4"/>
+            </bookmark>
+        </bookmarks>
+    </head>
     <body>
    
-    <h2>Text</h2>
+    <h2 id="text">Text</h2>
     <div style="width: 25%; border: 1px solid black;">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Donec venenatis velit enim, a placerat lectus viverra non.
             Proin varius porta ligula, in fringilla erat suscipit a.</p>
     </div>
-    <h2>SVG</h2>
+    <h2 id="SVG">SVG</h2>
     
-    <h3>width: percentage, max-width: none, calc-width: 25%</h3>
+    <h3 id="w25">width: percentage, max-width: none, calc-width: 25%</h3>
     
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 20"
         style="width: 25%; border: black 1px solid;">
@@ -17,7 +30,7 @@
             stroke="blue" fill="yellow" stroke-width="2" />
     </svg>
     
-    <h3>width: percentage, max-width: absolute, calc-width: 8cm</h3>
+    <h3 id="w8">width: percentage, max-width: absolute, calc-width: 8cm</h3>
     
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 20"
         style="width: 80%; max-width: 8cm; border: black 1px solid;">
@@ -25,7 +38,7 @@
             stroke="blue" fill="yellow" stroke-width="2" />
     </svg>
 
-    <h3>width: absolute, max-width: percentage, calc-width: 10%</h3>
+    <h3 id="#w10">width: absolute, max-width: percentage, calc-width: 10%</h3>
     
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 20"
         style="width: 500px; max-width: 10%; border: black 1px solid;">
@@ -34,7 +47,7 @@
     </svg>
 
 
-    <h3>height: absolute, max-height: none, calc-height: 4cm</h3>
+    <h3 id="w4">height: absolute, max-height: none, calc-height: 4cm</h3>
     
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 20" width="300" height="200"
         style="height: 4cm; border: black 1px solid;">
@@ -42,7 +55,7 @@
             stroke="blue" fill="yellow" stroke-width="2" />
     </svg>
 
-    <h3>height: absolute, max-height: percentage, calc-height: 2.5cm (50% of containing block)</h3>
+    <h3 id="h50">height: absolute, max-height: percentage, calc-height: 2.5cm (50% of containing block)</h3>
     
     <div style="height: 5cm; border: 1px solid red;">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 20" width="300" height="200"
@@ -52,7 +65,7 @@
     </svg>
     </div>
 
-    <h3>height: absolute, max-height: absolute, calc-height: 4cm</h3>
+    <h3 id="h4">height: absolute, max-height: absolute, calc-height: 4cm</h3>
     
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 20" width="300" height="200"
         style="height: 45cm; max-height: 4cm; border: black 1px solid;">

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/ConcateOutputTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/ConcateOutputTest.java
@@ -1,0 +1,59 @@
+package com.openhtmltopdf.testcases;
+
+import static com.openhtmltopdf.testcases.TestcaseRunner.buildObjectDrawerFactory;
+
+import java.io.File;
+
+import org.apache.pdfbox.io.IOUtils;
+import org.apache.pdfbox.io.MemoryUsageSetting;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.util.Charsets;
+import org.junit.Test;
+
+import com.openhtmltopdf.bidi.support.ICUBidiReorderer;
+import com.openhtmltopdf.bidi.support.ICUBidiSplitter;
+import com.openhtmltopdf.latexsupport.LaTeXDOMMutator;
+import com.openhtmltopdf.mathmlsupport.MathMLDrawer;
+import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
+import com.openhtmltopdf.pdfboxout.PdfBoxRenderer;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.svgsupport.BatikSVGDrawer;
+
+public class ConcateOutputTest {
+
+	@Test
+	public void testConcateOutput() throws Exception {
+		File targetFile = new File("target/test/concatoutput/concated.pdf");
+		targetFile.getParentFile().mkdirs();
+		PDDocument doc = new PDDocument(MemoryUsageSetting.setupMixed(1000000));
+
+		for (String testCaseFile : new String[] { "color", "background-color",
+				"FSPageBreakMinHeightSample", "math-ml", "multi-column-layout", "simplerotate",
+				"svg-inline", "svg-sizes", "transform", "RepeatedTableSample",
+				"RepeatedTableTransformSample" }) {
+			renderPDF(testCaseFile, doc);
+		}
+
+		doc.save(targetFile);
+		doc.close();
+
+	}
+
+	private static void renderPDF(String testCaseFile, PDDocument document) throws Exception {
+		byte[] htmlBytes = IOUtils
+				.toByteArray(TestcaseRunner.class.getResourceAsStream("/testcases/" + testCaseFile + ".html"));
+		String html = new String(htmlBytes, Charsets.UTF_8);
+		PdfRendererBuilder builder = new PdfRendererBuilder();
+		builder.useUnicodeBidiSplitter(new ICUBidiSplitter.ICUBidiSplitterFactory());
+		builder.useUnicodeBidiReorderer(new ICUBidiReorderer());
+		builder.defaultTextDirection(BaseRendererBuilder.TextDirection.LTR);
+		builder.useSVGDrawer(new BatikSVGDrawer());
+		builder.useMathMLDrawer(new MathMLDrawer());
+		builder.addDOMMutator(LaTeXDOMMutator.INSTANCE);
+		builder.useObjectDrawerFactory(buildObjectDrawerFactory());
+		builder.withHtmlContent(html, TestcaseRunner.class.getResource("/testcases/").toString());
+		builder.usePDDocument(document);
+		PdfBoxRenderer pdfBoxRenderer = builder.buildPdfRenderer();
+		pdfBoxRenderer.createPDFWithoutClosing();
+	}
+}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxOutputDevice.java
@@ -1056,8 +1056,11 @@ public class PdfBoxOutputDevice extends AbstractOutputDevice implements OutputDe
         if (_bookmarks.size() > 0) {
             // TODO: .setViewerPreferences(PdfWriter.PageModeUseOutlines);
     
-            PDDocumentOutline outline = new PDDocumentOutline();
-            _writer.getDocumentCatalog().setDocumentOutline( outline );
+            PDDocumentOutline outline = _writer.getDocumentCatalog().getDocumentOutline();
+			if (outline == null) {
+                outline = new PDDocumentOutline();
+                _writer.getDocumentCatalog().setDocumentOutline(outline);
+            }
             
             writeBookmarks(c, root, outline, _bookmarks);
         }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -129,6 +129,7 @@ public class PdfBoxRenderer implements Closeable {
         _useFastMode = state._useFastRenderer;
         _outputDevice = new PdfBoxOutputDevice(DEFAULT_DOTS_PER_POINT, _testMode);
         _outputDevice.setWriter(_pdfDoc);
+        _outputDevice.setStartPageNo(_pdfDoc.getNumberOfPages());
         
         PdfBoxUserAgent userAgent = new PdfBoxUserAgent(_outputDevice);
 


### PR DESCRIPTION
This is a sample testdriver how to use multiple HTML documents for one PDF. I also fixed a bug with bookmarks related to multiple HTML documents in one PDF.

The bookmark-markup is very special and esoteric (i.e. non-standard). But at least it works now again. No idea if we should let it be as it is, or come up with something more standard... Also requiring the bookmarks in the header is rather difficult if you only know the content at the end of the document...

Should PdfBoxRenderer::createPDFWithoutClosing() stay public, or should we try to hide it with the builder? i.e. as a builder option? This would also help the user discovering this feature.