### PR TITLE
handle NPE in justify text edge case #420

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/InlineText.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/InlineText.java
@@ -312,6 +312,10 @@ public class InlineText {
             // letter spacing is already explicitly set.
             return 0f;
         }
+
+        if (_counts == null) {
+            return 0f;
+        }
         
         return (_counts.getSpaceCount() * info.getSpaceAdjust()) +
                (_counts.getNonSpaceCount() * info.getNonSpaceAdjust());

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-420-justify-text-null-pointer-exception.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-420-justify-text-null-pointer-exception.pdf
@@ -1,0 +1,80 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20191129143428+01'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 595.275 841.875]
+/Parent 2 0 R
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 148
+/Filter /FlateDecode
+>>
+stream
+xœu=Â@DûùS&Í¹{Éå.­ EÀB8°)ÑŒ ß;?
+ÙjovÄHå°ì œ ÂúÂ#n¨q&$e†s­±Ş‰}³Ë«šüª	¦Öoúø#v¸¦¡|÷3–‹µR-ã	ú¢ÊÚÒ‡Ö¨ÚºeœÑûr`ì°ŠÿŞ™&O$¿8”ŒS¶·x,ã
+endstream
+endobj
+6 0 obj
+<<
+/Font 7 0 R
+>>
+endobj
+7 0 obj
+<<
+/F1 8 0 R
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000226 00000 n
+0000000342 00000 n
+0000000564 00000 n
+0000000597 00000 n
+0000000628 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<9D6FA6735B39E8E62A416FDF25C374C7> <9D6FA6735B39E8E62A416FDF25C374C7>]
+/Size 9
+>>
+startxref
+727
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-420-justify-text-null-pointer-exception.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-420-justify-text-null-pointer-exception.html
@@ -1,0 +1,1 @@
+<html><body><p style="text-align: justify"><span>a<br />b</span></p></body></html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -923,7 +923,12 @@ public class VisualRegressionTest {
         assertTrue(vt.runTest("issue-399-table-header-with-no-rows"));    
     }
     
-    
+
+    @Test
+    public void testIssue420JustifyTextNullPointerException() throws IOException {
+        assertTrue(vt.runTest("issue-420-justify-text-null-pointer-exception"));
+    }
+
     // TODO:
     // + Elements that appear just on generated overflow pages.
     // + content property (page counters, etc)


### PR DESCRIPTION
hi @danfickle , this fix the issue #420 . From the debugging session, I see the issue is caused by a `InlineText`: "\n"  which I guess is generated by the `br` element, but I can't get a clear picture.

If I understood correctly, the align logic is calling `InlineText.calcTotalAdjustment` without calling `InlineText.countJustifiableChars` on that `InlineText` element before (which has the `InlineLayoutBox`: "br" as a parent), thus not creating a "_counts" instance.

