### PR TITLE
fix issue #428: use relative path instead of ${project.build.outputDirectory}/META-INF

### DIFF
--- a/openhtmltopdf-core/pom.xml
+++ b/openhtmltopdf-core/pom.xml
@@ -45,7 +45,7 @@
       </resource>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>

--- a/openhtmltopdf-examples/pom.xml
+++ b/openhtmltopdf-examples/pom.xml
@@ -150,7 +150,7 @@
       </resource>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>

--- a/openhtmltopdf-java2d/pom.xml
+++ b/openhtmltopdf-java2d/pom.xml
@@ -40,7 +40,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/openhtmltopdf-latex-support/pom.xml
+++ b/openhtmltopdf-latex-support/pom.xml
@@ -52,7 +52,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/openhtmltopdf-log4j/pom.xml
+++ b/openhtmltopdf-log4j/pom.xml
@@ -47,7 +47,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/openhtmltopdf-mathml-support/pom.xml
+++ b/openhtmltopdf-mathml-support/pom.xml
@@ -54,7 +54,7 @@
 		<resources>
 			<resource>
 				<directory>../</directory>
-				<targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+				<targetPath>META-INF</targetPath>
 				<includes>
 					<include>LICENSE*</include>
 				</includes>

--- a/openhtmltopdf-objects/pom.xml
+++ b/openhtmltopdf-objects/pom.xml
@@ -66,7 +66,7 @@
 		<resources>
 			<resource>
 				<directory>../</directory>
-				<targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+				<targetPath>META-INF</targetPath>
 				<includes>
 					<include>LICENSE*</include>
 				</includes>

--- a/openhtmltopdf-pdfa-testing/pom.xml
+++ b/openhtmltopdf-pdfa-testing/pom.xml
@@ -76,7 +76,7 @@
       </resource>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -73,7 +73,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/openhtmltopdf-rtl-support/pom.xml
+++ b/openhtmltopdf-rtl-support/pom.xml
@@ -47,7 +47,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/openhtmltopdf-slf4j/pom.xml
+++ b/openhtmltopdf-slf4j/pom.xml
@@ -47,7 +47,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/openhtmltopdf-svg-support/pom.xml
+++ b/openhtmltopdf-svg-support/pom.xml
@@ -62,7 +62,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>


### PR DESCRIPTION
This fix issue #428 . I've checked the resulting jars and they are now correctly built (the final jar, the source jar  the javadoc jars).

ATM I can't find any downside/issues.