### PR TITLE
refactor: use StandardCharsets.UTF_8/UTF_16_BE instead of String

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/protocols/data/DataURLConnection.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/protocols/data/DataURLConnection.java
@@ -22,7 +22,6 @@ package com.openhtmltopdf.protocols.data;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
@@ -69,7 +68,7 @@ public class DataURLConnection extends URLConnection {
         return new ByteArrayInputStream(_data);
     }
 
-    protected void parseURL() throws UnsupportedEncodingException {
+    protected void parseURL() throws UnsupportedCharsetException {
         String sub = getURL().getPath();
 
         int comma = sub.indexOf(',');

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/AbstractResource.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/AbstractResource.java
@@ -21,13 +21,11 @@ package com.openhtmltopdf.resource;
 
 import org.xml.sax.InputSource;
 
-import com.openhtmltopdf.util.XRLog;
-
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Patrick Wright
@@ -77,11 +75,7 @@ public abstract class AbstractResource implements Resource {
     public Reader getResourceReader() {
     	if (streamType == StreamType.STREAM &&
         	this.inputReader == null) {
-        	try {
-				this.inputReader = new InputStreamReader(this.inputStream, "UTF-8");
-			} catch (UnsupportedEncodingException e) {
-				XRLog.exception("Could not create reader for stream", e);
-			}
+            this.inputReader = new InputStreamReader(this.inputStream, StandardCharsets.UTF_8);
         }
         return this.inputReader;
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -86,11 +86,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 		@Override
 		public Reader getReader() {
 			if (this.strm != null) {
-				try {
-					return new InputStreamReader(this.strm, "UTF-8");
-				} catch (UnsupportedEncodingException e) {
-					XRLog.exception("Exception when creating stream reader", e);
-				}
+				return new InputStreamReader(this.strm, StandardCharsets.UTF_8);
 			}
 			return null;
 		}
@@ -207,14 +203,8 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         } catch (URISyntaxException e1) {
         	XRLog.exception("bad URL given: " + uri, e1);
 		}
-    	
-    	try {
-			return is == null ? null : new InputStreamReader(is, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			XRLog.exception("Failed to create stream reader", e);
-		}
-    	
-    	return null;
+
+		return is == null ? null : new InputStreamReader(is, StandardCharsets.UTF_8);
     }
     
     protected String readAll(Reader reader) throws IOException {

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/freemarker/FreeMarkerGenerator.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/freemarker/FreeMarkerGenerator.java
@@ -2,6 +2,7 @@ package com.openhtmltopdf.freemarker;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.apache.pdfbox.io.MemoryUsageSetting;
@@ -64,7 +65,7 @@ public class FreeMarkerGenerator {
 	public void generateHTMLToFile(String templateName, Locale locale, FreemarkerRootObject object, File htmlFile)
 			throws IOException, TemplateException {
 		FileOutputStream output = new FileOutputStream(htmlFile);
-		Writer fw = new OutputStreamWriter(output, "UTF-8");
+		Writer fw = new OutputStreamWriter(output, StandardCharsets.UTF_8);
 		cfg.getTemplate(templateName, locale, "UTF-8").process(object, fw);
 		fw.close();
 		output.close();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxForm.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxForm.java
@@ -5,7 +5,7 @@ import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -538,7 +538,7 @@ public class PdfBoxForm {
         OutputStream os = null;
         try {
             os = s.getContentStream().createOutputStream();
-            os.write(appear.getBytes("ASCII"));
+            os.write(appear.getBytes(StandardCharsets.US_ASCII));
         } catch (IOException e) {
             throw new PdfContentStreamAdapter.PdfException("createCheckboxAppearance", e);
         } finally {
@@ -553,9 +553,9 @@ public class PdfBoxForm {
         return s;
     }
 
-    private COSString getCOSStringUTF16Encoded(String value) throws UnsupportedEncodingException {
+    private COSString getCOSStringUTF16Encoded(String value) {
         // UTF-16BE encoded string with a leading byte order marker
-        byte[] data = value.getBytes("UTF-16BE");
+        byte[] data = value.getBytes(StandardCharsets.UTF_16BE);
         ByteArrayOutputStream out = new ByteArrayOutputStream(data.length + 2);
         out.write(0xFE); // BOM
         out.write(0xFF); // BOM


### PR DESCRIPTION
Small refactor: replace use of "UTF-8" and "UTF-16BE" with the equivalent one from `StandardCharsets` (available since java 1.7).

Remove the need to catch the `UnsupportedEncodingException` :)