### PR TITLE
Cherry-pick from PR #143: pdf/a support

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -107,6 +107,30 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 		state._pdfVersion = version;
 		return this;
 	}
+
+	/**
+	 * Set the PDF/A conformance, typically we use PDF/A-1
+	 *
+	 * @param pdfAConformance
+	 * @return
+	 */
+	public PdfRendererBuilder usePdfAConformance(PdfAConformance pdfAConformance) {
+		this.state._pdfAConformance = pdfAConformance.value;
+		return this;
+	}
+
+	/**
+	 * Sets the color profile, needed for PDF/A conformance.
+	 *
+	 * You can use the sRGB.icc from https://svn.apache.org/viewvc/pdfbox/trunk/examples/src/main/resources/org/apache/pdfbox/resources/pdfa/
+	 *
+	 * @param colorProfile
+	 * @return
+	 */
+	public PdfRendererBuilder useColorProfile(byte[] colorProfile) {
+		this.state._colorProfile = colorProfile;
+		return this;
+	}
 	
 	/**
 	 * By default, this project creates an entirely in-memory <code>PDDocument</code>.
@@ -213,6 +237,22 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 			this.subset = subset;
 			this.style = style;
 		}
+	}
+
+	/**
+	 * Various level of PDF/A conformance:
+	 *
+	 * PDF/A-1, PDF/A-2 and PDF/A-3
+	 */
+	public enum PdfAConformance {
+
+		PDF_A_1("A"), PDF_A_2("B"), PDF_A_3("U");
+
+		PdfAConformance(String value) {
+			this.value = value;
+		}
+
+		private final String value;
 	}
 }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
@@ -22,4 +22,6 @@ public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBui
 	public float _pdfVersion = 1.7f;
 	public String _producer;
 	public PDDocument pddocument;
+	public String _pdfAConformance;
+	public byte[] _colorProfile;
 }


### PR DESCRIPTION
Hi @danfickle , I've cherry-picked from the PR done by @backslash47 the pdf/a support.

Additionally, from the PR, I've done some changes:
 - refactored the code: the 2 new parameters are set in the State object
 - switched from string to enum for setting the pdf/a level as requested in the comment of the PR
 - added the "StructTreeRoot" for passing the pdf/a-1 validation.

I've validated the various level of compliance using https://www.pdf-online.com/osa/validate.aspx and they seems to pass. Obviously you need to supply a ICC profile (I've used the one from https://svn.apache.org/viewvc/pdfbox/trunk/examples/src/main/resources/org/apache/pdfbox/resources/pdfa/ )

As an interesting note: for level 1/2 validation, you cannot use the fallback fonts: all the fonts must be embedded.