### PR TITLE
Fix #439 linear gradient support for PDF output

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/AbstractPropertyBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/AbstractPropertyBuilder.java
@@ -164,6 +164,10 @@ public abstract class AbstractPropertyBuilder implements PropertyBuilder {
     }
     
     protected boolean isLength(CSSPrimitiveValue value) {
+        return isLengthHelper(value);
+    }
+
+    public static boolean isLengthHelper(CSSPrimitiveValue value) {
         int unit = value.getPrimitiveType();
         return unit == CSSPrimitiveValue.CSS_EMS || unit == CSSPrimitiveValue.CSS_EXS
                 || unit == CSSPrimitiveValue.CSS_PX || unit == CSSPrimitiveValue.CSS_IN

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
@@ -529,6 +529,24 @@ public class PrimitivePropertyBuilders {
     }
 
     public static class BackgroundImage extends GenericURIWithNone {
+        @Override
+        public List<PropertyDeclaration> buildDeclarations(
+            CSSName cssName, List<PropertyValue> values, int origin,
+            boolean important, boolean inheritAllowed) {
+
+            checkValueCount(cssName, 1, values.size());
+            PropertyValue value = values.get(0);
+
+            if (value.getPropertyValueType() == PropertyValue.VALUE_TYPE_FUNCTION &&
+                Objects.equals(value.getFunction().getName(), "linear-gradient")) {
+                // TODO: Validation of linear-gradient args.
+                return Collections.singletonList(
+                        new PropertyDeclaration(cssName, value, important, origin));
+            } else {
+                return super.buildDeclarations(cssName, values, origin, important, inheritAllowed);
+            }
+        }
+
     }
 
     public static class BackgroundSize extends AbstractPropertyBuilder {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -22,6 +22,7 @@ package com.openhtmltopdf.css.style;
 
 import java.awt.Cursor;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -39,6 +40,7 @@ import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.style.derived.BorderPropertySet;
 import com.openhtmltopdf.css.style.derived.CountersValue;
 import com.openhtmltopdf.css.style.derived.DerivedValueFactory;
+import com.openhtmltopdf.css.style.derived.FSLinearGradient;
 import com.openhtmltopdf.css.style.derived.FunctionValue;
 import com.openhtmltopdf.css.style.derived.LengthValue;
 import com.openhtmltopdf.css.style.derived.ListValue;
@@ -1393,9 +1395,22 @@ public class CalculatedStyle {
 			return (int) cssMaxHeight.value();
 		}
 	}
-	
-	
-}// end class
+
+    public boolean isLinearGradient() {
+        FSDerivedValue value = valueByName(CSSName.BACKGROUND_IMAGE);    	
+        return value instanceof FunctionValue &&
+               Objects.equals(((FunctionValue) value).getFunction().getName(), "linear-gradient");
+    }
+
+    public FSLinearGradient getLinearGradient(CssContext cssContext, int boxWidth, int boxHeight) {
+        if (!isLinearGradient()) {
+            return null;
+        }
+
+        FunctionValue value = (FunctionValue) valueByName(CSSName.BACKGROUND_IMAGE);
+        return new FSLinearGradient(this, value.getFunction(), boxWidth, boxHeight, cssContext);
+    }
+}
 
 /*
  * $Id$

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/FSLinearGradient.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/FSLinearGradient.java
@@ -1,0 +1,247 @@
+package com.openhtmltopdf.css.style.derived;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.css.constants.Idents;
+import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
+import com.openhtmltopdf.css.parser.FSColor;
+import com.openhtmltopdf.css.parser.FSFunction;
+import com.openhtmltopdf.css.parser.PropertyValue;
+import com.openhtmltopdf.css.parser.property.AbstractPropertyBuilder;
+import com.openhtmltopdf.css.parser.property.Conversions;
+import com.openhtmltopdf.css.style.CalculatedStyle;
+import com.openhtmltopdf.css.style.CssContext;
+
+public class FSLinearGradient {
+
+    /**
+     * A stop point which does not yet have a length.
+     * We need all the stop points first before we can calculate
+     * a length for intermediate stop points without a length.
+     */
+    private static class IntermediateStopPoint {
+        private final FSColor _color;
+
+        IntermediateStopPoint(FSColor color) {
+            _color = color;
+        }
+
+        public FSColor getColor() {
+            return _color;
+        }
+    }
+
+    public static class StopPoint extends IntermediateStopPoint {
+        private final float _length;
+
+        public StopPoint(FSColor color, float length) {
+            super(color);
+            this._length = length;
+        }
+
+        public float getLength() {
+            return _length;
+        }
+    }
+
+    private final List<StopPoint> _stopPoints;
+    private final float _angle;
+    // TODO.
+    // private final int x1;
+    // private final int x2;
+    // private final int y1;
+    // private final int y2;
+
+    public FSLinearGradient(CalculatedStyle style, FSFunction function, float boxWidth, CssContext ctx) {
+        List<PropertyValue> params = function.getParameters();
+        int stopsStartIndex = getStopsStartIndex(params);
+
+        float prelimAngle = calculateAngle(params, stopsStartIndex);
+        prelimAngle = prelimAngle % 360f;
+        if (prelimAngle < 0) {
+            prelimAngle += 360f;
+        }
+
+        this._angle = prelimAngle;
+        this._stopPoints = calculateStopPoints(params, style, ctx, boxWidth, stopsStartIndex);
+    }
+
+    private boolean isLengthOrPercentage(PropertyValue value) {
+        return AbstractPropertyBuilder.isLengthHelper(value) || 
+               value.getPrimitiveType() == CSSPrimitiveValue.CSS_PERCENTAGE;
+    }
+
+    private List<StopPoint> calculateStopPoints(
+        List<PropertyValue> params, CalculatedStyle style, CssContext ctx, float boxWidth, int stopsStartIndex) {
+
+        List<IntermediateStopPoint> points = new ArrayList<>();
+
+        for (int i = stopsStartIndex; i < params.size(); i++) {
+            PropertyValue value = params.get(i);
+            FSColor color;
+
+            if (value.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
+                color = Conversions.getColor(value.getStringValue());
+            } else {
+                color = value.getFSColor();
+            }
+
+            if (i + 1 < params.size() && isLengthOrPercentage(params.get(i + 1))) {
+
+                PropertyValue lengthValue = params.get(i + 1);
+                float length = LengthValue.calcFloatProportionalValue(style, CSSName.BACKGROUND_IMAGE, "",
+                        lengthValue.getFloatValue(), lengthValue.getPrimitiveType(), boxWidth, ctx);
+                points.add(new StopPoint(color, length));
+            } else {
+                points.add(new IntermediateStopPoint(color));
+            }
+        }
+
+        List<StopPoint> ret = new ArrayList<>(points.size());
+
+        for (int i = 0; i < points.size(); i++) {
+            IntermediateStopPoint pt = points.get(i);
+            boolean intermediate = pt.getClass() == IntermediateStopPoint.class;
+            
+            if (!intermediate) {
+                ret.add((StopPoint) pt);
+            } else if (i == 0) {
+                ret.add(new StopPoint(pt.getColor(), 0f));
+            } else if (i == points.size() - 1) {
+                float len = get100PercentDefaultStopLength(style, ctx, boxWidth);
+                ret.add(new StopPoint(pt.getColor(), len));
+            } else {
+                // Poo, we've got a length-less stop in the middle.
+                // Lets say we have linear-gradient(to right, red, blue 10px, orange, yellow, black 100px, purple):
+                // In this case because orange and yellow don't have lengths we have to devide the difference
+                // between them. So difference = 90px and there are 3 color changes means that the interval
+                // will be 30px and that orange will be at 40px and yellow at 70px.
+                int nextWithLengthIndex = getNextStopPointWithLengthIndex(points, i + 1);
+                int prevWithLengthIndex = getPrevStopPointWithLengthIndex(points, i - 1);
+
+                float nextLength = nextWithLengthIndex == -1 ?
+                                    get100PercentDefaultStopLength(style, ctx, boxWidth) :
+                                    ((StopPoint) points.get(nextWithLengthIndex)).getLength();
+
+                float prevLength = prevWithLengthIndex == -1 ? 0 :
+                                    ((StopPoint) points.get(prevWithLengthIndex)).getLength();
+
+                float range = nextLength - prevLength;
+
+                int topRangeIndex = nextWithLengthIndex == -1 ? points.size() - 1 : nextWithLengthIndex;
+                int bottomRangeIndex = prevWithLengthIndex == -1 ? 0 : prevWithLengthIndex;
+                
+                int rangeCount = (topRangeIndex - bottomRangeIndex) + 1;
+                int thisCount = i - bottomRangeIndex;
+
+                // TODO: Check for div by zero.
+                float interval = range / rangeCount;
+
+                float thisLength = prevLength + (interval * thisCount);
+
+                ret.add(new StopPoint(pt.getColor(), thisLength));
+            }
+        }
+
+        return ret;
+    }
+
+    private int getPrevStopPointWithLengthIndex(List<IntermediateStopPoint> points, int maxIndex) {
+        for (int i = maxIndex; i >= 0; i--) {
+            if (isStopPointWithLength(points.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private float get100PercentDefaultStopLength(CalculatedStyle style, CssContext ctx, float boxWidth) {
+        return LengthValue.calcFloatProportionalValue(style, CSSName.BACKGROUND_IMAGE, "100%",
+                100f, CSSPrimitiveValue.CSS_PERCENTAGE, boxWidth, ctx);
+    }
+
+    private boolean isStopPointWithLength(IntermediateStopPoint pt) {
+        return pt.getClass() == IntermediateStopPoint.class;
+    }
+
+    private int getNextStopPointWithLengthIndex(List<IntermediateStopPoint> points, int startIndex) {
+        for (int i = startIndex; i < points.size(); i++) {
+            if (isStopPointWithLength(points.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int getStopsStartIndex(List<PropertyValue> params) {
+        if (Objects.equals(params.get(0).getStringValue(), "to")) {
+            int i = 1;
+            while (i < params.size() && 
+                   Idents.looksLikeABGPosition(params.get(i).getStringValue())) {
+                 i++;
+            }
+
+            return i;
+        } else {
+            return 1;
+        }
+    }
+
+    /**
+     * Calculates the angle of the linear gradient in degrees.
+     */
+    private float calculateAngle(List<PropertyValue> params, int stopsStartIndex) {
+        if (Objects.equals(params.get(0).getStringValue(), "to")) {
+            // The to keyword is followed by one or two position
+            // idents (in any order).
+            // linear-gradient( to left top, blue, red);
+            // linear-gradient( to top right, blue, red);
+            List<String> positions = new ArrayList<>(2);
+
+            for (int i = 1; i < stopsStartIndex; i++) {
+                 positions.add(params.get(i).getStringValue());
+            }
+
+            if (positions.contains("top") && positions.contains("left"))
+                return 315f;
+            else if (positions.contains("top") && positions.contains("right"))
+                return 45f;
+            else if (positions.contains("bottom") && positions.contains("left"))
+                return 225f;
+            else if (positions.contains("bottom") && positions.contains("right"))
+                return 135f;
+            else if (positions.contains("bottom"))
+                return 180f;
+            else
+                return 0f;
+        }
+        else if (params.get(0).getPrimitiveType() == CSSPrimitiveValue.CSS_DEG)
+        {
+            // linear-gradient(45deg, ...)
+            return params.get(0).getFloatValue();
+        }
+        else if (params.get(0).getPrimitiveType() == CSSPrimitiveValue.CSS_RAD)
+        {
+            // linear-gradient(2rad)
+            return params.get(0).getFloatValue() * (float) (180 / Math.PI);
+        }
+        else
+        {
+            return 0f;
+        }
+    }
+
+    public List<StopPoint> getStopPoints() {
+        return _stopPoints;
+    }
+
+    /**
+     * The angle of this linear gradient in compass degrees.
+     */
+    public float getAngle() {
+        return _angle;
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -22,11 +22,15 @@ package com.openhtmltopdf.extend;
 import com.openhtmltopdf.css.parser.FSColor;
 import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.css.style.derived.BorderPropertySet;
+import com.openhtmltopdf.css.style.derived.FSLinearGradient;
 import com.openhtmltopdf.render.*;
+import com.openhtmltopdf.util.XRLog;
+
 import java.awt.*;
 import java.awt.RenderingHints.Key;
 import java.awt.geom.AffineTransform;
 import java.util.List;
+import java.util.logging.Level;
 
 public interface OutputDevice {
 	public void setPaint(Paint paint);
@@ -84,6 +88,10 @@ public interface OutputDevice {
     public void drawBorderLine(Shape bounds, int side, int width, boolean solid);
     
     public void drawImage(FSImage image, int x, int y, boolean interpolate);
+
+    default public void drawLinearGradient(FSLinearGradient backgroundLinearGradient, Shape bounds) {
+        XRLog.render(Level.WARNING, "linear-gradient(...) is not supported in this output device");
+    }
 
     public void draw(Shape s);
     public void fill(Shape s);

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-439-linear-gradient.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-439-linear-gradient.pdf
@@ -1,0 +1,684 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20200223215107+11'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 150.0 300.0]
+/Parent 2 0 R
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 2334
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+0 300 m
+150 300 l
+150 0.03751 l
+0 0.03751 l
+0 300 l
+h
+W
+n
+q
+6 291.75 m
+6 269.25 l
+144 269.25 l
+144 291.75 l
+h
+W
+n
+/sh1 sh
+Q
+0 0 0 rg
+5.25 292.5 m
+144.75 292.5 l
+144 291.75 l
+6 291.75 l
+h
+f
+144.75 268.5 m
+5.25 268.5 l
+6 269.25 l
+144 269.25 l
+h
+f
+5.25 268.5 m
+5.25 292.5 l
+6 291.75 l
+6 269.25 l
+h
+f
+144.75 292.5 m
+144.75 268.5 l
+144 269.25 l
+144 291.75 l
+h
+f
+q
+6 260.25 m
+6 237.75 l
+144 237.75 l
+144 260.25 l
+h
+W
+n
+/sh2 sh
+Q
+5.25 261 m
+144.75 261 l
+144 260.25 l
+6 260.25 l
+h
+f
+144.75 237 m
+5.25 237 l
+6 237.75 l
+144 237.75 l
+h
+f
+5.25 237 m
+5.25 261 l
+6 260.25 l
+6 237.75 l
+h
+f
+144.75 261 m
+144.75 237 l
+144 237.75 l
+144 260.25 l
+h
+f
+q
+6 228.75 m
+6 206.25 l
+144 206.25 l
+144 228.75 l
+h
+W
+n
+/sh3 sh
+Q
+5.25 229.5 m
+144.75 229.5 l
+144 228.75 l
+6 228.75 l
+h
+f
+144.75 205.5 m
+5.25 205.5 l
+6 206.25 l
+144 206.25 l
+h
+f
+5.25 205.5 m
+5.25 229.5 l
+6 228.75 l
+6 206.25 l
+h
+f
+144.75 229.5 m
+144.75 205.5 l
+144 206.25 l
+144 228.75 l
+h
+f
+q
+6 197.25 m
+6 174.75 l
+144 174.75 l
+144 197.25 l
+h
+W
+n
+/sh4 sh
+Q
+5.25 198 m
+144.75 198 l
+144 197.25 l
+6 197.25 l
+h
+f
+144.75 174 m
+5.25 174 l
+6 174.75 l
+144 174.75 l
+h
+f
+5.25 174 m
+5.25 198 l
+6 197.25 l
+6 174.75 l
+h
+f
+144.75 198 m
+144.75 174 l
+144 174.75 l
+144 197.25 l
+h
+f
+q
+6 165.75 m
+6 143.25 l
+144 143.25 l
+144 165.75 l
+h
+W
+n
+/sh5 sh
+Q
+5.25 166.5 m
+144.75 166.5 l
+144 165.75 l
+6 165.75 l
+h
+f
+144.75 142.5 m
+5.25 142.5 l
+6 143.25 l
+144 143.25 l
+h
+f
+5.25 142.5 m
+5.25 166.5 l
+6 165.75 l
+6 143.25 l
+h
+f
+144.75 166.5 m
+144.75 142.5 l
+144 143.25 l
+144 165.75 l
+h
+f
+q
+6 134.25 m
+6 111.75 l
+144 111.75 l
+144 134.25 l
+h
+W
+n
+/sh6 sh
+Q
+5.25 135 m
+144.75 135 l
+144 134.25 l
+6 134.25 l
+h
+f
+144.75 111 m
+5.25 111 l
+6 111.75 l
+144 111.75 l
+h
+f
+5.25 111 m
+5.25 135 l
+6 134.25 l
+6 111.75 l
+h
+f
+144.75 135 m
+144.75 111 l
+144 111.75 l
+144 134.25 l
+h
+f
+q
+6 102.75 m
+6 80.25 l
+144 80.25 l
+144 102.75 l
+h
+W
+n
+/sh7 sh
+Q
+5.25 103.5 m
+144.75 103.5 l
+144 102.75 l
+6 102.75 l
+h
+f
+144.75 79.5 m
+5.25 79.5 l
+6 80.25 l
+144 80.25 l
+h
+f
+5.25 79.5 m
+5.25 103.5 l
+6 102.75 l
+6 80.25 l
+h
+f
+144.75 103.5 m
+144.75 79.5 l
+144 80.25 l
+144 102.75 l
+h
+f
+q
+6 71.25 m
+6 11.25 l
+144 11.25 l
+144 71.25 l
+h
+W
+n
+/sh8 sh
+Q
+5.25 72 m
+144.75 72 l
+144 71.25 l
+6 71.25 l
+h
+f
+144.75 10.5 m
+5.25 10.5 l
+6 11.25 l
+144 11.25 l
+h
+f
+5.25 10.5 m
+5.25 72 l
+6 71.25 l
+6 11.25 l
+h
+f
+144.75 72 m
+144.75 10.5 l
+144 11.25 l
+144 71.25 l
+h
+f
+Q
+
+endstream
+endobj
+6 0 obj
+<<
+/Shading 7 0 R
+>>
+endobj
+7 0 obj
+<<
+/sh1 8 0 R
+/sh2 9 0 R
+/sh3 10 0 R
+/sh4 11 0 R
+/sh5 12 0 R
+/sh6 13 0 R
+/sh7 14 0 R
+/sh8 15 0 R
+>>
+endobj
+8 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [144.0 291.75 6.0 291.75]
+/Function 16 0 R
+/Extend [false false]
+>>
+endobj
+9 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [6.0 260.25 144.0 260.25]
+/Function 17 0 R
+/Extend [false false]
+>>
+endobj
+10 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [6.0 228.75 6.0 206.25]
+/Function 18 0 R
+/Extend [false false]
+>>
+endobj
+11 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [34.875 145.875 115.125 226.125]
+/Function 19 0 R
+/Extend [false false]
+>>
+endobj
+12 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [144.0 165.75 6.0 165.75]
+/Function 20 0 R
+/Extend [false false]
+>>
+endobj
+13 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [6.0 134.25 144.0 134.25]
+/Function 21 0 R
+/Extend [false false]
+>>
+endobj
+14 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [6.0 102.75 144.0 102.75]
+/Function 22 0 R
+/Extend [false false]
+>>
+endobj
+15 0 obj
+<<
+/ShadingType 2
+/ColorSpace /DeviceRGB
+/Coords [6.0 11.25 6.0 71.25]
+/Function 23 0 R
+/Extend [false false]
+>>
+endobj
+16 0 obj
+<<
+/FunctionType 3
+/Functions [24 0 R]
+/Bounds []
+/Encode [0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+17 0 obj
+<<
+/FunctionType 3
+/Functions [25 0 R 26 0 R 27 0 R]
+/Bounds [0.24999999 0.49999997]
+/Encode [0.0 1.0 0.0 1.0 0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+18 0 obj
+<<
+/FunctionType 3
+/Functions [28 0 R]
+/Bounds []
+/Encode [0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+19 0 obj
+<<
+/FunctionType 3
+/Functions [29 0 R]
+/Bounds []
+/Encode [0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+20 0 obj
+<<
+/FunctionType 3
+/Functions [30 0 R]
+/Bounds []
+/Encode [0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+21 0 obj
+<<
+/FunctionType 3
+/Functions [31 0 R 32 0 R 33 0 R]
+/Bounds [0.2173913 0.54347825]
+/Encode [0.0 1.0 0.0 1.0 0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+22 0 obj
+<<
+/FunctionType 3
+/Functions [34 0 R 35 0 R 36 0 R 37 0 R]
+/Bounds [0.10869565 0.1811594 0.32608694]
+/Encode [0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+23 0 obj
+<<
+/FunctionType 3
+/Functions [38 0 R 39 0 R]
+/Bounds [0.19999999]
+/Encode [0.0 1.0 0.0 1.0]
+/Domain [0.0 1.0]
+>>
+endobj
+24 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.0 0.0]
+/C1 [0.0 0.0 1.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+25 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.5019608 0.0]
+/C1 [0.0 0.0 1.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+26 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.0 1.0]
+/C1 [1.0 0.0 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+27 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.0 0.0]
+/C1 [1.0 0.64705884 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+28 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.0 1.0]
+/C1 [1.0 0.0 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+29 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.0 0.0]
+/C1 [0.0 0.0 1.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+30 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.64705884 0.0]
+/C1 [0.0 0.0 1.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+31 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.0 1.0]
+/C1 [1.0 0.64705884 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+32 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.64705884 0.0]
+/C1 [0.0 0.0 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+33 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.0 0.0]
+/C1 [0.0 0.5019608 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+34 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.5019608 0.0]
+/C1 [1.0 0.0 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+35 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.0 0.0]
+/C1 [0.0 0.0 1.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+36 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.0 1.0]
+/C1 [1.0 0.64705884 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+37 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.64705884 0.0]
+/C1 [0.0 0.0 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+38 0 obj
+<<
+/FunctionType 2
+/C0 [0.0 0.5019608 0.0]
+/C1 [1.0 0.0 0.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+39 0 obj
+<<
+/FunctionType 2
+/C0 [1.0 0.0 0.0]
+/C1 [0.0 0.0 1.0]
+/N 1
+/Domain [0.0 1.0]
+>>
+endobj
+xref
+0 40
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000226 00000 n
+0000000338 00000 n
+0000002726 00000 n
+0000002762 00000 n
+0000002877 00000 n
+0000003009 00000 n
+0000003141 00000 n
+0000003272 00000 n
+0000003412 00000 n
+0000003545 00000 n
+0000003678 00000 n
+0000003811 00000 n
+0000003940 00000 n
+0000004045 00000 n
+0000004201 00000 n
+0000004306 00000 n
+0000004411 00000 n
+0000004516 00000 n
+0000004671 00000 n
+0000004852 00000 n
+0000004982 00000 n
+0000005079 00000 n
+0000005182 00000 n
+0000005279 00000 n
+0000005383 00000 n
+0000005480 00000 n
+0000005577 00000 n
+0000005681 00000 n
+0000005785 00000 n
+0000005889 00000 n
+0000005992 00000 n
+0000006095 00000 n
+0000006192 00000 n
+0000006296 00000 n
+0000006400 00000 n
+0000006503 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<86E2A0A8C86376308D0C692FE4F2CCF4> <86E2A0A8C86376308D0C692FE4F2CCF4>]
+/Size 40
+>>
+startxref
+6600
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-439-linear-gradient.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-439-linear-gradient.html
@@ -1,0 +1,55 @@
+<html>
+<head>
+<style>
+@page {
+  size: 200px 400px;
+  margin: 0;
+}
+body {
+  max-width: 200px;
+  margin: 0;
+}
+div {
+  margin: 10px 7px;
+  border: 1px solid black;
+  height: 30px;
+}
+#one {
+  background-image: linear-gradient(to left, red, blue);
+}
+#two {
+  background-image: linear-gradient(to right, green, blue, red, orange);
+}
+#three {
+  background-image: linear-gradient(to bottom, #00f, #f00);
+}
+#four {
+  background-image: linear-gradient(45deg, red, blue);
+}
+#five {
+  background-image: linear-gradient(to left, orange 0%, blue 100%);
+}
+#six {
+  background-image: linear-gradient(to right, blue, orange 40px, black 100px, green);
+}
+#seven {
+  background-image: linear-gradient(to right, green, red 20px, blue, orange 60px, black);
+}
+#eight {
+  height: 60px;
+  padding: 10px;
+  background-image: linear-gradient(to top, green, red 20%, blue);
+}
+</style>
+</head>
+<body>
+<div id="one"></div>
+<div id="two"></div>
+<div id="three"></div>
+<div id="four"></div>
+<div id="five"></div>
+<div id="six"></div>
+<div id="seven"></div>
+<div id="eight"></div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1034,7 +1034,15 @@ public class VisualRegressionTest {
     public void testIssue309ClassCastExceptionOnFloatTd() throws IOException {
         assertTrue(vt.runTest("issue-309-classcastexception-on-float-td"));
     }
-    
+
+    /**
+     * Tests various linear gradients.
+     */
+    @Test
+    public void testIssue439LinearGradient() throws IOException {
+        assertTrue(vt.runTest("issue-439-linear-gradient"));
+    }
+
     /**
      * Tests that a font-face rule with multiple sources in different formats
      * loads the truetype font only.

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1037,6 +1037,7 @@ public class VisualRegressionTest {
 
     /**
      * Tests various linear gradients.
+     * https://github.com/danfickle/openhtmltopdf/issues/439
      */
     @Test
     public void testIssue439LinearGradient() throws IOException {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/GradientHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/GradientHelper.java
@@ -1,0 +1,153 @@
+package com.openhtmltopdf.pdfboxout;
+
+import java.util.List;
+import java.awt.geom.*;
+import java.awt.Rectangle;
+import java.awt.Shape;
+
+import com.openhtmltopdf.css.parser.FSRGBColor;
+import com.openhtmltopdf.css.style.derived.FSLinearGradient;
+import com.openhtmltopdf.css.style.derived.FSLinearGradient.StopPoint;
+
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBoolean;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSFloat;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.common.function.PDFunctionType3;
+import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
+import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceRGB;
+import org.apache.pdfbox.pdmodel.graphics.shading.PDShading;
+import org.apache.pdfbox.pdmodel.graphics.shading.PDShadingType2;
+
+public class GradientHelper {
+    /**
+     * This method is used for creating linear gradient with its components.
+     * 
+     * @return shading for rendering linear gradient in PDF
+     */
+    public static PDShading createLinearGradient(PdfBoxFastOutputDevice od, AffineTransform transform, FSLinearGradient gradient, Shape bounds)
+    {
+        PDShadingType2 shading = new PDShadingType2(new COSDictionary());
+        shading.setShadingType(PDShading.SHADING_TYPE2);
+        shading.setColorSpace(PDDeviceRGB.INSTANCE);
+
+        Rectangle rect = bounds.getBounds();
+
+        Point2D ptStart = new Point2D.Float(gradient.getX1() + (float) rect.getMinX(), gradient.getY1() + (float) rect.getMinY());
+        Point2D ptEnd = new Point2D.Float(gradient.getX2() + (float) rect.getMinX(), gradient.getY2() + (float) rect.getMinY());
+
+        Point2D ptStartDevice = transform.transform(ptStart, null);
+        Point2D ptEndDevice = transform.transform(ptEnd, null);
+
+        float startX = (float) ptStartDevice.getX();
+        float startY = (float) od.normalizeY((float) ptStartDevice.getY());
+        float endX = (float) ptEndDevice.getX();
+        float endY = (float) od.normalizeY((float) ptEndDevice.getY());
+
+        COSArray coords = new COSArray();
+        coords.add(new COSFloat(startX));
+        coords.add(new COSFloat(startY));
+        coords.add(new COSFloat(endX));
+        coords.add(new COSFloat(endY));
+        shading.setCoords(coords);
+
+        PDFunctionType3 type3 = buildType3Function(gradient.getStopPoints(), (float) ptEnd.distance(ptStart));
+
+        COSArray extend = new COSArray();
+        extend.add(COSBoolean.FALSE);
+        extend.add(COSBoolean.FALSE);
+        shading.setFunction(type3);
+        shading.setExtend(extend);
+        return shading;
+    }
+
+    /**
+     * This method is used for setting colour lengths to linear gradient.
+     * 
+     * @return the function, which is an important parameter for setting linear
+     *         gradient.
+     * @param stopPoints
+     *            colours and lengths of linear gradient.
+     */
+    private static PDFunctionType3 buildType3Function(List<StopPoint> stopPoints, float distance) {
+        float max = stopPoints.get(stopPoints.size() - 1).getLength();
+
+        COSDictionary function = new COSDictionary();
+        function.setInt(COSName.FUNCTION_TYPE, 3);
+
+        COSArray domain = new COSArray();
+        domain.add(new COSFloat(0));
+        domain.add(new COSFloat(1));
+
+        COSArray encode = new COSArray();
+
+        COSArray range = new COSArray();
+        range.add(new COSFloat(0));
+        range.add(new COSFloat(1));
+        COSArray bounds = new COSArray();
+        for (int i = 1; i < stopPoints.size() - 1; i++) {
+            float pos = ((stopPoints.get(i).getLength() / max) * distance) * (1 / distance);
+            bounds.add(new COSFloat(pos));
+        }
+
+        COSArray functions = buildType2Functions(stopPoints, domain, encode);
+
+        function.setItem(COSName.FUNCTIONS, functions);
+        function.setItem(COSName.BOUNDS, bounds);
+        function.setItem(COSName.ENCODE, encode);
+        PDFunctionType3 type3 = new PDFunctionType3(function);
+        type3.setDomainValues(domain);
+        return type3;
+    }
+
+    /**
+     * This method is used for setting colours to linear gradient.
+     * 
+     * @return the COSArray, which is an important parameter for setting linear
+     *         gradient.
+     * @param stopPoints
+     *            colours to use.
+     * @param domain
+     *            parameter for setting functiontype2
+     * @param encode
+     *            encoding COSArray
+     */
+    private static COSArray buildType2Functions(List<StopPoint> stopPoints, COSArray domain, COSArray encode)
+    {
+        FSRGBColor prevColor = (FSRGBColor) stopPoints.get(0).getColor();
+
+        COSArray functions = new COSArray();
+        for (int i = 1; i < stopPoints.size(); i++)
+        {
+
+            FSRGBColor color = (FSRGBColor) stopPoints.get(i).getColor();
+
+            float[] component = new float[] { prevColor.getRed() / 255f, prevColor.getGreen() / 255f, prevColor.getBlue() / 255f };
+            PDColor prevPdColor = new PDColor(component, PDDeviceRGB.INSTANCE);
+
+            float[] component1 = new float[] { color.getRed() / 255f, color.getGreen() / 255f, color.getBlue() / 255f };
+            PDColor pdColor = new PDColor(component1, PDDeviceRGB.INSTANCE);
+
+            COSArray c0 = new COSArray();
+            COSArray c1 = new COSArray();
+            for (float component2 : prevPdColor.getComponents())
+                c0.add(new COSFloat(component2));
+            for (float component3 : pdColor.getComponents())
+                c1.add(new COSFloat(component3));
+
+            COSDictionary type2Function = new COSDictionary();
+            type2Function.setInt(COSName.FUNCTION_TYPE, 2);
+            type2Function.setItem(COSName.C0, c0);
+            type2Function.setItem(COSName.C1, c1);
+            type2Function.setInt(COSName.N, 1);
+            type2Function.setItem(COSName.DOMAIN, domain);
+            functions.add(type2Function);
+
+            encode.add(new COSFloat(0));
+            encode.add(new COSFloat(1));
+            prevColor = color;
+        }
+        return functions;
+    }
+}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -27,6 +27,7 @@ import com.openhtmltopdf.css.parser.FSColor;
 import com.openhtmltopdf.css.parser.FSRGBColor;
 import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.css.style.CssContext;
+import com.openhtmltopdf.css.style.derived.FSLinearGradient;
 import com.openhtmltopdf.css.value.FontSpecification;
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.extend.OutputDevice;
@@ -35,7 +36,6 @@ import com.openhtmltopdf.extend.StructureType;
 import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription;
-import com.openhtmltopdf.pdfboxout.PdfBoxPerDocumentFormState;
 import com.openhtmltopdf.pdfboxout.PdfBoxSlowOutputDevice.FontRun;
 import com.openhtmltopdf.pdfboxout.PdfBoxSlowOutputDevice.Metadata;
 import com.openhtmltopdf.render.*;
@@ -54,6 +54,7 @@ import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.apache.pdfbox.pdmodel.graphics.image.JPEGFactory;
 import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.graphics.shading.PDShading;
 import org.apache.pdfbox.pdmodel.graphics.state.RenderingMode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -630,7 +631,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
     /**
      * Converts a top down unit to a bottom up PDF unit for the current page.
      */
-    private float normalizeY(float y) {
+    public float normalizeY(float y) {
         return _pageHeight - y;
     }
     
@@ -798,6 +799,12 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
         }
         img.clearBytes();
         img.setXObject(xobject);
+    }
+
+    @Override
+    public void drawLinearGradient(FSLinearGradient backgroundLinearGradient, Shape bounds) {
+        PDShading shading = GradientHelper.createLinearGradient(this, getTransform(), backgroundLinearGradient, bounds);
+        _cp.paintGradient(shading);
     }
 
     @Override

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
@@ -9,6 +9,7 @@ import org.apache.pdfbox.pdmodel.documentinterchange.markedcontent.PDPropertyLis
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.graphics.shading.PDShading;
 import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
 import org.apache.pdfbox.pdmodel.graphics.state.RenderingMode;
 import org.apache.pdfbox.util.Matrix;
@@ -365,6 +366,14 @@ public class PdfContentStreamAdapter {
             cs.endMarkedContent();
         } catch (IOException e) {
             logAndThrow("endMarkedContent", e);
+        }
+    }
+
+    public void paintGradient(PDShading shading) {
+        try {
+            cs.shadingFill(shading);
+        } catch (IOException e) {
+            logAndThrow("paintGradient", e);
         }
     }
 }


### PR DESCRIPTION
Limitations:
+ Does not yet validate linear-gradient CSS. Specifically, the linear-gradient must specify at least two color stops with the first at 0% (or unspecified) and the last at 100% (or unspecified). If you violate the linear-gradient contract you'll get an exception.
+ Does not support repeating-linear-gradient.

Notes:
+ Supports linear gradients in transformed elements.

Example (renders identical to Chrome):
````html
<html>
<head>
<style>
@page {
  size: 200px 400px;
  margin: 0;
}
body {
  max-width: 200px;
  margin: 0;
}
div {
  margin: 10px 7px;
  border: 1px solid black;
  height: 30px;
}
#one {
  background-image: linear-gradient(to left, red, blue);
}
#two {
  background-image: linear-gradient(to right, green, blue, red, orange);
}
#three {
  background-image: linear-gradient(to bottom, #00f, #f00);
}
#four {
  background-image: linear-gradient(45deg, red, blue);
}
#five {
  background-image: linear-gradient(to left, orange 0%, blue 100%);
}
#six {
  background-image: linear-gradient(to right, blue, orange 40px, black 100px, green);
}
#seven {
  background-image: linear-gradient(to right, green, red 20px, blue, orange 60px, black);
}
#eight {
  height: 60px;
  padding: 10px;
  background-image: linear-gradient(to top, green, red 20%, blue);
}
</style>
</head>
<body>
<div id="one"></div>
<div id="two"></div>
<div id="three"></div>
<div id="four"></div>
<div id="five"></div>
<div id="six"></div>
<div id="seven"></div>
<div id="eight"></div>
</body>
</html>



````