### PR TITLE
Update batik deps due to CVE-2018-8013

### DIFF
--- a/openhtmltopdf-svg-support/pom.xml
+++ b/openhtmltopdf-svg-support/pom.xml
@@ -39,12 +39,12 @@
     <dependency>
 	    <groupId>org.apache.xmlgraphics</groupId>
 	    <artifactId>batik-transcoder</artifactId>
-	    <version>1.9</version>
+	    <version>1.10</version>
     </dependency>
     <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-codec</artifactId>
-        <version>1.9</version>
+        <version>1.10</version>
     </dependency>
     <dependency>
 	    <groupId>org.apache.xmlgraphics</groupId>

--- a/openhtmltopdf-svg-support/pom.xml
+++ b/openhtmltopdf-svg-support/pom.xml
@@ -47,6 +47,11 @@
         <version>1.10</version>
     </dependency>
     <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-ext</artifactId>
+        <version>1.10</version>
+    </dependency>
+    <dependency>
 	    <groupId>org.apache.xmlgraphics</groupId>
 	    <artifactId>xmlgraphics-commons</artifactId>
 	    <version>2.1</version>


### PR DESCRIPTION
Our security engineer stumbled over the [CVE-2018-8013](
https://nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=cpe%3A%2Fa%3Aapache%3Abatik%3A1.9)

I increased the required version to 1.10 and run into the issue [BATIK-1229](https://jira.apache.org/jira/browse/BATIK-1229) so the dependency to batik-ext seems to be necessary to work around this issue.
