### PR TITLE
Remove dependency on JAXB

### DIFF
--- a/openhtmltopdf-core/pom.xml
+++ b/openhtmltopdf-core/pom.xml
@@ -36,18 +36,6 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.w3c</groupId>
-      <artifactId>dom</artifactId>
-      <version>2.3.0-jaxb-1.0.6</version>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.xml</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.1</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/ImageUtil.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/ImageUtil.java
@@ -24,12 +24,12 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * Static utility methods for working with images. Meant to suggest "best practices" for the most straightforward
@@ -290,7 +290,7 @@ public class ImageUtil {
         int b64Index = imageDataUri.indexOf("base64,");
         if (b64Index != -1) {
             String b64encoded = imageDataUri.substring(b64Index + "base64,".length());
-            return DatatypeConverter.parseBase64Binary(b64encoded);
+            return Base64.getMimeDecoder().decode(b64encoded);
         } else {
             XRLog.load(Level.SEVERE, "Embedded XHTML images must be encoded in base 64.");
         }

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/ImageUtilTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/ImageUtilTest.java
@@ -1,0 +1,26 @@
+package com.openhtmltopdf.util;
+
+import java.awt.image.BufferedImage;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import org.junit.Test;
+import org.junit.Assert;
+
+public class ImageUtilTest {
+
+    @Test
+    public void testGetEmbeddedBase64Image() {
+        String onePixel = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADElEQVQI12P4//8/AAX+Av7czFnnAAAAAElFTkSuQmCC";
+        byte[] result = ImageUtil.getEmbeddedBase64Image(onePixel);
+        Assert.assertThat(result, notNullValue());
+    }
+
+    @Test
+    public void testLoadEmbeddedBase64Image() {
+        String onePixel = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADElEQVQI12P4//8/AAX+Av7czFnnAAAAAElFTkSuQmCC";
+        BufferedImage result = ImageUtil.loadEmbeddedBase64Image(onePixel);
+        Assert.assertThat(result.getHeight(), is(1));
+        Assert.assertThat(result.getWidth(), is(1));
+    }
+
+}


### PR DESCRIPTION
If https://github.com/danfickle/openhtmltopdf/issues/280 goes forward, JAXB can finally be removed. It's causing split package conflicts on the module path for me, and the fix was easy. Pull request https://github.com/danfickle/openhtmltopdf/pull/279 also mentions this.

Thanks for all you work on this library! :)