### PR TITLE
Fix link shapes #477

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -288,7 +288,7 @@ public class PdfBoxFastLinkManager {
 		// We must flip the whole thing upside down
 		transformForQuads.translate(0, targetArea.getHeight());
 		transformForQuads.scale(1, -1);
-		transformForQuads.concatenate(transform);
+		transformForQuads.concatenate(AffineTransform.getScaleInstance(transform.getScaleX(), transform.getScaleX()));
 		Area area = new Area(linkShape);
 		PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
 		double[] vals = new double[6];

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -281,7 +281,7 @@ public class PdfBoxFastLinkManager {
 		return true;
 	}
 
-	private float[] mapShapeToQuadPoints(AffineTransform transform, Shape linkShape, Rectangle2D targetArea) {
+	static float[] mapShapeToQuadPoints(AffineTransform transform, Shape linkShape, Rectangle2D targetArea) {
 		List<Point2D.Float> points = new ArrayList<Point2D.Float>();
 		AffineTransform transformForQuads = new AffineTransform();
 		transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -318,7 +318,7 @@ public class PdfBoxFastLinkManager {
 		KongAlgo algo = new KongAlgo(points);
 		algo.runKong();
 
-		float ret[] = new float[algo.getTriangles().size() * 8];
+		float[] ret = new float[algo.getTriangles().size() * 8];
 		int i = 0;
 		for (Triangle triangle : algo.getTriangles()) {
 			ret[i++] = triangle.a.x;
@@ -335,6 +335,7 @@ public class PdfBoxFastLinkManager {
 			ret[i++] = triangle.c.y;
 		}
 
+		//noinspection ConstantConditions
 		if (ret.length % 8 != 0)
 			throw new IllegalStateException("Not exact 8xn QuadPoints!");
 		for (; i < ret.length; i += 2) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -14,8 +14,6 @@ import com.openhtmltopdf.util.XRLog;
 
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDObjectReference;
-import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
 import org.apache.pdfbox.pdmodel.interactive.action.PDAction;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionGoTo;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionJavaScript;
@@ -270,19 +268,27 @@ public class PdfBoxFastLinkManager {
 		annot.setPrinted(true);
 		
 		if (linkShape != null) {
-			float[] quadPoints = mapShapeToQuadPoints(transform, linkShape, targetArea);
+			QuadPointShape quadPointsResult = mapShapeToQuadPoints(transform, linkShape, targetArea);
 			/*
 			 * Is this not an area shape? Then we can not setup quads - ignore this shape.
 			 */
-			if (quadPoints.length == 0)
+			if (quadPointsResult.quadPoints.length == 0)
 				return false;
-			annot.setQuadPoints(quadPoints);
+			annot.setQuadPoints(quadPointsResult.quadPoints);
+			Rectangle2D reducedTarget = quadPointsResult.boundingBox;
+			annot.setRectangle(new PDRectangle((float) reducedTarget.getMinX(), (float) reducedTarget.getMinY(),
+					(float) reducedTarget.getWidth(), (float) reducedTarget.getHeight()));
 		}
 		return true;
 	}
 
-	static float[] mapShapeToQuadPoints(AffineTransform transform, Shape linkShape, Rectangle2D targetArea) {
-		List<Point2D.Float> points = new ArrayList<Point2D.Float>();
+	static class QuadPointShape {
+		float[] quadPoints;
+		Rectangle2D boundingBox;
+	}
+	
+	static QuadPointShape mapShapeToQuadPoints(AffineTransform transform, Shape linkShape, Rectangle2D targetArea) {
+		List<Point2D.Float> points = new ArrayList<>();
 		AffineTransform transformForQuads = new AffineTransform();
 		transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());
 		// We must flip the whole thing upside down
@@ -318,6 +324,11 @@ public class PdfBoxFastLinkManager {
 		KongAlgo algo = new KongAlgo(points);
 		algo.runKong();
 
+		float minX = (float) targetArea.getMaxX();
+		float maxX = (float) targetArea.getMinX();
+		float minY = (float) targetArea.getMaxY();
+		float maxY = (float) targetArea.getMinY();
+		
 		float[] ret = new float[algo.getTriangles().size() * 8];
 		int i = 0;
 		for (Triangle triangle : algo.getTriangles()) {
@@ -333,6 +344,17 @@ public class PdfBoxFastLinkManager {
 
 			ret[i++] = triangle.c.x;
 			ret[i++] = triangle.c.y;
+			
+			for (Point2D.Float p : new Point2D.Float[] { triangle.a, triangle.b, triangle.c }) {
+				float x = p.x;
+				float y = p.y;
+
+				minX = Math.min(x, minX);
+				minY = Math.min(y, minY);
+
+				maxX = Math.max(x, maxX);
+				maxY = Math.max(y, maxY);
+			}
 		}
 
 		//noinspection ConstantConditions
@@ -341,10 +363,17 @@ public class PdfBoxFastLinkManager {
 		for (; i < ret.length; i += 2) {
 			if (ret[i] < targetArea.getMinX() || ret[i] > targetArea.getMaxX())
 				throw new IllegalStateException("Invalid rectangle calculation. Map shape is out of bound.");
-			if (ret[i + 1] < targetArea.getMinY() || ret[i + 1] > targetArea.getMaxY())
+			if (ret[i + 1] < targetArea.getMinY() || ret[
+					i + 1] > targetArea.getMaxY())
 				throw new IllegalStateException("Invalid rectangle calculation. Map shape is out of bound.");
 		}
-		return ret;
+
+		QuadPointShape result = new QuadPointShape();
+		result.quadPoints = ret;
+		Rectangle2D.Float boundingRectangle = new Rectangle2D.Float(minX, minY, maxX - minX, maxY - minY);
+		Rectangle.intersect(targetArea, boundingRectangle, boundingRectangle);
+		result.boundingBox = boundingRectangle;
+		return result;
 	}
 
 	private void addLinkToPage(PDPage page, PDAnnotationLink annot, Box anchor, Box target) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
@@ -271,7 +271,7 @@ public class PdfBoxLinkManager {
 		// We must flip the whole thing upside down
 		transformForQuads.translate(0, targetArea.getHeight());
 		transformForQuads.scale(1, -1);
-		transformForQuads.concatenate(transform);
+		transformForQuads.concatenate(AffineTransform.getScaleInstance(transform.getScaleX(), transform.getScaleX()));
 		Area area = new Area(linkShape);
 		PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
 		double[] vals = new double[6];

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxLinkManager.java
@@ -4,8 +4,6 @@ import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.extend.NamespaceHandler;
 import com.openhtmltopdf.extend.ReplacedElement;
 import com.openhtmltopdf.layout.SharedContext;
-import com.openhtmltopdf.pdfboxout.quads.KongAlgo;
-import com.openhtmltopdf.pdfboxout.quads.Triangle;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.PageBox;
@@ -255,13 +253,16 @@ public class PdfBoxLinkManager {
 		annot.setRectangle(new PDRectangle((float) targetArea.getMinX(), (float) targetArea.getMinY(),
 				(float) targetArea.getWidth(), (float) targetArea.getHeight()));
 		if (linkShape != null) {
-			float[] quadPoints = mapShapeToQuadPoints(transform, linkShape, targetArea);
+			PdfBoxFastLinkManager.QuadPointShape quadPointsResult = mapShapeToQuadPoints(transform, linkShape, targetArea);
 			/*
 			 * Is this not an area shape? Then we can not setup quads - ignore this shape.
 			 */
-			if (quadPoints.length == 0)
+			if (quadPointsResult.quadPoints.length == 0)
 				return false;
-			annot.setQuadPoints(quadPoints);
+			annot.setQuadPoints(quadPointsResult.quadPoints);
+			Rectangle2D reducedTarget = quadPointsResult.boundingBox;
+			annot.setRectangle(new PDRectangle((float) reducedTarget.getMinX(), (float) reducedTarget.getMinY(),
+					(float) reducedTarget.getWidth(), (float) reducedTarget.getHeight()));
 		}
 		return true;
 	}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/KongAlgo.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/quads/KongAlgo.java
@@ -10,11 +10,11 @@ import java.util.List;
  *         https://www.sunshine2k.de/coding/java/Polygon/Kong/Kong.html
  */
 public class KongAlgo {
-	private static boolean isDebug = false;
+	private static final boolean isDebug = false;
 
-	private List<Point2D.Float> points;
-	private List<Point2D.Float> nonconvexPoints;
-	private List<Triangle> triangles;
+	private final List<Point2D.Float> points;
+	private final List<Point2D.Float> nonconvexPoints;
+	private final List<Triangle> triangles;
 
 	// orientation of polygon - true = clockwise, false = counterclockwise
 	private boolean isCw;


### PR DESCRIPTION
Only use the scaling from the given transform

For whatever reason we only want the DPI scaling from the given transform, and
not any other property of the transform.

When adding a link to process later, the transform has at that moment also a translate in it. 

Before 1ffd27175926d8d25294500f71cc39f651421fc8 the used transform was after the last page was 
processed. At that moment the transform only had a scale component and no translate. 