### PR TITLE
Update pdfbox-graphics2d version to 0.25

### DIFF
--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -65,7 +65,7 @@
 	  <dependency>
 		  <groupId>de.rototor.pdfbox</groupId>
 		  <artifactId>graphics2d</artifactId>
-		  <version>0.24</version>
+		  <version>0.25</version>
 	  </dependency>
   </dependencies>
 
@@ -82,7 +82,7 @@
   </build>
 
   <properties>
-    <pdfbox.version>2.0.16</pdfbox.version>
+    <pdfbox.version>2.0.17</pdfbox.version>
   </properties>
 
 </project>


### PR DESCRIPTION
And while we are at it, we should also update PDFBox itself. But this is redundant with #394.