### PR TITLE
svg backend: use openhtmltopdf UserAgentCallback for fetching external resources #444

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/SVGDrawer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/SVGDrawer.java
@@ -12,18 +12,20 @@ import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.RenderingContext;
 
 public interface SVGDrawer extends Closeable {
-    public void importFontFaceRules(List<FontFaceRule> fontFaces,
+    void importFontFaceRules(List<FontFaceRule> fontFaces,
             SharedContext shared);
 
-    public SVGImage buildSVGImage(Element svgElement, Box box, CssContext cssContext, double cssWidth,
+    SVGImage buildSVGImage(Element svgElement, Box box, CssContext cssContext, double cssWidth,
             double cssHeight, double dotsPerPixel);
 
-    public static interface SVGImage {
-        public int getIntrinsicWidth();
+    default void withUserAgent(UserAgentCallback userAgentCallback) {}
 
-        public int getIntrinsicHeight();
+    interface SVGImage {
+        int getIntrinsicWidth();
 
-        public void drawSVG(OutputDevice outputDevice, RenderingContext ctx,
+        int getIntrinsicHeight();
+
+        void drawSVG(OutputDevice outputDevice, RenderingContext ctx,
                 double x, double y);
     }
 }

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/svg-custom-protocol.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/svg-custom-protocol.pdf
@@ -1,0 +1,116 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20200523145030+02'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 30.0 30.0]
+/Parent 2 0 R
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 116
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+0 30 m
+30 30 l
+30 0.0375 l
+0 0.0375 l
+0 30 l
+h
+W
+n
+q
+1 0 0 1 6 10.5 cm
+/Form1 Do
+Q
+Q
+
+endstream
+endobj
+6 0 obj
+<<
+/XObject <<
+/Form1 7 0 R
+>>
+>>
+endobj
+7 0 obj
+<<
+/Length 168
+/Type /XObject
+/Subtype /Form
+/Resources <<
+/ExtGState 8 0 R
+>>
+/BBox [0.0 0.0 18.0 18.0]
+/Filter /FlateDecode
+/Matrix [0.75 0.0 0.0 0.75 0.0 0.0]
+>>
+stream
+xœÍOA
+Â0¼Ï+öí¦Zê^­ ´j«X¡ôûNÚRêÁ»$³vg’I'BÅm¤÷#²’tªC¯ÅOJMÜŠR’&…©I‘djNLrÂ#»œÏ
+-¤|ÔNWĞÃâ1İÁ³Í"]-Ò]ıºùú¼ßJYÅPI®£UåräÃb<Ò&8i®Ãÿ õÄßiUÄk9òå7*¦ëoòWÈ
+endstream
+endobj
+8 0 obj
+<<
+/gs1 9 0 R
+>>
+endobj
+9 0 obj
+<<
+/Type /ExtGState
+/BM /Compatible
+>>
+endobj
+xref
+0 10
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000226 00000 n
+0000000336 00000 n
+0000000505 00000 n
+0000000554 00000 n
+0000000922 00000 n
+0000000954 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<99DC2B8A0F4793E22298168F16B2C3D4> <99DC2B8A0F4793E22298168F16B2C3D4>]
+/Size 10
+>>
+startxref
+1008
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/svg-external-file-load-blocked.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/svg-external-file-load-blocked.pdf
@@ -1,0 +1,77 @@
+%PDF-1.4
+%цдья
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20200523142415+02'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 30.0 30.0]
+/Parent 2 0 R
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 84
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+0 30 m
+30 30 l
+30 0.0375 l
+0 0.0375 l
+0 30 l
+h
+W
+n
+Q
+
+endstream
+endobj
+6 0 obj
+<<
+>>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000226 00000 n
+0000000336 00000 n
+0000000472 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<106808D03B104E08458EA8F8C9EF2E37> <106808D03B104E08458EA8F8C9EF2E37>]
+/Size 7
+>>
+startxref
+493
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/svg-external-file-whitelist-file-protocol.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/svg-external-file-whitelist-file-protocol.pdf
@@ -1,0 +1,115 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20200523144310+02'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 30.0 30.0]
+/Parent 2 0 R
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 116
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+0 30 m
+30 30 l
+30 0.0375 l
+0 0.0375 l
+0 30 l
+h
+W
+n
+q
+1 0 0 1 6 10.5 cm
+/Form1 Do
+Q
+Q
+
+endstream
+endobj
+6 0 obj
+<<
+/XObject <<
+/Form1 7 0 R
+>>
+>>
+endobj
+7 0 obj
+<<
+/Length 165
+/Type /XObject
+/Subtype /Form
+/Resources <<
+/ExtGState 8 0 R
+>>
+/BBox [0.0 0.0 18.0 18.0]
+/Filter /FlateDecode
+/Matrix [0.75 0.0 0.0 0.75 0.0 0.0]
+>>
+stream
+xœÅOA
+Â0¼Ï+öí¦Zê^­ ´j«¨Pú}'m("Ş%Ù™0™İL8°TÜJî pß"+IZ´š¸­$Í*S“*+Ôœ˜”,bRy?;\lñ •“7y\Å‚GšÁ³Í&›ºzä›öyñíq»–ºá”«©?e’<ò.8éÎãÇşV§Õï´*;ÖKÙóå¦ëÛ±V@
+endstream
+endobj
+8 0 obj
+<<
+/gs1 9 0 R
+>>
+endobj
+9 0 obj
+<<
+/Type /ExtGState
+/BM /Compatible
+>>
+endobj
+xref
+0 10
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000226 00000 n
+0000000336 00000 n
+0000000505 00000 n
+0000000554 00000 n
+0000000919 00000 n
+0000000951 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<1364800DBDE635AF529B3EF3A3CE206D> <1364800DBDE635AF529B3EF3A3CE206D>]
+/Size 10
+>>
+startxref
+1005
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/solid.svg
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="10" width="10">
+    <circle id="icon-1" cx="5" cy="5" r="4" stroke="black" stroke-width="1" fill="red" />
+</svg>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/svg-custom-protocol.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/svg-custom-protocol.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<style>
+@page  {
+    size: 40px 40px;
+    margin: 0;
+    padding:0;
+}
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="18"
+     height="18">
+    <use xlink:href="custom:/solid.svg#icon-1" width="18" height="18" fill="red" />
+</svg>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/svg-external-file-load-blocked.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/svg-external-file-load-blocked.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<style>
+@page  {
+    size: 40px 40px;
+    margin: 0;
+    padding:0;
+}
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="18"
+     height="18">
+    <use xlink:href="solid.svg#icon-1" width="18" height="18" fill="red" />
+</svg>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/svg-external-file-whitelist-file-protocol.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/svg-external-file-whitelist-file-protocol.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<style>
+@page  {
+    size: 40px 40px;
+    margin: 0;
+    padding:0;
+}
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="18"
+     height="18">
+    <use xlink:href="solid.svg#icon-1" width="18" height="18" fill="red" />
+</svg>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1,8 +1,13 @@
 package com.openhtmltopdf.visualregressiontests;
 
