### PR TITLE
Cache PDF font metrics across runs to avoid loading fallback fonts

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSCacheEx.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSCacheEx.java
@@ -1,0 +1,9 @@
+package com.openhtmltopdf.extend;
+
+import java.util.concurrent.Callable;
+
+public interface FSCacheEx<K, V> {
+    public void put(K key, V value);
+    public V get(K key, Callable<? extends V> loader);
+    public V get(K key);
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSCacheValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSCacheValue.java
@@ -1,0 +1,11 @@
+package com.openhtmltopdf.extend;
+
+/**
+ * Note: Classes implementing this interface should be thread safe as we document the cache being useable accross threads.
+ */
+public interface FSCacheValue {
+    /**
+     * @return the (very) approximate weight of a cache value in bytes if known or -1 otherwise.
+     */
+    public int weight();
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/impl/FSDefaultCacheStore.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/impl/FSDefaultCacheStore.java
@@ -1,0 +1,55 @@
+package com.openhtmltopdf.extend.impl;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+import com.openhtmltopdf.extend.FSCacheEx;
+import com.openhtmltopdf.extend.FSCacheValue;
+import com.openhtmltopdf.util.XRLog;
+
+
+/**
+ * A simple default cache implementation, mainly for testing. For production you will probably want to wrap Guava's cache implementation
+ * or something similar. This implementation does not use synchronisation beyond using a <code>ConcurrentHashMap<code> internally.
+ * Specifically, the {@link #get(String, Callable)} may call the loader multiple times if called in close succession.
+ */
+public class FSDefaultCacheStore implements FSCacheEx<String, FSCacheValue> {
+    private final Map<String, FSCacheValue> _store = new ConcurrentHashMap<String, FSCacheValue>();
+    
+    @Override
+    public void put(String key, FSCacheValue value) {
+        XRLog.load(Level.INFO, "Putting key(" + key + ") in cache.");
+        _store.put(key, value);
+    }
+
+    @Override
+    public FSCacheValue get(String key, Callable<? extends FSCacheValue> loader) {
+        if (_store.containsKey(key)) {
+            return this.get(key);
+        }
+    
+        FSCacheValue value;
+        try {
+            value = loader.call();
+
+            if (value != null) {
+                _store.put(key, value);
+            }
+        } catch (Exception e) {
+            XRLog.exception("Could not load cache value for key(" + key + ")", e);
+            value = null;
+        }
+        
+        XRLog.load(Level.INFO, (value == null ? "Missed" : "Hit") + " key(" + key + ") from cache.");
+        return value;
+    }
+
+    @Override
+    public FSCacheValue get(String key) {
+        FSCacheValue value = _store.get(key);
+        XRLog.load(Level.INFO, (value == null ? "Missed" : "Hit") + " key(" + key + ") from cache.");
+        return value;
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/impl/FSNoOpCacheStore.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/impl/FSNoOpCacheStore.java
@@ -1,0 +1,24 @@
+package com.openhtmltopdf.extend.impl;
+
+import java.util.concurrent.Callable;
+
+import com.openhtmltopdf.extend.FSCacheEx;
+import com.openhtmltopdf.extend.FSCacheValue;
+
+public class FSNoOpCacheStore implements FSCacheEx<String, FSCacheValue> {
+    public final static FSNoOpCacheStore INSTANCE = new FSNoOpCacheStore();
+    
+    @Override
+    public void put(String key, FSCacheValue value) {
+    }
+
+    @Override
+    public FSCacheValue get(String key, Callable<? extends FSCacheValue> loader) {
+        return null;
+    }
+
+    @Override
+    public FSCacheValue get(String key) {
+        return null;
+    }
+}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -91,12 +91,15 @@ public class PdfBoxFontResolver implements FontResolver {
 			/*
 			 * If the font is not yet subset, we must subset it, otherwise we may leak a
 			 * file handle because the PDType0Font may still have the font file open.
+			 * 
+			 * FIXME: Remove this as soon as we begin using PDFBOX 2.0.12 as it correctly closes
+			 * all fonts opened with a PDDocument.
 			 */
 			if (fontDescription._font != null && fontDescription._font.willBeSubset()) {
 				try {
 					fontDescription._font.subset();
 				} catch (IOException e) {
-					e.printStackTrace();
+					//e.printStackTrace();
 				}
 			}
 		}
@@ -107,7 +110,7 @@ public class PdfBoxFontResolver implements FontResolver {
 			try {
 				collection.close();
 			} catch (IOException e) {
-				e.printStackTrace();
+				//e.printStackTrace();
 			}
 		}
 		_collectionsToClose.clear();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -707,23 +707,17 @@ public class PdfBoxFontResolver implements FontResolver {
             _metricsCache = metricsCache;
             _metrics = getFontMetricsFromCache(family, weight, style);
         }
+
+        private String createFontMetricsCacheKey(String family, int weight, IdentValue style) {
+            return "font-metrics:" + family + ":" + weight + ":" + style.toString();
+        }
         
         private PdfBoxRawPDFontMetrics getFontMetricsFromCache(String family, int weight, IdentValue style) {
-            if (_metricsCache == null) {
-                return null;
-            }
-            
-            String cacheKey = "font-metrics:" + family + ":" + weight + ":" + style.toString();
-            return (PdfBoxRawPDFontMetrics) _metricsCache.get(cacheKey);
+            return (PdfBoxRawPDFontMetrics) _metricsCache.get(createFontMetricsCacheKey(family, weight, style));
         }
         
         private void putFontMetricsInCache(String family, int weight, IdentValue style, PdfBoxRawPDFontMetrics metrics) {
-            if (_metricsCache == null) {
-                return;
-            }
-            
-            String cacheKey = "font-metrics:" + family + ":" + weight + ":" + style.toString();
-            _metricsCache.put(cacheKey, metrics);
+            _metricsCache.put(createFontMetricsCacheKey(family, weight, style), metrics);
         }
 
         private boolean realizeFont() {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRawPDFontMetrics.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRawPDFontMetrics.java
@@ -1,0 +1,41 @@
+package com.openhtmltopdf.pdfboxout;
+
+import java.io.IOException;
+
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
+
+import com.openhtmltopdf.extend.FSCacheValue;
+
+public class PdfBoxRawPDFontMetrics implements FSCacheValue {
+    public final float _ascent;
+    public final float _descent;
+    public final float _strikethroughOffset;
+    public final float _strikethroughThickness;
+    public final float _underlinePosition;
+    public final float _underlineThickness;
+    
+    public PdfBoxRawPDFontMetrics(float ascent, float descent, float strikethroughOffset, float strikethroughThickness, float underlinePosition, float underlineThickness) {
+        this._ascent = ascent;
+        this._descent = descent;
+        this._strikethroughOffset = strikethroughOffset;
+        this._strikethroughThickness = strikethroughThickness;
+        this._underlinePosition = underlinePosition;
+        this._underlineThickness = underlineThickness;
+    }
+    
+    public static PdfBoxRawPDFontMetrics fromPdfBox(PDFont font, PDFontDescriptor descriptor) throws IOException {
+        return new PdfBoxRawPDFontMetrics(
+            font.getBoundingBox().getUpperRightY(),                 // Ascent
+            -font.getBoundingBox().getLowerLeftY(),                 // Descent
+            -descriptor.getFontBoundingBox().getUpperRightY() / 3f, // Strikethrough offset
+            100f,                                                   // FIXME: Strikethrough thickness
+            -descriptor.getDescent(),                               // Underline position
+            50f);                                                   // FIXME: Underline thickness
+    }
+
+    @Override
+    public int weight() {
+        return 6 * 4; // Six floats.
+    }
+}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -35,6 +35,7 @@ import com.openhtmltopdf.extend.FSDOMMutator;
 import com.openhtmltopdf.outputdevice.helper.PageDimensions;
 import com.openhtmltopdf.outputdevice.helper.UnicodeImplementation;
 import com.openhtmltopdf.pdfboxout.PdfBoxOutputDevice.Metadata;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.CacheStore;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.PageBox;
 import com.openhtmltopdf.render.RenderingContext;
@@ -162,7 +163,7 @@ public class PdfBoxRenderer implements Closeable {
         userAgent.setSharedContext(_sharedContext);
         _outputDevice.setSharedContext(_sharedContext);
 
-        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc);
+        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc, state._caches.get(CacheStore.PDF_FONT_METRICS));
         _sharedContext.setFontResolver(fontResolver);
 
         PdfBoxReplacedElementFactory replacedElementFactory = new PdfBoxReplacedElementFactory(_outputDevice, state._svgImpl, state._objectDrawerFactory, state._mathmlImpl);

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -36,6 +36,7 @@ import com.openhtmltopdf.outputdevice.helper.PageDimensions;
 import com.openhtmltopdf.outputdevice.helper.UnicodeImplementation;
 import com.openhtmltopdf.pdfboxout.PdfBoxOutputDevice.Metadata;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.CacheStore;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.PdfAConformance;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.PageBox;
 import com.openhtmltopdf.render.RenderingContext;
@@ -104,7 +105,7 @@ public class PdfBoxRenderer implements Closeable {
     // Usually 1.7
     private float _pdfVersion;
 
-    private String _pdfAConformance;
+    private PdfAConformance _pdfAConformance;
 
     private byte[] _colorProfile;
 
@@ -637,8 +638,8 @@ public class PdfBoxRenderer implements Closeable {
         firePreWrite(pageCount); // opportunity to adjust meta data
         setDidValues(doc); // set PDF header fields from meta data
 
-        if (_pdfAConformance != null) {
-            addPdfASchema(doc, _pdfAConformance);
+        if (_pdfAConformance != PdfAConformance.NONE) {
+            addPdfASchema(doc, _pdfAConformance.getConformanceValue());
         }
 
         for (int i = 0; i < pageCount; i++) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -178,7 +178,7 @@ public class PdfBoxRenderer implements Closeable {
         userAgent.setSharedContext(_sharedContext);
         _outputDevice.setSharedContext(_sharedContext);
 
-        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc, state._caches.get(CacheStore.PDF_FONT_METRICS));
+        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc, state._caches.get(CacheStore.PDF_FONT_METRICS), state._pdfAConformance);
         _sharedContext.setFontResolver(fontResolver);
 
         PdfBoxReplacedElementFactory replacedElementFactory = new PdfBoxReplacedElementFactory(_outputDevice, state._svgImpl, state._objectDrawerFactory, state._mathmlImpl);

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxTextRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxTextRenderer.java
@@ -48,21 +48,23 @@ public class PdfBoxTextRenderer implements TextRenderer {
         this._reorderer = reorderer;
     }
 
+    @Override
     public void drawString(OutputDevice outputDevice, String string, float x, float y) {
         ((PdfBoxOutputDevice)outputDevice).drawString(string, x, y, null);
     }
     
+    @Override
     public void drawString(
             OutputDevice outputDevice, String string, float x, float y, JustificationInfo info) {
         ((PdfBoxOutputDevice)outputDevice).drawString(string, x, y, info);
     }
 
+    @Override
     public FSFontMetrics getFSFontMetrics(FontContext context, FSFont font, String string) {
         List<FontDescription> descrs = ((PdfBoxFSFont) font).getFontDescription();
         float size = font.getSize2D();
         PdfBoxFSFontMetrics result = new PdfBoxFSFontMetrics();
         
-        try {
             float largestAscent = -Float.MAX_VALUE;
             float largestDescent = -Float.MAX_VALUE;
             float largestStrikethroughOffset = -Float.MAX_VALUE;
@@ -71,12 +73,18 @@ public class PdfBoxTextRenderer implements TextRenderer {
             float largestUnderlineThickness = -Float.MAX_VALUE;
             
             for (FontDescription des : descrs) {
-                float loopAscent = des.getFont().getBoundingBox().getUpperRightY();
-                float loopDescent = -des.getFont().getBoundingBox().getLowerLeftY();
-                float loopStrikethroughOffset = -des.getYStrikeoutPosition();
-                float loopStrikethroughThickness = des.getYStrikeoutSize();
-                float loopUnderlinePosition = -des.getUnderlinePosition();
-                float loopUnderlineThickness = des.getUnderlineThickness();
+                PdfBoxRawPDFontMetrics metrics = des.getFontMetrics();
+
+                if (metrics == null) {
+                    continue;
+                }
+                
+                float loopAscent = metrics._ascent;
+                float loopDescent = metrics._descent;
+                float loopStrikethroughOffset = metrics._strikethroughOffset;
+                float loopStrikethroughThickness = metrics._strikethroughThickness;
+                float loopUnderlinePosition = metrics._underlinePosition;
+                float loopUnderlineThickness = metrics._underlineThickness;
                 
                 if (loopAscent > largestAscent) {
                     largestAscent = loopAscent;
@@ -115,9 +123,6 @@ public class PdfBoxTextRenderer implements TextRenderer {
             
             result.setUnderlineOffset(largestUnderlinePosition / 1000f * size);
             result.setUnderlineThickness(largestUnderlineThickness / 1000f * size);
-        } catch (IOException e) {
-            throw new PdfContentStreamAdapter.PdfException("getFSFontMetrics", e);
-        }
 
         return result;
     }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -122,7 +122,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	 * @return
 	 */
 	public PdfRendererBuilder usePdfAConformance(PdfAConformance pdfAConformance) {
-		this.state._pdfAConformance = pdfAConformance.value;
+		this.state._pdfAConformance = pdfAConformance;
 		return this;
 	}
 
@@ -276,7 +276,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	 * PDF/A-1, PDF/A-2 and PDF/A-3
 	 */
 	public enum PdfAConformance {
-
+                NONE(""),
 		PDF_A_1("A"), PDF_A_2("B"), PDF_A_3("U");
 
 		PdfAConformance(String value) {
@@ -284,6 +284,10 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 		}
 
 		private final String value;
+		
+		public String getConformanceValue() {
+		    return this.value;
+		}
 	}
 }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -194,6 +194,30 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 		state._producer = producer;
 		return this;
 	}
+	
+	/**
+	 * List of caches available.
+	 */
+	public static enum CacheStore {
+	    
+	    /**
+	     * Caches font metrics, based on a combined key of family name, weight and style.
+	     * Using this cache avoids loading fallback fonts if the metrics are already in the cache
+	     * and the previous fonts contain the needed characters.
+	     */
+	    PDF_FONT_METRICS;
+	}
+	
+	/**
+	 * Use a specific cache. Cache values should be thread safe, so provided your cache store itself
+	 * is thread safe can be used accross threads.
+	 * @return this for method chaining.
+	 * @see {@link CacheStore}
+	 */
+	public PdfRendererBuilder useCacheStore(CacheStore which, FSCacheEx<String, FSCacheValue> cache) {
+	    state._caches.put(which, cache);
+	    return this;
+	}
 
 
 	static class AddedFont {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -2,6 +2,7 @@ package com.openhtmltopdf.pdfboxout;
 
 import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.extend.*;
+import com.openhtmltopdf.extend.impl.FSNoOpCacheStore;
 import com.openhtmltopdf.outputdevice.helper.BaseDocument;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
 import com.openhtmltopdf.outputdevice.helper.PageDimensions;
@@ -18,6 +19,12 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 
 	public PdfRendererBuilder() {
 		super(new PdfRendererBuilderState());
+		
+		for (CacheStore cacheStore : CacheStore.values()) {
+		    // Use the flyweight pattern to initialize all caches with a no-op implementation to
+		    // avoid excessive null handling.
+		    state._caches.put(cacheStore, FSNoOpCacheStore.INSTANCE);
+		}
 	}
 
 	/**

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -117,6 +117,10 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 
 	/**
 	 * Set the PDF/A conformance, typically we use PDF/A-1
+	 * 
+	 * Note: PDF/A documents require fonts to be embedded. So if this is not set to NONE,
+	 * the built-in fonts will not be available and currently any text without a
+	 * specified and embedded font will cause the renderer to crash with an exception.
 	 *
 	 * @param pdfAConformance
 	 * @return

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
@@ -4,6 +4,7 @@ import com.openhtmltopdf.extend.FSCacheEx;
 import com.openhtmltopdf.extend.FSCacheValue;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.CacheStore;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.PdfAConformance;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 
@@ -28,7 +29,7 @@ public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBui
 	public float _pdfVersion = 1.7f;
 	public String _producer;
 	public PDDocument pddocument;
-        public Map<CacheStore, FSCacheEx<String, FSCacheValue>> _caches = new EnumMap<CacheStore, FSCacheEx<String, FSCacheValue>>(CacheStore.class);
-	public String _pdfAConformance;
+        public final Map<CacheStore, FSCacheEx<String, FSCacheValue>> _caches = new EnumMap<CacheStore, FSCacheEx<String, FSCacheValue>>(CacheStore.class);
+	public PdfAConformance _pdfAConformance = PdfAConformance.NONE;
 	public byte[] _colorProfile;
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
@@ -1,11 +1,17 @@
 package com.openhtmltopdf.pdfboxout;
 
+import com.openhtmltopdf.extend.FSCacheEx;
+import com.openhtmltopdf.extend.FSCacheValue;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.CacheStore;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class is internal. DO NOT USE! Just ignore it!
@@ -22,4 +28,5 @@ public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBui
 	public float _pdfVersion = 1.7f;
 	public String _producer;
 	public PDDocument pddocument;
+        public Map<CacheStore, FSCacheEx<String, FSCacheValue>> _caches = new EnumMap<CacheStore, FSCacheEx<String, FSCacheValue>>(CacheStore.class);
 }


### PR DESCRIPTION
Also general cleanup of PdfBoxFontResolver

@rototor 

I was wondering how you are using true type collections. The way I read the code is that all fonts in the collection will be added under the one name/style/weight tuple so while they will be added to the document only one of them will be resolved and used in content streams. Have I got this totally wrong?

Also, feel free to suggest improvements to this PR. Thanks.