### PR TITLE
implement #237 add support for svg files in img element

### DIFF
--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DReplacedElementFactory.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DReplacedElementFactory.java
@@ -36,10 +36,16 @@ public class Java2DReplacedElementFactory extends SwingReplacedElementFactory {
 			return new Java2DSVGReplacedElement(e, _svgImpl, cssWidth, cssHeight, box, context);
 		} else if (nodeName.equals("object") && _objectDrawerFactory != null) {
 			FSObjectDrawer drawer = _objectDrawerFactory.createDrawer(e);
-			if (drawer != null)
+			if (drawer != null) {
 				return new Java2DObjectDrawerReplacedElement(e, drawer, cssWidth, cssHeight,
 						context.getSharedContext().getDotsPerPixel());
-        }
+			}
+		} else if (nodeName.equals("img") && _svgImpl != null) {
+			String srcAttr = e.getAttribute("src");
+			if (srcAttr != null && srcAttr.endsWith(".svg")) {
+				return new Java2DSVGReplacedElement(uac.getXMLResource(srcAttr).getDocument().getDocumentElement(), _svgImpl, cssWidth, cssHeight, box, context);
+			}
+		}
 
 		/*
 		 * Default: Just let the base class handle everything

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
@@ -56,6 +56,12 @@ public class PdfBoxReplacedElementFactory implements ReplacedElementFactory {
         } else if (nodeName.equals("img")) {
             String srcAttr = e.getAttribute("src");
             if (srcAttr != null && srcAttr.length() > 0) {
+
+                //handle the case of linked svg from img tag
+                if (srcAttr.endsWith(".svg") && _svgImpl != null) {
+                    return new PdfBoxSVGReplacedElement(uac.getXMLResource(srcAttr).getDocument().getDocumentElement(), _svgImpl, cssWidth, cssHeight, box, c, c.getSharedContext());
+                }
+
                 FSImage fsImage = uac.getImageResource(srcAttr).getImage();
                 if (fsImage != null) {
                     boolean hasMaxHeight = !box.getStyle().isMaxHeightNone();

--- a/openhtmltopdf-svg-support/pom.xml
+++ b/openhtmltopdf-svg-support/pom.xml
@@ -37,14 +37,19 @@
         <version>${project.version}</version>
     </dependency>
     <dependency>
-	<groupId>org.apache.xmlgraphics</groupId>
-	<artifactId>batik-transcoder</artifactId>
-	<version>1.9</version>
+	    <groupId>org.apache.xmlgraphics</groupId>
+	    <artifactId>batik-transcoder</artifactId>
+	    <version>1.9</version>
     </dependency>
     <dependency>
-	<groupId>org.apache.xmlgraphics</groupId>
-	<artifactId>xmlgraphics-commons</artifactId>
-	<version>2.1</version>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-codec</artifactId>
+        <version>1.9</version>
+    </dependency>
+    <dependency>
+	    <groupId>org.apache.xmlgraphics</groupId>
+	    <artifactId>xmlgraphics-commons</artifactId>
+	    <version>2.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Hi @danfickle , with this PR, we can use svg files in img tag.

I'm not sure if it's the best way, but it seems an unobtrusive change, so it feel kinda right :)

Additionally, I've added `batik-codec` as a dependency, so we can support base64 encoded images in the svg (as in the case of the svg linked in the issue #237).

I've tested with both the java2d and pdfbox backend. 

Note: the dimension of the rendered svg (both as a `svg` and `img` element) is not handled like chrome or FF. But currently I don't know why. You can try with `https://docs.chef.io/_images/start_chef.svg` .

Rendered by pdfbox:

![pdfbox](https://user-images.githubusercontent.com/498146/42726289-4f49da06-8792-11e8-8dee-b1f8bb265e17.png)

Rendered by browser:

![chrome](https://user-images.githubusercontent.com/498146/42726292-54b3e18a-8792-11e8-9bb1-d6c482c1abc0.png)

The code of the page is simply:

```
<html>

<body>
top
<p><img style="border:1px solid red;" src="https://docs.chef.io/_images/start_chef.svg" alt="Chef Flow" /></p>
bottom
</body>
</html>
```


edit: ok, there is already an issue (#128) I'll try to investigate then.