-import java.io.File;
+import java.io.*;
+
 import static org.junit.Assert.assertTrue;
-import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import com.openhtmltopdf.extend.FSStream;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1116,6 +1121,37 @@ public class VisualRegressionTest {
     @Test
     public void testIssue484ImgSrcDataImageSvgBase64() throws IOException {
         assertTrue(vt.runTest("issue-484-data-image-svg-xml-base64", TestSupport.WITH_SVG));
+    }
+
+
+    @Test
+    public void testSVGLoadBlocked() throws IOException {
+        assertTrue(vt.runTest("svg-external-file-load-blocked", TestSupport.WITH_SVG));
+    }
+
+    @Test
+    public void testSVGLoadWhiteListFileProtocol() throws IOException {
+        assertTrue(vt.runTest("svg-external-file-whitelist-file-protocol",
+                (builder) -> builder.useSVGDrawer(new BatikSVGDrawer(SvgScriptMode.SECURE, Collections.singleton("file")))));
+    }
+
+    @Test
+    public void testSVGLoadCustomProtocol() throws IOException {
+        assertTrue(vt.runTest("svg-custom-protocol", (builder -> {
+            builder.useProtocolsStreamImplementation(url -> new FSStream() {
+
+                @Override
+                public InputStream getStream() {
+                    return new ByteArrayInputStream("<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"10\" width=\"10\"><circle id=\"icon-1\" cx=\"5\" cy=\"5\" r=\"4\" stroke=\"black\" stroke-width=\"1\" fill=\"green\" /></svg>".getBytes(StandardCharsets.UTF_8));
+                }
+
+                @Override
+                public Reader getReader() {
+                    return new InputStreamReader(getStream(), StandardCharsets.UTF_8);
+                }
+            }, "custom");
+            builder.useSVGDrawer(new BatikSVGDrawer(SvgScriptMode.SECURE, Collections.singleton("custom")));
+        })));
     }
 
     // TODO:

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -163,6 +163,10 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
         
         PdfBoxUserAgent userAgent = new PdfBoxUserAgent(_outputDevice);
 
+        if (_svgImpl != null) {
+            _svgImpl.withUserAgent(userAgent);
+        }
+
         userAgent.setProtocolsStreamFactory(state._streamFactoryMap);
         
         if (state._resolver != null) {

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGImage.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGImage.java
@@ -1,8 +1,10 @@
 package com.openhtmltopdf.svgsupport;
 
 import java.awt.Point;
+import java.util.Set;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.extend.UserAgentCallback;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.transcoder.SVGAbstractTranscoder;
 import org.apache.batik.transcoder.TranscoderException;
@@ -28,6 +30,7 @@ public class BatikSVGImage implements SVGImage {
     private final double dotsPerPixel;
     private OpenHtmlFontResolver fontResolver;
     private final PDFTranscoder pdfTranscoder;
+    private UserAgentCallback userAgentCallback;
 
     public BatikSVGImage(Element svgElement, Box box, double cssWidth, double cssHeight,
             double cssMaxWidth, double cssMaxHeight, double dotsPerPixel) {
@@ -98,9 +101,13 @@ public class BatikSVGImage implements SVGImage {
         this.fontResolver = fontResolver;
     }
     
-    public void setSecurityOptions(boolean allowScripts, boolean allowExternalResources) {
-        this.pdfTranscoder.setSecurityOptions(allowScripts, allowExternalResources);
+    public void setSecurityOptions(boolean allowScripts, boolean allowExternalResources, Set<String> allowedProtocols) {
+        this.pdfTranscoder.setSecurityOptions(allowScripts, allowExternalResources, allowedProtocols);
         this.pdfTranscoder.addTranscodingHint(SVGAbstractTranscoder.KEY_EXECUTE_ONLOAD, allowScripts);
+    }
+
+    public void setUserAgentCallback(UserAgentCallback userAgentCallback) {
+        this.userAgentCallback = userAgentCallback;
     }
     
     public Integer parseLength(String attrValue) {
@@ -159,7 +166,7 @@ public class BatikSVGImage implements SVGImage {
         }
 
         pdfTranscoder.setRenderingParameters(outputDevice, ctx, x, y,
-                fontResolver);
+                fontResolver, userAgentCallback);
 
         try {
             DOMImplementation impl = SVGDOMImplementation

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlDocumentLoader.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlDocumentLoader.java
@@ -1,0 +1,40 @@
+package com.openhtmltopdf.svgsupport;
+
+import com.openhtmltopdf.extend.UserAgentCallback;
+import com.openhtmltopdf.util.XRLog;
+import org.apache.batik.bridge.DocumentLoader;
+import org.apache.batik.bridge.UserAgent;
+import org.w3c.dom.Document;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class OpenHtmlDocumentLoader extends DocumentLoader {
+
+    private final UserAgentCallback userAgentCallback;
+
+    public OpenHtmlDocumentLoader(UserAgent userAgent, UserAgentCallback userAgentCallback) {
+        super(userAgent);
+        this.userAgentCallback = userAgentCallback;
+    }
+
+
+    @Override
+    public Document loadDocument(String uri) throws IOException {
+        try {
+            // special handling of relative uri in case of file protocol, we receive something like "file:file.svg"
+            // The path will be null, but the scheme specific part will be not null
+            URI parsedURI = new URI(uri);
+            if ("file".equals(parsedURI.getScheme()) && parsedURI.getPath() == null && parsedURI.getSchemeSpecificPart() != null) {
+                uri = userAgentCallback.resolveURI(parsedURI.getSchemeSpecificPart());
+            } else if (!parsedURI.isAbsolute()) {
+                uri = userAgentCallback.resolveURI(uri);
+            }
+        } catch (URISyntaxException uriSyntaxException) {
+            XRLog.exception("URI syntax exception while loading external svg resource: " + uri, uriSyntaxException);
+        }
+        return super.loadDocument(uri, new ByteArrayInputStream(userAgentCallback.getBinaryResource(uri)));
+    }
+}

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlUserAgent.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlUserAgent.java
@@ -7,16 +7,20 @@ import org.apache.batik.util.ParsedURL;
 import com.openhtmltopdf.svgsupport.PDFTranscoder.OpenHtmlFontResolver;
 import com.openhtmltopdf.util.XRLog;
 
+import java.util.Set;
+
 public class OpenHtmlUserAgent extends UserAgentAdapter {
 
 	private final OpenHtmlFontResolver resolver;
     private final boolean allowScripts;
     private final boolean allowExternalResources;
+    private final Set<String> allowedProtocols;
 
-	public OpenHtmlUserAgent(OpenHtmlFontResolver resolver, boolean allowScripts, boolean allowExternalResources) {
+    public OpenHtmlUserAgent(OpenHtmlFontResolver resolver, boolean allowScripts, boolean allowExternalResources, Set<String> allowedProtocols) {
 		this.resolver = resolver;
         this.allowScripts = allowScripts;
         this.allowExternalResources = allowExternalResources;
+        this.allowedProtocols = allowedProtocols;
 	}
 
 	@Override
@@ -34,7 +38,7 @@ public class OpenHtmlUserAgent extends UserAgentAdapter {
     
     @Override
     public void checkLoadExternalResource(ParsedURL resourceURL, ParsedURL docURL) throws SecurityException {
-        if (!this.allowExternalResources) {
+        if (!this.allowExternalResources && (allowedProtocols == null || !allowedProtocols.contains(resourceURL.getProtocol()))) {
             XRLog.exception("Tried to fetch external resource from SVG. Refusing. Details: " + resourceURL + ", " + docURL);
             throw new SecurityException("Tried to fetch external resource (" + resourceURL + ") from SVG. Refused!");
         }


### PR DESCRIPTION
Hi @danfickle , this PR is a work in progress for making more coherent the loading of resources in the svg backend (see issue #444)

Basically we inject our own `UserAgentCallback` which contain all the logic inside a custom `DocumentLoader`.

There still some open point:

 - currently it will block by default the loading through the `UserAgentCallback` as `allowExternalResources` is set false by default. Unfortunately at the moment it's a binary choice. We can totally open or totally close the access to the external world. How can we improve that so we can, for example, only allow some specific protocols (most likely a custom one)? Maybe we can extend the interface `UserAgentCallback` so he can provide some - customizable by the user - logic for checking the load of external resources ? Or maybe we pass a whitelist of protocol in the svg builder?

- tests :)

What do you think? :)