### PR TITLE
Add possibility to fetch all logged warning programmatically, see #76

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.logging.Level;
 
 import com.openhtmltopdf.css.sheet.FontFaceRule;
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -99,8 +100,8 @@ public class StyleReference {
         AttributeResolver attRes = new StandardAttributeResolver(_nsh, _uac, ui);
 
         List<StylesheetInfo> infos = getStylesheets();
-        
-        XRLog.match("media = " + _context.getMedia());
+
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.MATCH_MEDIA_IS, _context.getMedia());
         
         _matcher = new com.openhtmltopdf.css.newmatch.Matcher(
                 new DOMTreeResolver(), 
@@ -128,7 +129,7 @@ public class StyleReference {
                     
                     result.add(sheet);
                 } else {
-                    XRLog.load(Level.WARNING, "Unable to load CSS from "+info.getUri());
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_UNABLE_TO_LOAD_CSS_FROM_URI, info.getUri());
                 }
             }
         }
@@ -212,10 +213,9 @@ public class StyleReference {
         info.setOrigin(StylesheetInfo.AUTHOR);
         if (_stylesheetFactory.containsStylesheet(uri)) {
             _stylesheetFactory.removeCachedStylesheet(uri);
-            XRLog.cssParse("Removing stylesheet '" + uri + "' from cache by request.");
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.CSS_PARSE_REMOVING_STYLESHEET_URI_FROM_CACHE_BY_REQUEST, uri);
         } else {
-            XRLog.cssParse("Requested removing stylesheet '" + uri + "', but it's not in cache.");
-
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.CSS_PARSE_REQUESTED_REMOVING_STYLESHEET_URI_NOT_IN_CACHE, uri);
         }
     }
     
@@ -264,7 +264,7 @@ public class StyleReference {
         // TODO: here we should also get user stylesheet from userAgent
 
         long el = System.currentTimeMillis() - st;
-        XRLog.load("TIME: parse stylesheets  " + el + "ms");
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_PARSE_STYLESHEETS_TIME, el);
 
         return infos;
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StylesheetFactoryImpl.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StylesheetFactoryImpl.java
@@ -31,6 +31,7 @@ import com.openhtmltopdf.css.sheet.Stylesheet;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 import com.openhtmltopdf.extend.UserAgentCallback;
 import com.openhtmltopdf.resource.CSSResource;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 /**
@@ -64,10 +65,8 @@ public class StylesheetFactoryImpl implements StylesheetFactory {
 
     public StylesheetFactoryImpl(UserAgentCallback userAgentCallback) {
         _userAgentCallback = userAgentCallback;
-        _cssParser = new CSSParser(new CSSErrorHandler() {
-            public void error(String uri, String message) {
-                XRLog.cssParse(Level.WARNING, "(" + uri + ") " + message);
-            }
+        _cssParser = new CSSParser((uri, message) -> {
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.CSS_PARSE_GENERIC_MESSAGE, uri, message);
         });
     }
 
@@ -75,7 +74,7 @@ public class StylesheetFactoryImpl implements StylesheetFactory {
         try {
             return _cssParser.parseStylesheet(info.getUri(), info.getOrigin(), reader);
         } catch (IOException e) {
-            XRLog.cssParse(Level.WARNING, "Couldn't parse stylesheet at URI " + info.getUri() + ": " + e.getMessage(), e);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.CSS_PARSE_COULDNT_PARSE_STYLESHEET_AT_URI, info.getUri(), e.getMessage(), e);
             return new Stylesheet(info.getUri(), info.getOrigin());
         }
     }
@@ -170,7 +169,7 @@ public class StylesheetFactoryImpl implements StylesheetFactory {
      */
     //TODO: this looks a bit odd
     public Stylesheet getStylesheet(StylesheetInfo info) {
-        XRLog.load("Requesting stylesheet: " + info.getUri());
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_REQUESTING_STYLESHEET_AT_URI, info.getUri());
 
         Stylesheet s = getCachedStylesheet(info.getUri());
         if (s == null && !containsStylesheet(info.getUri())) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
+
 import com.openhtmltopdf.css.parser.CSSErrorHandler;
 import com.openhtmltopdf.css.parser.CSSParser;
 import com.openhtmltopdf.css.parser.PropertyValue;
@@ -42,6 +44,7 @@ import com.openhtmltopdf.css.parser.property.SizePropertyBuilder;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 import com.openhtmltopdf.css.style.FSDerivedValue;
 import com.openhtmltopdf.css.style.derived.DerivedValueFactory;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 
@@ -1959,11 +1962,8 @@ public final class CSSName implements Comparable<CSSName> {
     }
 
     static {
-        CSSParser parser = new CSSParser(new CSSErrorHandler() {
-            @Override
-            public void error(String uri, String message) {
-                XRLog.cssParse("(" + uri + ") " + message);
-            }
+        CSSParser parser = new CSSParser((uri, message) -> {
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.CSS_PARSE_GENERIC_MESSAGE, uri, message);
         });
         for (Iterator<CSSName> i = ALL_PRIMITIVE_PROPERTY_NAMES.values().iterator(); i.hasNext(); ) {
             CSSName cssName = i.next();
@@ -1972,7 +1972,7 @@ public final class CSSName implements Comparable<CSSName> {
                         cssName, StylesheetInfo.USER_AGENT, cssName.initialValue);
 
                 if (value == null) {
-                    XRLog.exception("Unable to derive initial value for " + cssName);
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_CSS_UNABLE_TO_DERIVE_INITIAL_VALUE_FOR_CLASSNAME, cssName);
                 } else {
                     cssName.initialDerivedValue = DerivedValueFactory.newDerivedValue(
                             null,

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/ValueConstants.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/ValueConstants.java
@@ -23,6 +23,7 @@ package com.openhtmltopdf.css.constants;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.css.parser.CSSValue;
 import com.openhtmltopdf.util.GeneralUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import com.openhtmltopdf.util.XRRuntimeException;
 
@@ -120,8 +121,7 @@ public final class ValueConstants {
             case CSSPrimitiveValue.CSS_STRING:
                 return true;
             case CSSPrimitiveValue.CSS_UNKNOWN:
-                XRLog.cascade(Level.WARNING, "Asked whether type was absolute, given CSS_UNKNOWN as the type. " +
-                        "Might be one of those funny values like background-position.");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.CASCADE_IS_ABSOLUTE_CSS_UNKNOWN_GIVEN);
                 GeneralUtil.dumpShortException(new Exception());
                 // fall-through
             default:

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
@@ -28,12 +28,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Level;
 
 import com.openhtmltopdf.css.constants.MarginBoxName;
 import com.openhtmltopdf.css.extend.AttributeResolver;
 import com.openhtmltopdf.css.extend.StylesheetFactory;
 import com.openhtmltopdf.css.extend.TreeResolver;
 import com.openhtmltopdf.css.sheet.*;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 
@@ -149,7 +151,7 @@ public class Matcher {
     Mapper createDocumentMapper(List<Stylesheet> stylesheets, String medium) {
         java.util.TreeMap<String,Selector> sorter = new java.util.TreeMap<String,Selector>();
         addAllStylesheets(stylesheets, sorter, medium);
-        XRLog.match("Matcher created with " + sorter.size() + " selectors");
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.MATCH_MATCHER_CREATED_WITH_SELECTOR, sorter.size());
         return new Mapper(sorter.values());
     }
     

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
@@ -22,6 +22,7 @@ package com.openhtmltopdf.css.newmatch;
 import com.openhtmltopdf.css.extend.AttributeResolver;
 import com.openhtmltopdf.css.extend.TreeResolver;
 import com.openhtmltopdf.css.sheet.Ruleset;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.util.logging.Level;
@@ -299,7 +300,7 @@ public class Selector {
     public void setPseudoElement(String pseudoElement) {
         if (_pe != null) {
             addUnsupportedCondition();
-            XRLog.match(Level.WARNING, "Trying to set more than one pseudo-element");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.MATCH_TRYING_TO_SET_MORE_THAN_ONE_PSEUDO_ELEMENT);
         } else {
             _specificityD++;
             _pe = pseudoElement;
@@ -408,7 +409,7 @@ public class Selector {
                 sibling = treeRes.getPreviousSiblingElement(e);
                 break;
             default:
-                XRLog.exception("Bad sibling axis");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_SELECTOR_BAD_SIBLING_AXIS);
         }
         return sibling;
     }
@@ -424,7 +425,7 @@ public class Selector {
         }
         if (_pe != null) {
             conditions.add(Condition.createUnsupportedCondition());
-            XRLog.match(Level.WARNING, "Trying to append conditions to pseudoElement " + _pe);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.MATCH_TRYING_TO_APPEND_CONDITIONS_TO_PSEUDO_ELEMENT, _pe);
         }
         conditions.add(c);
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -25,6 +25,7 @@ import com.openhtmltopdf.css.extend.TreeResolver;
 import com.openhtmltopdf.css.newmatch.Selector;
 import com.openhtmltopdf.css.parser.property.PropertyBuilder;
 import com.openhtmltopdf.css.sheet.*;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.ThreadCtx;
 import com.openhtmltopdf.util.XRLog;
 
@@ -257,7 +258,7 @@ public class CSSParser {
                     	String resolved = ThreadCtx.get().sharedContext().getUserAgentCallback().resolveUri(baseUri, uri);
                     	
                     	if (resolved == null) {
-                    		XRLog.load(Level.INFO, "URI resolver rejected resolving CSS import at (" + uri + ")");
+                    	    XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_URI_RESOLVER_REJECTED_RESOLVING_CSS_IMPORT_AT_URI, uri);
                     	}
                     	
                     	info.setUri(resolved);
@@ -1950,7 +1951,7 @@ public class CSSParser {
                 String uriResolved = ThreadCtx.get().sharedContext().getUserAgentCallback().resolveUri(_URI, uriResult);
 
                 if (uriResolved == null) {
-                	XRLog.load(Level.INFO, "URI resolver rejected resolving URI at (" + uriResult + ") in CSS stylehseet");
+                    XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_URI_RESOLVER_REJECTED_RESOLVING_URI_AT_URI_IN_CSS_STYLESHEET, uriResult);
                 }
                 
                 return uriResolved == null ? "" : uriResolved;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -52,6 +52,7 @@ import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.FSFont;
 import com.openhtmltopdf.render.FSFontMetrics;
 import com.openhtmltopdf.render.RenderingContext;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import com.openhtmltopdf.util.XRRuntimeException;
 
@@ -252,9 +253,7 @@ public class CalculatedStyle {
         try {
             isAbs = valueByName(cssName).hasAbsoluteUnit();
         } catch (Exception e) {
-            XRLog.layout(Level.WARNING, "Property " + cssName + " has an assignment we don't understand, " +
-                    "and can't tell if it's an absolute unit or not. Assuming it is not. Exception was: " +
-                    e.getMessage());
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.LAYOUT_CSS_PROPERTY_HAS_UNPROCESSABLE_ASSIGNMENT, cssName, e.getMessage());
             isAbs = false;
         }
         return isAbs;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/LengthValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/LengthValue.java
@@ -29,6 +29,7 @@ import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.css.style.CssContext;
 import com.openhtmltopdf.css.style.DerivedValue;
 import com.openhtmltopdf.css.value.FontSpecification;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 public class LengthValue extends DerivedValue {
@@ -192,23 +193,15 @@ public class LengthValue extends DerivedValue {
                 break;
             default:
                 // nothing to do, we only convert those listed above
-                XRLog.cascade(Level.WARNING,
-                        "Asked to convert " + cssName + " from relative to absolute, " +
-                        " don't recognize the datatype " +
-                        "'" + ValueConstants.stringForSACPrimitiveType(primitiveType) + "' "
-                        + primitiveType + "(" + stringValue + ")");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.CASCADE_UNKNOWN_DATATYPE_FOR_RELATIVE_TO_ABSOLUTE, cssName, ValueConstants.stringForSACPrimitiveType(primitiveType), primitiveType, stringValue);
         }
         //assert (new Float(absVal).intValue() >= 0);
 
         if (XRLog.isLoggingEnabled()) {
             if (cssName == CSSName.FONT_SIZE) {
-                XRLog.cascade(Level.FINEST, cssName + ", relative= " +
-                        relVal + " (" + stringValue + "), absolute= "
-                        + absVal);
+                XRLog.log(Level.FINEST, LogMessageId.LogMessageId4Param.CASCADE_CALC_FLOAT_PROPORTIONAL_VALUE_INFO_FONT_SIZE, cssName, relVal, stringValue, absVal);
             } else {
-                XRLog.cascade(Level.FINEST, cssName + ", relative= " +
-                        relVal + " (" + stringValue + "), absolute= "
-                        + absVal + " using base=" + baseValue);
+                XRLog.log(Level.FINEST, LogMessageId.LogMessageId5Param.CASCADE_CALC_FLOAT_PROPORTIONAL_VALUE_INFO, cssName, relVal, stringValue, absVal, baseValue);
             }
         }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/OutputDevice.java
@@ -24,6 +24,7 @@ import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.css.style.derived.BorderPropertySet;
 import com.openhtmltopdf.css.style.derived.FSLinearGradient;
 import com.openhtmltopdf.render.*;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.awt.*;
@@ -90,7 +91,7 @@ public interface OutputDevice {
     public void drawImage(FSImage image, int x, int y, boolean interpolate);
 
     default public void drawLinearGradient(FSLinearGradient backgroundLinearGradient, Shape bounds) {
-        XRLog.render(Level.WARNING, "linear-gradient(...) is not supported in this output device");
+    	XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_LINEAR_GRADIENT_IS_NOT_SUPPORTED);
     }
 
     public void draw(Shape s);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/impl/FSDefaultCacheStore.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/impl/FSDefaultCacheStore.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 
 import com.openhtmltopdf.extend.FSCacheEx;
 import com.openhtmltopdf.extend.FSCacheValue;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 
@@ -20,7 +21,7 @@ public class FSDefaultCacheStore implements FSCacheEx<String, FSCacheValue> {
     
     @Override
     public void put(String key, FSCacheValue value) {
-        XRLog.load(Level.INFO, "Putting key(" + key + ") in cache.");
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_PUTTING_KEY_IN_CACHE, key);
         _store.put(key, value);
     }
 
@@ -38,18 +39,18 @@ public class FSDefaultCacheStore implements FSCacheEx<String, FSCacheValue> {
                 _store.put(key, value);
             }
         } catch (Exception e) {
-            XRLog.exception("Could not load cache value for key(" + key + ")", e);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_CACHE_VALUE_FOR_KEY, key, e);
             value = null;
         }
-        
-        XRLog.load(Level.INFO, (value == null ? "Missed" : "Hit") + " key(" + key + ") from cache.");
+
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_CACHE_HIT_STATUS, (value == null ? "Missed" : "Hit"), key);
         return value;
     }
 
     @Override
     public FSCacheValue get(String key) {
         FSCacheValue value = _store.get(key);
-        XRLog.load(Level.INFO, (value == null ? "Missed" : "Hit") + " key(" + key + ") from cache.");
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_CACHE_HIT_STATUS, (value == null ? "Missed" : "Hit"), key);
         return value;
     }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/InlineBoxing.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/InlineBoxing.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Element;
 
 import com.openhtmltopdf.bidi.BidiSplitter;
@@ -206,10 +207,8 @@ public class InlineBoxing {
                                 }
 
                                 if (troublesomeAttemptCount > 5) {
-                                    XRLog.general(Level.SEVERE, 
-                                            "A fatal infinite loop bug was detected in the line breaking " +
-                                            "algorithm for break-word! Start-substring=[" + lbContext.getStartSubstring() + "], " +
-                                            "end=" + lbContext.getEnd());
+                                    XRLog.log(Level.SEVERE, LogMessageId.LogMessageId2Param.GENERAL_FATAL_INFINITE_LOOP_BUG_IN_LINE_BREAKING_ALGO,
+                                            lbContext.getStartSubstring(), lbContext.getEnd());
                                     throw new RuntimeException("Infinite loop bug in break-word line breaking algorithm!");
                                 }
                             }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
@@ -35,6 +35,7 @@ import com.openhtmltopdf.css.style.derived.RectPropertySet;
 import com.openhtmltopdf.newtable.TableCellBox;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.render.displaylist.TransformCreator;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.awt.*;
@@ -616,11 +617,11 @@ public class Layer {
 								params.get(2).getFloatValue(), params.get(3).getFloatValue(),
 								params.get(4).getFloatValue(), params.get(5).getFloatValue()));
 			} else if ("translate".equalsIgnoreCase(fName)) {
-				XRLog.layout(Level.WARNING, "translate function not implemented at this time");
+			    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LAYOUT_FUNCTION_NOT_IMPLEMENTED, "translate");
 			} else if ("translateX".equalsIgnoreCase(fName)) {
-				XRLog.layout(Level.WARNING, "translateX function not implemented at this time");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LAYOUT_FUNCTION_NOT_IMPLEMENTED, "translateX");
 			} else if ("translateY".equalsIgnoreCase(fName)) {
-				XRLog.layout(Level.WARNING, "translateY function not implemented at this time");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LAYOUT_FUNCTION_NOT_IMPLEMENTED, "translateY");
 			}
 		}
 	}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
@@ -29,6 +29,7 @@ import com.openhtmltopdf.render.FSFont;
 import com.openhtmltopdf.render.FSFontMetrics;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.swing.AWTFontResolver;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.ThreadCtx;
 import com.openhtmltopdf.util.XRLog;
 import org.w3c.dom.Document;
@@ -40,6 +41,7 @@ import java.text.BreakIterator;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * The SharedContext stores pseudo global variables.
@@ -139,7 +141,7 @@ public class SharedContext {
         setMedia("screen");
         this.uac = uac;
         setCss(new StyleReference(uac));
-        XRLog.render("Using CSS implementation from: " + getCss().getClass().getName());
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.RENDER_USING_CSS_IMPLEMENTATION_FROM, getCss().getClass().getName());
         setTextRenderer(tr);
         setDPI(dpi);
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/newtable/TableBox.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/newtable/TableBox.java
@@ -41,6 +41,7 @@ import com.openhtmltopdf.render.ContentLimitContainer;
 import com.openhtmltopdf.render.PageBox;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.util.ArrayUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 // Much of this code is directly inspired by (and even copied from)
@@ -420,7 +421,7 @@ public class TableBox extends BlockBox {
         ContentLimit limit = _contentLimitContainer.getContentLimit(c.getPageNo());
 
         if (limit == null) {
-            XRLog.layout(Level.WARNING, "No content limit found");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LAYOUT_NO_CONTENT_LIMIT_FOUND);
             return result;
         } else {
             if (limit.getTop() == ContentLimit.UNDEFINED ||

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
@@ -6,8 +6,11 @@ import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.layout.Layer;
 import com.openhtmltopdf.swing.NaiveUserAgent;
 
+import com.openhtmltopdf.util.Diagnostic;
+import com.openhtmltopdf.util.ThreadCtx;
 import org.w3c.dom.Document;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -15,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Baseclass for all RendererBuilders (PDF and Java2D), has all common settings
@@ -60,7 +64,8 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 		public String _preferredTransformerFactoryImplementationClass = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
 		public String _preferredDocumentBuilderFactoryImplementationClass = "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl";
 		public boolean _useFastRenderer = false;
-	}
+		public Consumer<Diagnostic> _diagnosticConsumer;
+    }
 
 	protected final TBaseRendererBuilderState state;
 
@@ -496,6 +501,15 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
     public TFinalClass useFont(FSSupplier<InputStream> supplier, String fontFamily) {
         return this.useFont(supplier, fontFamily, 400, FontStyle.NORMAL, true);
     }
+
+	public TFinalClass withDiagnosticConsumer(Consumer<Diagnostic> diagnosticConsumer) {
+		state._diagnosticConsumer = diagnosticConsumer;
+		return (TFinalClass) this;
+	}
+
+	protected Closeable applyDiagnosticConsumer() {
+		return ThreadCtx.applyDiagnosticConsumer(state._diagnosticConsumer);
+	}
 
 	public enum TextDirection {
 		RTL, LTR

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplier.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplier.java
@@ -2,9 +2,11 @@ package com.openhtmltopdf.outputdevice.helper;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.logging.Level;
 
 import com.openhtmltopdf.extend.FSSupplier;
 import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 public class FontFaceFontSupplier implements FSSupplier<InputStream> {
@@ -21,7 +23,7 @@ public class FontFaceFontSupplier implements FSSupplier<InputStream> {
         byte[] font1 = ctx.getUserAgentCallback().getBinaryResource(src);
         
         if (font1 == null) {
-            XRLog.exception("Could not load @font-face font: " + src);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT_FACE, src);
             return null;
         }
         

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -38,12 +38,14 @@ import com.openhtmltopdf.css.value.FontSpecification;
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.extend.OutputDevice;
 import com.openhtmltopdf.util.Configuration;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.awt.*;
 import java.awt.geom.Area;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * An abstract implementation of an {@link OutputDevice}.  It provides complete
@@ -202,7 +204,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
             try {
                 return c.getUac().getImageResource(uri).getImage();
             } catch (Exception ex) {
-                XRLog.exception("Failed to load background image at uri " + uri, ex);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_FAILED_TO_LOAD_BACKGROUND_IMAGE_AT_URI, uri, ex);
             }
         }
         return null;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/Box.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/Box.java
@@ -34,6 +34,7 @@ import com.openhtmltopdf.layout.PaintingInfo;
 import com.openhtmltopdf.layout.Styleable;
 import com.openhtmltopdf.render.FlowingColumnContainerBox.ColumnBreakStore;
 import com.openhtmltopdf.util.LambdaUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -347,10 +348,9 @@ public abstract class Box implements Styleable, DisplayListItem {
             if (this.type.isAssignableFrom(box.getClass())) {
                 return (T) box;
             }
-            
-            XRLog.general(Level.SEVERE, "Expecting box children to be of type (" +
-                                        this.type.getCanonicalName() + ") but got (" +
-                                        box.getClass().getCanonicalName() + ").");
+
+            XRLog.log(Level.SEVERE, LogMessageId.LogMessageId2Param.GENERAL_EXPECTING_BOX_CHILDREN_OF_TYPE_BUT_GOT,
+                    this.type.getCanonicalName(), box.getClass().getCanonicalName());
             return null;
         }
     }
@@ -758,7 +758,7 @@ public abstract class Box implements Styleable, DisplayListItem {
     public int forcePageBreakBefore(LayoutContext c, IdentValue pageBreakValue, boolean pendingPageName) {
         PageBox page = c.getRootLayer().getFirstPage(c, this);
         if (page == null) {
-            XRLog.layout(Level.WARNING, "Box has no page");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LAYOUT_BOX_HAS_NO_PAGE);
             return 0;
         } else {
             int pageBreakCount = 1;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/FSCatalog.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/FSCatalog.java
@@ -20,6 +20,7 @@
  */
 package com.openhtmltopdf.resource;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -69,7 +70,7 @@ public class FSCatalog {
         try (InputStream in = FSCatalog.class.getResourceAsStream(catalogURI)){
             map = parseCatalog(new InputSource(new BufferedInputStream(in)));
         } catch (Exception ex) {
-            XRLog.xmlEntities(Level.WARNING, "Could not open XML catalog from URI '" + catalogURI + "'", ex);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.XML_ENTITIES_COULD_NOT_OPEN_XML_CATALOG_FROM_URI, catalogURI, ex);
             map = Collections.emptyMap();
         }
         return map;
@@ -107,19 +108,19 @@ public class FSCatalog {
             xmlReader.setErrorHandler(new ErrorHandler() {
                 public void error(SAXParseException ex) {
                     if (XRLog.isLoggingEnabled()) {
-                        XRLog.xmlEntities(Level.WARNING, ex.getMessage());
+                        XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.XML_ENTITIES_EXCEPTION_MESSAGE, ex.getMessage());
                     }
                 }
 
                 public void fatalError(SAXParseException ex) {
                     if (XRLog.isLoggingEnabled()) {
-                        XRLog.xmlEntities(Level.WARNING, ex.getMessage());
+                        XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.XML_ENTITIES_EXCEPTION_MESSAGE, ex.getMessage());
                     }
                 }
 
                 public void warning(SAXParseException ex) {
                     if (XRLog.isLoggingEnabled()) {
-                        XRLog.xmlEntities(Level.WARNING, ex.getMessage());
+                        XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.XML_ENTITIES_EXCEPTION_MESSAGE, ex.getMessage());
                     }
                 }
             });
@@ -167,18 +168,11 @@ public class FSCatalog {
     private void setFeature(XMLReader xmlReader, String featureUri, boolean value) {
         try {
             xmlReader.setFeature(featureUri, value);
-
-            XRLog.xmlEntities(Level.FINE, "SAX Parser feature: " +
-                    featureUri.substring(featureUri.lastIndexOf("/")) +
-                    " set to " +
-                    xmlReader.getFeature(featureUri));
+            XRLog.log(Level.FINE, LogMessageId.LogMessageId2Param.XML_ENTITIES_SAX_FEATURE_SET, featureUri.substring(featureUri.lastIndexOf("/")), Boolean.toString(xmlReader.getFeature(featureUri)));
         } catch (SAXNotSupportedException ex) {
-            XRLog.xmlEntities(Level.WARNING,
-                    "SAX feature not supported on this XMLReader: " + featureUri);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.XML_ENTITIES_SAX_FEATURE_NOT_SUPPORTED, featureUri);
         } catch (SAXNotRecognizedException ex) {
-            XRLog.xmlEntities(Level.WARNING,
-                    "SAX feature not recognized on this XMLReader: " +
-                    featureUri + ". Feature may be properly named, but not recognized by this parser.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.XML_ENTITIES_SAX_FEATURE_NOT_RECOGNIZED, featureUri);
         }
     }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/FSEntityResolver.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/FSEntityResolver.java
@@ -20,6 +20,7 @@
  */
 package com.openhtmltopdf.resource;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -88,20 +89,13 @@ public class FSEntityResolver implements EntityResolver {
             }
 
             if (is == null) {
-                XRLog.xmlEntities(Level.WARNING,
-                        "Can't find a local reference for Entity for public ID: " + publicID +
-                        " and expected to. The local URL should be: " + url + ". Not finding " +
-                        "this probably means a CLASSPATH configuration problem; this resource " +
-                        "should be included with the renderer and so not finding it means it is " +
-                        "not on the CLASSPATH, and should be. Will let parser use the default in " +
-                        "this case.");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.XML_ENTITIES_ENTITY_CANT_FIND_LOCAL_REFERENCE, publicID, url);
             }
             local = new InputSource(is);
             local.setSystemId(realUrl.toExternalForm());
-            XRLog.xmlEntities(Level.FINE, "Entity public: " + publicID + " -> " + url +
-                    (local == null ? ", NOT FOUND" : " (local)"));
+            XRLog.log(Level.FINE, LogMessageId.LogMessageId2Param.XML_ENTITIES_ENTITY_PUBLIC_NOT_FOUND_OR_LOCAL, publicID, url + (local == null ? ", NOT FOUND" : " (local)"));
         } else {
-            XRLog.xmlEntities("Entity public: " + publicID + ", no local mapping. Returning empty entity to avoid pulling from network.");
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.XML_ENTITIES_ENTITY_PUBLIC_NO_LOCAL_MAPPING, publicID);
             local = new InputSource(new StringReader(""));
         }
         return local;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/XMLResource.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/XMLResource.java
@@ -36,6 +36,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXSource;
 
+import com.openhtmltopdf.util.*;
 import org.w3c.dom.Document;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
@@ -45,11 +46,6 @@ import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
-
-import com.openhtmltopdf.util.Configuration;
-import com.openhtmltopdf.util.ThreadCtx;
-import com.openhtmltopdf.util.XRLog;
-import com.openhtmltopdf.util.XRRuntimeException;
 
 
 /**
@@ -113,21 +109,14 @@ public class XMLResource extends AbstractResource {
                     Class.forName(xmlReaderClass);
                 } catch (Exception ex) {
                     XMLResource.useConfiguredParser = false;
-                    XRLog.load(Level.WARNING,
-                            "The XMLReader class you specified as a configuration property " +
-                            "could not be found. Class.forName() failed on "
-                            + xmlReaderClass + ". Please check classpath. Use value 'default' in " +
-                            "FS configuration if necessary. Will now try JDK default.");
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_XMLREADER_CLASS_SPECIFIED_COULD_NOT_BE_FOUND, xmlReaderClass);
                 }
                 if (XMLResource.useConfiguredParser) {
                     xmlReader = XMLReaderFactory.createXMLReader(xmlReaderClass);
                 }
             }
         } catch (Exception ex) {
-            XRLog.load(Level.WARNING,
-                    "Could not instantiate custom XMLReader class for XML parsing: "
-                    + xmlReaderClass + ". Please check classpath. Use value 'default' in " +
-                    "FS configuration if necessary. Will now try JDK default.", ex);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_COULD_NOT_INSTANTIATE_CUSTOM_XML_READER, xmlReaderClass, ex);
         }
         if (xmlReader == null) {
             try {
@@ -143,17 +132,17 @@ public class XMLResource extends AbstractResource {
                 xmlReader = XMLReaderFactory.createXMLReader();
                 xmlReaderClass = "{JDK default}";
             } catch (Exception ex) {
-                XRLog.general(ex.getMessage());
+                XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.GENERAL_MESSAGE, ex.getMessage());
             }
         }
         if (xmlReader == null) {
             try {
-                XRLog.load(Level.WARNING, "falling back on the default parser");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LOAD_FALLING_BACK_ON_THE_DEFAULT_PARSER);
                 SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
                 xmlReader = parser.getXMLReader();
                 xmlReaderClass = "SAXParserFactory default";
             } catch (Exception ex) {
-                XRLog.general(ex.getMessage());
+                XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.GENERAL_MESSAGE, ex.getMessage());
             }
         }
         if (xmlReader == null) {
@@ -161,7 +150,7 @@ public class XMLResource extends AbstractResource {
                     "The name of the class to use should have been read from the org.xml.sax.driver System " +
                     "property, which is set to: "/*CHECK: is this meaningful? + System.getProperty("org.xml.sax.driver")*/);
         }
-        XRLog.load("SAX XMLReader in use (parser): " + xmlReader.getClass().getName());
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_SAX_XMLREADER_IN_USE, xmlReader.getClass().getName());
         return xmlReader;
     }
 
@@ -176,10 +165,8 @@ public class XMLResource extends AbstractResource {
            	 xmlReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
            	 xmlReader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
            	 xmlReader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-           } catch (SAXNotSupportedException e) {
-           	 XRLog.load(Level.SEVERE, "Unable to disable XML External Entities, which might put you at risk to XXE attacks", e);
-           } catch (SAXNotRecognizedException e) {
-           	 XRLog.load(Level.SEVERE, "Unable to disable XML External Entities, which might put you at risk to XXE attacks", e);
+           } catch (SAXNotSupportedException | SAXNotRecognizedException e) {
+                XRLog.log(Level.SEVERE, LogMessageId.LogMessageId0Param.LOAD_UNABLE_TO_DISABLE_XML_EXTERNAL_ENTITIES, e);
            }
     	}
     	
@@ -193,7 +180,7 @@ public class XMLResource extends AbstractResource {
               dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
               dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     		} catch (ParserConfigurationException e) {
-    		  XRLog.load(Level.SEVERE, "Unable to disable XML External Entities, which might put you at risk to XXE attacks", e);
+                XRLog.log(Level.SEVERE, LogMessageId.LogMessageId0Param.LOAD_UNABLE_TO_DISABLE_XML_EXTERNAL_ENTITIES, e);
     		}
     	}
     	
@@ -202,7 +189,7 @@ public class XMLResource extends AbstractResource {
     		  xformFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
               xformFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
     		} catch (IllegalArgumentException e) {
-    		  XRLog.load(Level.SEVERE, "Unable to disable XML External Entities, which might put you at risk to XXE attacks", e);
+                XRLog.log(Level.SEVERE, LogMessageId.LogMessageId0Param.LOAD_UNABLE_TO_DISABLE_XML_EXTERNAL_ENTITIES, e);
     		}
     	}
     	
@@ -210,7 +197,7 @@ public class XMLResource extends AbstractResource {
             try {
             	return TransformerFactory.newInstance(preferredImpl, null);
             } catch (TransformerFactoryConfigurationError e) {
-            	XRLog.load(Level.SEVERE, "Could not load preferred XML transformer, using default which may not be secure.");
+                XRLog.log(Level.SEVERE, LogMessageId.LogMessageId1Param.LOAD_COULD_NOT_LOAD_PREFERRED_XML, "transformer");
             	return TransformerFactory.newInstance();
             }
     	}
@@ -219,7 +206,7 @@ public class XMLResource extends AbstractResource {
             try {
             	return preferredImpl == null ? DocumentBuilderFactory.newInstance() : DocumentBuilderFactory.newInstance(preferredImpl, null);
             } catch (FactoryConfigurationError e) {
-            	XRLog.load(Level.SEVERE, "Could not load preferred XML document builder, using default which may not be secure.");
+                XRLog.log(Level.SEVERE, LogMessageId.LogMessageId1Param.LOAD_COULD_NOT_LOAD_PREFERRED_XML, "document builder");
             	return DocumentBuilderFactory.newInstance();
             }
     	}
@@ -278,7 +265,7 @@ public class XMLResource extends AbstractResource {
 
             target.setElapsedLoadTime(end - st);
 
-            XRLog.load("Loaded document in ~" + target.getElapsedLoadTime() + "ms");
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_LOADED_DOCUMENT_TIME, target.getElapsedLoadTime());
 
             target.setDocument((Document) output.getNode());
             return target;
@@ -294,15 +281,15 @@ public class XMLResource extends AbstractResource {
                 xmlReader.setErrorHandler(new ErrorHandler() {
 
                     public void error(SAXParseException ex) {
-                        XRLog.load(ex.getMessage());
+                        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_EXCEPTION_MESSAGE, ex.getMessage());
                     }
 
                     public void fatalError(SAXParseException ex) {
-                        XRLog.load(ex.getMessage());
+                        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_EXCEPTION_MESSAGE, ex.getMessage());
                     }
 
                     public void warning(SAXParseException ex) {
-                        XRLog.load(ex.getMessage());
+                        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_EXCEPTION_MESSAGE, ex.getMessage());
                     }
                 });
             } catch (Exception ex) {
@@ -320,11 +307,10 @@ public class XMLResource extends AbstractResource {
                 xmlReader.setFeature("http://xml.org/sax/features/namespaces", true);
             } catch (SAXException s) {
                 // nothing to do--some parsers will not allow setting features
-                XRLog.load(Level.WARNING, "Could not set validation/namespace features for XML parser," +
-                        "exception thrown.", s);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LOAD_COULD_NOT_SET_VALIDATION_NAMESPACE_FEATURES_FOR_XML_PARSER, s);
             }
             if (Configuration.isFalse("xr.load.configure-features", false)) {
-                XRLog.load(Level.FINE, "SAX Parser: by request, not changing any parser features.");
+                XRLog.log(Level.FINE, LogMessageId.LogMessageId0Param.LOAD_SAX_PARSER_BY_REQUEST_NOT_CHANGING_PARSER_FEATURES);
                 return;
             }
             
@@ -346,16 +332,11 @@ public class XMLResource extends AbstractResource {
         private void setFeature(XMLReader xmlReader, String featureUri, String configName) {
             try {
                 xmlReader.setFeature(featureUri, Configuration.isTrue(configName, false));
-
-                XRLog.load(Level.FINE, "SAX Parser feature: " +
-                        featureUri.substring(featureUri.lastIndexOf("/")) +
-                        " set to " +
-                        xmlReader.getFeature(featureUri));
+                XRLog.log(Level.FINE, LogMessageId.LogMessageId2Param.LOAD_SAX_FEATURE_SET, featureUri.substring(featureUri.lastIndexOf("/")), xmlReader.getFeature(featureUri));
             } catch (SAXNotSupportedException ex) {
-                XRLog.load(Level.WARNING, "SAX feature not supported on this XMLReader: " + featureUri);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_SAX_FEATURE_NOT_SUPPORTED, featureUri);
             } catch (SAXNotRecognizedException ex) {
-                XRLog.load(Level.WARNING, "SAX feature not recognized on this XMLReader: " + featureUri +
-                        ". Feature may be properly named, but not recognized by this parser.");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_SAX_FEATURE_NOT_RECOGNIZED, featureUri);
             }
         }
 
@@ -385,7 +366,7 @@ public class XMLResource extends AbstractResource {
                 try {
                 	xformFactory = TransformerFactory.newInstance("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl", null);
                 } catch(Exception e) {
-                	XRLog.load(Level.SEVERE, "Could not load preferred XML transformer, using default which may not be secure.");
+                    XRLog.log(Level.SEVERE, LogMessageId.LogMessageId1Param.LOAD_COULD_NOT_LOAD_PREFERRED_XML, "transformer");
                 	xformFactory = TransformerFactory.newInstance();
                 }
                 
@@ -410,7 +391,7 @@ public class XMLResource extends AbstractResource {
 
             target.setElapsedLoadTime(end - st);
 
-            XRLog.load("Loaded document in ~" + target.getElapsedLoadTime() + "ms");
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_LOADED_DOCUMENT_TIME, target.getElapsedLoadTime());
 
             target.setDocument((Document) output.getNode());
             return target;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -26,7 +26,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -390,7 +392,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
                 is = null;
             } catch (Exception e) {
                 _defaultStylesheetError = true;
-                XRLog.exception("Could not parse default stylesheet", e);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_COULD_NOT_PARSE_DEFAULT_STYLESHEET, e);
             } finally {
                 if (is != null) {
                     try {
@@ -412,8 +414,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         String defaultStyleSheet = Configuration.valueFor("xr.css.user-agent-default-css") + "XhtmlNamespaceHandler.css";
         stream = this.getClass().getResourceAsStream(defaultStyleSheet);
         if (stream == null) {
-            XRLog.exception("Can't load default CSS from " + defaultStyleSheet + "." +
-                    "This file must be on your CLASSPATH. Please check before continuing.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_DEFAULT_CSS, defaultStyleSheet);
             _defaultStylesheetError = true;
         }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlForm.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlForm.java
@@ -24,12 +24,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
 import javax.swing.JComponent;
 import javax.swing.JRadioButton;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;
@@ -114,8 +116,7 @@ public class XhtmlForm {
             field = FormFieldFactory.create(this, context, box);
     
             if (field == null) {
-                XRLog.layout("Unknown field type: " + e.getNodeName());
-
+                XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LAYOUT_UNKNOWN_FIELD_TYPE, e.getNodeName());
                 return null;
             }
             

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlNamespaceHandler.java
@@ -20,6 +20,7 @@ package com.openhtmltopdf.simple.extend;
 
 import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -127,8 +128,7 @@ public class XhtmlNamespaceHandler extends XhtmlCssOnlyNamespaceHandler {
             sb.append(viewBoxHeight);
             sb.append("px;");
         } catch (NumberFormatException ex) {
-            XRLog.general(Level.WARNING,
-                    "Invalid integer passed in viewBox attribute for SVG: " + viewBoxAttr);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_INVALID_INTEGER_PASSED_IN_VIEWBOX_ATTRIBUTE_FOR_SVG, viewBoxAttr);
             /* FALL-THRU */
         }
         

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/form/ImageField.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/form/ImageField.java
@@ -20,14 +20,14 @@
 package com.openhtmltopdf.simple.extend.form;
 
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.util.logging.Level;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.plaf.basic.BasicButtonUI;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Element;
 
 import com.openhtmltopdf.css.constants.CSSName;
@@ -91,12 +91,9 @@ class ImageField extends InputField {
             intrinsicHeight = new Integer(getBox().getHeight());
         }
 
-        button.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
-                XRLog.layout("Image pressed: Submit");
-
-                getParentForm().submit(getComponent());
-            }
+        button.addActionListener(event -> {
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LAYOUT_FORM_ACTION_PERFORMED, "Image", "Submit");
+            getParentForm().submit(getComponent());
         });
 
         return button;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/form/ResetField.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/form/ResetField.java
@@ -19,12 +19,12 @@
  */
 package com.openhtmltopdf.simple.extend.form;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.util.logging.Level;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Element;
 
 import com.openhtmltopdf.layout.LayoutContext;
@@ -54,12 +54,9 @@ class ResetField extends AbstractButtonField {
 
         button.setText(value);
         
-        button.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
-                XRLog.layout("Reset pressed: Restore");
-                
-                getParentForm().reset();
-            }
+        button.addActionListener(event -> {
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LAYOUT_FORM_ACTION_PERFORMED, "Reset", "Restore");
+            getParentForm().reset();
         });
 
         return button;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/form/SubmitField.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/form/SubmitField.java
@@ -19,12 +19,12 @@
  */
 package com.openhtmltopdf.simple.extend.form;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.util.logging.Level;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Element;
 
 import com.openhtmltopdf.layout.LayoutContext;
@@ -54,12 +54,9 @@ class SubmitField extends AbstractButtonField {
 
         button.setText(value);
 
-        button.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
-                XRLog.layout("Submit pressed: Submit");
-
-                getParentForm().submit(getComponent());
-            }
+        button.addActionListener(event -> {
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LAYOUT_FORM_ACTION_PERFORMED, "Submit", "Submit");
+            getParentForm().submit(getComponent());
         });
 
         return button;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/DeferredImageReplacedElement.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/DeferredImageReplacedElement.java
@@ -27,6 +27,7 @@ import com.openhtmltopdf.layout.LayoutContext;
 import com.openhtmltopdf.resource.ImageResource;
 import com.openhtmltopdf.util.Configuration;
 import com.openhtmltopdf.util.ImageUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import javax.swing.*;
@@ -149,12 +150,8 @@ public class DeferredImageReplacedElement extends ImageReplacedElement {
                 _image = image;
             }
             _loaded = true;
-            XRLog.load(Level.FINE, "Icon: replaced image " + _imageResource.getImageUri() + ", repaint requested");
-            SwingUtilities.invokeLater(new Runnable() {
-                public void run() {
-                    repaintListener.repaintRequested(_doScaleImage);
-                }
-            });
+            XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.LOAD_ICON_REPLACED_IMAGE_REPAINT_REQUESTED, _imageResource.getImageUri());
+            SwingUtilities.invokeLater(() -> repaintListener.repaintRequested(_doScaleImage));
 
         }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageLoadQueue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageLoadQueue.java
@@ -19,6 +19,7 @@
  */
 package com.openhtmltopdf.swing;
 
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.util.LinkedList;
@@ -66,7 +67,7 @@ class ImageLoadQueue {
      *            the URI is a proper URL before calling this method.
      */
     public synchronized void addToQueue(final ImageResourceLoader imageResourceLoader, final String uri, final MutableFSImage mfsi, final int width, final int height) {
-        XRLog.general(Level.FINE, "Queueing load for image uri " + uri);
+        XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.GENERAL_QUEUEING_LOAD_FOR_IMAGE_URI, uri);
         _loadQueue.addLast(new ImageLoadItem(imageResourceLoader, uri, mfsi, width, height));
         notifyAll();
     }
@@ -83,14 +84,12 @@ class ImageLoadQueue {
             wait();
         }
         if (_loadQueue.getLast() == KILL_SWITCH) {
-            XRLog.general(Level.FINE, "Thread " + Thread.currentThread().getName() +
-                    " requested item, but queue is shutting down; returning kill switch.");
+            XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.GENERAL_THREAD_REQUESTED_ITEM_BUT_QUEUE_IS_SHUTTING_DOWN, Thread.currentThread().getName());
             return KILL_SWITCH;
         } else {
             ImageLoadItem item = (ImageLoadItem) _loadQueue.removeLast();
 
-            XRLog.general(Level.FINE, "Thread " + Thread.currentThread().getName() +
-                    " pulled item " + item._uri + " from queue, " + (_loadQueue.size() - 1) + " remaining");
+            XRLog.log(Level.FINE, LogMessageId.LogMessageId3Param.GENERAL_THREAD_PULLED_ITEM_FROM_QUEUE, Thread.currentThread().getName(), item._uri, _loadQueue.size() - 1);
             return item;
         }
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageLoadWorker.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageLoadWorker.java
@@ -22,6 +22,7 @@ package com.openhtmltopdf.swing;
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.resource.ImageResource;
 import com.openhtmltopdf.util.ImageUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.awt.*;
@@ -57,13 +58,13 @@ class ImageLoadWorker extends Thread {
                 }
                 final ImageResource ir = ImageResourceLoader.loadImageResourceFromUri(loadItem._uri);
                 FSImage awtfsImage = ir.getImage();
-                BufferedImage newImg = (BufferedImage) ((AWTFSImage) awtfsImage).getImage();
-                XRLog.load(Level.FINE, this + ", loaded " + loadItem._uri);
+                BufferedImage newImg = ((AWTFSImage) awtfsImage).getImage();
+                XRLog.log(Level.FINE, LogMessageId.LogMessageId2Param.LOAD_IMAGE_LOAD_WORKER_LOADED_WITH_URI, this, loadItem._uri);
 
                 loadItem._imageResourceLoader.loaded(ir, newImg.getWidth(), newImg.getHeight());
                 final boolean wasScaled;
                 if (loadItem.haveTargetDimensions() && !ir.hasDimensions(loadItem._targetWidth, loadItem._targetHeight)) {
-                    XRLog.load(Level.FINE, this + ", scaling " + loadItem._uri + " to " + loadItem._targetWidth + ", " + loadItem._targetHeight);
+                    XRLog.log(Level.FINE, LogMessageId.LogMessageId4Param.LOAD_IMAGE_LOADER_SCALING_URI_TO, this, loadItem._uri, loadItem._targetWidth, loadItem._targetHeight);
                     newImg = ImageUtil.getScaledInstance(newImg, loadItem._targetWidth, loadItem._targetHeight);
                     ImageResource sir = new ImageResource(ir.getImageUri(), AWTFSImage.createImage(newImg));
                     loadItem._imageResourceLoader.loaded(sir, newImg.getWidth(), newImg.getHeight());
@@ -74,11 +75,7 @@ class ImageLoadWorker extends Thread {
 
                 // msfImage belongs to the Swing AWT thread
                 final BufferedImage newImg1 = newImg;
-                EventQueue.invokeLater(new Runnable() {
-                    public void run() {
-                        loadItem._mfsImage.setImage(loadItem._uri, newImg1, wasScaled);
-                    }
-                });
+                EventQueue.invokeLater(() -> loadItem._mfsImage.setImage(loadItem._uri, newImg1, wasScaled));
             }
         } catch (InterruptedException e) {
             //

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageMapParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageMapParser.java
@@ -20,6 +20,7 @@ package com.openhtmltopdf.swing;
  */
 
 import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -71,7 +72,7 @@ public class ImageMapParser {
 				}
 			}
 			if (null == map) {
-				XRLog.layout(Level.INFO, "No map named: '" + mapName + "'");
+				XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LAYOUT_NO_MAP_NAMED, mapName);
 				return null;
 			}
 		}
@@ -124,7 +125,7 @@ public class ImageMapParser {
 							}
 						} else {
 							if (XRLog.isLoggingEnabled()) {
-								XRLog.layout(Level.INFO, "Unsupported shape: '" + shapeAttr + "'");
+								XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LAYOUT_UNSUPPORTED_SHAPE, shapeAttr);
 							}
 						}
 					}
@@ -149,7 +150,7 @@ public class ImageMapParser {
 				try {
 					coords[i++] = Float.parseFloat(coord.trim());
 				} catch (NumberFormatException e) {
-					XRLog.layout(Level.WARNING, "Error while parsing shape coords", e);
+					XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LAYOUT_ERROR_PARSING_SHAPE_COORDS, e);
 					return null;
 				}
 			}
@@ -168,7 +169,7 @@ public class ImageMapParser {
 				}
 				return new Polygon(xpoints, ypoints, npoints);
 			} else {
-				XRLog.layout(Level.INFO, "Unsupported shape: '" + length + "'");
+				XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LAYOUT_UNSUPPORTED_SHAPE, length);
 				return null;
 			}
 		} else {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageResourceLoader.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/ImageResourceLoader.java
@@ -13,21 +13,14 @@ import javax.imageio.ImageIO;
 
 import com.openhtmltopdf.extend.FSImage;
 import com.openhtmltopdf.resource.ImageResource;
-import com.openhtmltopdf.util.Configuration;
-import com.openhtmltopdf.util.ImageUtil;
-import com.openhtmltopdf.util.StreamResource;
-import com.openhtmltopdf.util.XRLog;
+import com.openhtmltopdf.util.*;
 
 
 /**
  *
  */
 public class ImageResourceLoader {
-    public static final RepaintListener NO_OP_REPAINT_LISTENER = new RepaintListener() {
-        public void repaintRequested(boolean doLayout) {
-            XRLog.general(Level.FINE, "No-op repaint requested");
-        }
-    };
+    public static final RepaintListener NO_OP_REPAINT_LISTENER = doLayout -> XRLog.log(Level.FINE, LogMessageId.LogMessageId0Param.GENERAL_NO_OP_REPAINT_REQUESTED);
     private final Map _imageCache;
 
     private final ImageLoadQueue _loadQueue;
@@ -81,15 +74,15 @@ public class ImageResourceLoader {
                     }
                     ir = createImageResource(uri, img);
                 } catch (FileNotFoundException e) {
-                    XRLog.exception("Can't read image file; image at URI '" + uri + "' not found");
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI_NOT_FOUND, uri);
                 } catch (IOException e) {
-                    XRLog.exception("Can't read image file; unexpected problem for URI '" + uri + "'", e);
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI, uri, e);
                 } finally {
                     sr.close();
                 }
             } catch (IOException e) {
                 // couldnt open stream at URI...
-                XRLog.exception("Can't open stream for URI '" + uri + "': " + e.getMessage());
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.EXCEPTION_CANT_OPEN_STREAM_FOR_URI, uri, e.getMessage());
             }
             if (ir == null) {
                 ir = createImageResource(uri, null);
@@ -142,19 +135,19 @@ public class ImageResourceLoader {
                 // no: loaded
                 if (ir == null) {
                     if (isImmediateLoadUri(uri)) {
-                        XRLog.load(Level.FINE, "Load immediate: " + uri);
+                        XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.LOAD_LOAD_IMMEDIATE_URI, uri);
                         ir = loadImageResourceFromUri(uri);
                         FSImage awtfsImage = ir.getImage();
                         BufferedImage newImg = ((AWTFSImage) awtfsImage).getImage();
                         loaded(ir, -1, -1);
                         if (width > -1 && height > -1) {
-                            XRLog.load(Level.FINE, this + ", scaling " + uri + " to " + width + ", " + height);
+                            XRLog.log(Level.FINE, LogMessageId.LogMessageId4Param.LOAD_IMAGE_LOADER_SCALING_URI_TO, this, uri, width, height);
                             newImg = ImageUtil.getScaledInstance(newImg, width, height);
                             ir = new ImageResource(ir.getImageUri(), AWTFSImage.createImage(newImg));
                             loaded(ir, width, height);
                         }
                     } else {
-                        XRLog.load(Level.FINE, "Image cache miss, URI not yet loaded, queueing: " + uri);
+                        XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.LOAD_IMAGE_CACHE_MISS_QUEUEING, uri);
                         MutableFSImage mfsi = new MutableFSImage(_repaintListener);
                         ir = new ImageResource(uri, mfsi);
                         _loadQueue.addToQueue(this, uri, mfsi, width, height);
@@ -163,7 +156,7 @@ public class ImageResourceLoader {
                     _imageCache.put(key, ir);
                 } else {
                     // loaded at base size, need to scale
-                    XRLog.load(Level.FINE, this + ", scaling " + uri + " to " + width + ", " + height);
+                    XRLog.log(Level.FINE, LogMessageId.LogMessageId4Param.LOAD_IMAGE_LOADER_SCALING_URI_TO, this, uri, width, height);
                     FSImage awtfsImage = ir.getImage();
                     BufferedImage newImg = ((AWTFSImage) awtfsImage).getImage();
 
@@ -201,7 +194,7 @@ public class ImageResourceLoader {
 
     public void stopLoading() {
         if (_loadQueue != null) {
-            XRLog.load("By request, clearing pending items from load queue: " + _loadQueue.size());
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_CLEARING_PENDING_ITEMS_FROM_LOAD_QUEUE, _loadQueue.size());
             _loadQueue.reset();
         }
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/MutableFSImage.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/MutableFSImage.java
@@ -20,6 +20,7 @@
 package com.openhtmltopdf.swing;
 
 import com.openhtmltopdf.util.ImageUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.awt.*;
@@ -64,7 +65,7 @@ public class MutableFSImage extends AWTFSImage {
         
         img = newImg;
         loaded = true;
-        XRLog.general(Level.FINE, "Mutable image " + uri + " loaded, repaint requested");
+        XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.GENERAL_MUTABLE_IMAGE_URI_LOADED_REPAINT_REQUESTED, uri);
         repaintListener.repaintRequested(wasScaled);
     }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -47,6 +47,7 @@ import com.openhtmltopdf.resource.CSSResource;
 import com.openhtmltopdf.resource.ImageResource;
 import com.openhtmltopdf.resource.XMLResource;
 import com.openhtmltopdf.util.ImageUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 /**
@@ -101,11 +102,11 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 	        try {
 	            is = new URL(uri).openStream();
 	        } catch (java.net.MalformedURLException e) {
-	            XRLog.exception("bad URL given: " + uri, e);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_MALFORMED_URL, uri, e);
 	        } catch (java.io.FileNotFoundException e) {
-	            XRLog.exception("item at URI " + uri + " not found");
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_ITEM_AT_URI_NOT_FOUND, uri, e);
 	        } catch (java.io.IOException e) {
-	            XRLog.exception("IO problem for " + uri, e);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_IO_PROBLEM_FOR_URI, uri, e);
 	        }
 	        return new DefaultHttpStream(is);
 		}
@@ -162,15 +163,15 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 		        try {
 		            is = new URL(uri).openStream();
 		        } catch (java.net.MalformedURLException e) {
-		            XRLog.exception("bad URL given: " + uri, e);
+		        	XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_MALFORMED_URL, uri, e);
 		        } catch (java.io.FileNotFoundException e) {
-		            XRLog.exception("item at URI " + uri + " not found", e);
+		        	XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_ITEM_AT_URI_NOT_FOUND, uri, e);
 		        } catch (java.io.IOException e) {
-		            XRLog.exception("IO problem for " + uri, e);
+		        	XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_IO_PROBLEM_FOR_URI, uri, e);
 		        }
 			}
         } catch (URISyntaxException e1) {
-        	XRLog.exception("bad URL given: " + uri, e1);
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_MALFORMED_URL, uri, e1);
 		}
 
         return is;
@@ -193,15 +194,15 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 		        try {
 		            is = new URL(uri).openStream();
 		        } catch (java.net.MalformedURLException e) {
-		            XRLog.exception("bad URL given: " + uri, e);
+					XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_MALFORMED_URL, uri, e);
 		        } catch (java.io.FileNotFoundException e) {
-		            XRLog.exception("item at URI " + uri + " not found");
+					XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_ITEM_AT_URI_NOT_FOUND, uri, e);
 		        } catch (java.io.IOException e) {
-		            XRLog.exception("IO problem for " + uri, e);
+					XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_IO_PROBLEM_FOR_URI, uri, e);
 		        }
 			}
         } catch (URISyntaxException e1) {
-        	XRLog.exception("bad URL given: " + uri, e1);
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_MALFORMED_URL, uri, e1);
 		}
 
 		return is == null ? null : new InputStreamReader(is, StandardCharsets.UTF_8);
@@ -230,7 +231,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
     	String resolved = _resolver.resolveURI(this._baseUri, uri);
     	
     	if (resolved == null) {
-    		XRLog.load(Level.INFO, "URI resolver rejected loading CSS resource at (" + uri + ")");
+    		XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "CSS resource", uri);
     		return null;
     	}
     	
@@ -256,7 +257,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
             String resolved = _resolver.resolveURI(this._baseUri, uri);
             
             if (resolved == null) {
-        		XRLog.load(Level.INFO, "URI resolver rejected loading image resource at (" + uri + ")");
+            	XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "image resource", uri);
         		return null;
         	}
             
@@ -283,9 +284,9 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
                         
                         return ir;
                     } catch (FileNotFoundException e) {
-                        XRLog.exception("Can't read image file; image at URI '" + resolved + "' not found");
+                    	XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI_NOT_FOUND, resolved);
                     } catch (IOException e) {
-                        XRLog.exception("Can't read image file; unexpected problem for URI '" + resolved + "'", e);
+						XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI, uri, e);
                     } finally {
                         try {
                             is.close();
@@ -312,7 +313,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
     	String resolved = _resolver.resolveURI(this._baseUri, uri);
     	
     	if (resolved == null) {
-    		XRLog.load(Level.INFO, "URI resolver rejected loading XML resource at (" + uri + ")");
+    		XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "XML resource", uri);
     		return null;
     	}
     	
@@ -334,7 +335,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         String resolved = _resolver.resolveURI(this._baseUri, uri);
     	
     	if (resolved == null) {
-    		XRLog.load(Level.INFO, "URI resolver rejected loading binary resource at (" + uri + ")");
+			XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "binary resource", uri);
     		return null;
     	}
     	
@@ -413,8 +414,8 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 				} else {
 					if (baseUri == null) {
 						// If user hasn't provided base URI, just reject resolving relative URIs.
-						XRLog.load(Level.WARNING, "Couldn't resolve relative URI(" + uri + ") because no base URI was provided.");
-					    return null;	
+						XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_COULD_NOT_RESOLVE_RELATIVE_URI_BECAUSE_NO_BASE_URI_WAS_PROVIDED, uri);
+					    return null;
 					} else if (baseUri.startsWith("jar")) {
 				    	// Fix for OpenHTMLtoPDF issue-#125, URI class doesn't resolve jar: scheme urls and so returns only
 				    	// the relative part on calling base.resolve(relative) so we use the URL class instead which does
@@ -429,10 +430,10 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 				    }
 				}
 			} catch (URISyntaxException e) {
-				XRLog.exception("When trying to load uri(" + uri + ") with base URI(" + baseUri + "), one or both were invalid URIs.", e);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId3Param.EXCEPTION_URI_WITH_BASE_URI_INVALID, uri, "", baseUri, e);
 				return null;
 			} catch (MalformedURLException e) {
-				XRLog.exception("When trying to load uri(" + uri + ") with base jar scheme URI(" + baseUri + "), one or both were invalid URIs.", e);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId3Param.EXCEPTION_URI_WITH_BASE_URI_INVALID, uri, "jar scheme", baseUri, e);
 				return null;
 			}
 		}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/SwingReplacedElementFactory.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/SwingReplacedElementFactory.java
@@ -19,6 +19,7 @@
  */
 package com.openhtmltopdf.swing;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -145,7 +146,7 @@ public abstract class SwingReplacedElementFactory implements ReplacedElementFact
         String imageSrc = context.getNamespaceHandler().getImageSourceURI(elem);
         
         if (imageSrc == null || imageSrc.length() == 0) {
-            XRLog.layout(Level.WARNING, "No source provided for img element.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LAYOUT_NO_SOURCE_PROVIDED_FOR_IMG_ELEMENT);
             re = newIrreplaceableImageElement(cssWidth, cssHeight);
         } else if (ImageUtil.isEmbeddedBase64Image(imageSrc)) {
             BufferedImage image = ImageUtil.loadEmbeddedBase64Image(imageSrc);
@@ -158,7 +159,7 @@ public abstract class SwingReplacedElementFactory implements ReplacedElementFact
 
             re = lookupImageReplacedElement(elem, ruri, cssWidth, cssHeight);
             if (re == null) {
-                XRLog.load(Level.FINE, "Swing: Image " + ruri + " requested at "+ " to " + cssWidth + ", " + cssHeight);
+                XRLog.log(Level.FINE, LogMessageId.LogMessageId3Param.LOAD_SWING_IMAGE_REQUESTED_AT_URI, ruri, cssWidth, cssHeight);
                 ImageResource imageResource = imageResourceLoader.get(ruri, cssWidth, cssHeight);
                 if (imageResource.isLoaded()) {
                     re = new ImageReplacedElement(((AWTFSImage) imageResource.getImage()).getImage(), cssWidth, cssHeight);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/UriResolver.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/UriResolver.java
@@ -1,5 +1,6 @@
 package com.openhtmltopdf.swing;
 
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.net.URL;
@@ -14,7 +15,7 @@ public class UriResolver {
         if (uri == null) return null;
         String ret = null;
         if (_baseUri == null) {//first try to set a base URL
-            XRLog.load(Level.WARNING, "Base url is null, trying to configure one now.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LOAD_BASE_URL_IS_NULL_TRYING_TO_CONFIGURE_ONE);
         	try {
                 URL result = new URL(uri);
                 setBaseUri(result.toExternalForm());
@@ -22,7 +23,7 @@ public class UriResolver {
                 try {
                     setBaseUri(new File(".").toURI().toURL().toExternalForm());
                 } catch (Exception e1) {
-                    XRLog.exception("The default NaiveUserAgent doesn't know how to resolve the base URL for " + uri);
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_DEFAULT_USERAGENT_IS_NOT_ABLE_TO_RESOLVE_BASE_URL_FOR, uri);
                     return null;
                 }
             }
@@ -31,13 +32,13 @@ public class UriResolver {
         try {
             return new URL(uri).toString();
         } catch (MalformedURLException e) {
-            XRLog.load(Level.FINE, "Could not read " + uri + " as a URL; may be relative. Testing using parent URL " + _baseUri);
+            XRLog.log(Level.FINE, LogMessageId.LogMessageId2Param.LOAD_COULD_NOT_READ_URI_AT_URL_MAY_BE_RELATIVE, uri, _baseUri);
             try {
                 URL result = new URL(new URL(_baseUri), uri);
                 ret = result.toString();
-                XRLog.load(Level.FINE, "Was able to read from " + uri + " using parent URL " + _baseUri);
+                XRLog.log(Level.FINE, LogMessageId.LogMessageId2Param.LOAD_WAS_ABLE_TO_READ_FROM_URI_USING_PARENT_URL, uri, _baseUri);
             } catch (MalformedURLException e1) {
-                XRLog.exception("The default NaiveUserAgent cannot resolve the URL " + uri + " with base URL " + _baseUri);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.EXCEPTION_DEFAULT_USERAGENT_IS_NOT_ABLE_TO_RESOLVE_URL_WITH_BASE_URL, uri, _baseUri);
             }
         }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/Configuration.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/Configuration.java
@@ -482,8 +482,7 @@ public class Configuration {
         try {
             bval = Byte.valueOf(val).byteValue();
         } catch (NumberFormatException nex) {
-            XRLog.exception("Property '" + key + "' was requested as a byte, but " +
-                    "value of '" + val + "' is not a byte. Check configuration.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.EXCEPTION_CONFIGURATION_WRONG_TYPE, key, "byte", val, "byte");
             bval = defaultVal;
         }
         return bval;
@@ -509,8 +508,7 @@ public class Configuration {
         try {
             sval = Short.valueOf(val).shortValue();
         } catch (NumberFormatException nex) {
-            XRLog.exception("Property '" + key + "' was requested as a short, but " +
-                    "value of '" + val + "' is not a short. Check configuration.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.EXCEPTION_CONFIGURATION_WRONG_TYPE, key, "short", val, "short");
             sval = defaultVal;
         }
         return sval;
@@ -536,36 +534,10 @@ public class Configuration {
         try {
             ival = Integer.valueOf(val).intValue();
         } catch (NumberFormatException nex) {
-            XRLog.exception("Property '" + key + "' was requested as an integer, but " +
-                    "value of '" + val + "' is not an integer. Check configuration.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.EXCEPTION_CONFIGURATION_WRONG_TYPE, key, "integer", val, "integer");
             ival = defaultVal;
         }
         return ival;
-    }
-
-    /**
-     * Returns the value for key in the Configuration as a character, or a
-     * default value if not found. A warning is issued to the log if the
-     * property is not defined, or if the configuration value is too long
-     * to be a char. If the configuration value is longer than a single
-     * character, only the first character is returned.
-     *
-     * @param key Name of the property
-     * @param defaultVal PARAM
-     * @return Value assigned to the key, as a character
-     */
-    public static char valueAsChar(String key, char defaultVal) {
-        String val = valueFor(key);
-        if (val == null) {
-            return defaultVal;
-        }
-
-        if(val.length() > 1) {
-            XRLog.exception("Property '" + key + "' was requested as a character. The value of '" +
-                    val + "' is too long to be a char. Returning only the first character.");
-        }
-
-        return val.charAt(0);
     }
 
     /**
@@ -588,8 +560,7 @@ public class Configuration {
         try {
             lval = Long.valueOf(val).longValue();
         } catch (NumberFormatException nex) {
-            XRLog.exception("Property '" + key + "' was requested as a long, but " +
-                    "value of '" + val + "' is not a long. Check configuration.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.EXCEPTION_CONFIGURATION_WRONG_TYPE, key, "long", val, "long");
             lval = defaultVal;
         }
         return lval;
@@ -615,8 +586,7 @@ public class Configuration {
         try {
             fval = Float.valueOf(val).floatValue();
         } catch (NumberFormatException nex) {
-            XRLog.exception("Property '" + key + "' was requested as a float, but " +
-                    "value of '" + val + "' is not a float. Check configuration.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.EXCEPTION_CONFIGURATION_WRONG_TYPE, key, "float", val, "float");
             fval = defaultVal;
         }
         return fval;
@@ -642,8 +612,7 @@ public class Configuration {
         try {
             dval = Double.valueOf(val).doubleValue();
         } catch (NumberFormatException nex) {
-            XRLog.exception("Property '" + key + "' was requested as a double, but " +
-                    "value of '" + val + "' is not a double. Check configuration.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.EXCEPTION_CONFIGURATION_WRONG_TYPE, key, "double", val, "double");
             dval = defaultVal;
         }
         return dval;
@@ -688,26 +657,6 @@ public class Configuration {
         return l.iterator();
     }
 
-
-    /**
-     * Command-line execution for testing. No arguments.
-     *
-     * @param args Ignored
-     */
-    public static void main(String args[]) {
-        try {
-            System.out.println("byte: " + String.valueOf(Configuration.valueAsByte("xr.test-config-byte", (byte) 15)));
-            System.out.println("short: " + String.valueOf(Configuration.valueAsShort("xr.test-config-short", (short) 20)));
-            System.out.println("int: " + String.valueOf(Configuration.valueAsInt("xr.test-config-int", 25)));
-            System.out.println("long: " + String.valueOf(Configuration.valueAsLong("xr.test-config-long", 30L)));
-            System.out.println("float: " + String.valueOf(Configuration.valueAsFloat("xr.test-config-float", 45.5F)));
-            System.out.println("double: " + String.valueOf(Configuration.valueAsDouble("xr.test-config-double", 50.75D)));
-            System.out.println("boolean: " + String.valueOf(Configuration.isTrue("xr.test-config-boolean", false)));
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-    }
-
     /**
      * Returns true if the value is "true" (ignores case), or the default
      * provided value if not found or if the value is not a valid boolean (true
@@ -725,8 +674,7 @@ public class Configuration {
         }
 
         if ("true|false".indexOf(val) == -1) {
-            XRLog.exception("Property '" + key + "' was requested as a boolean, but " +
-                    "value of '" + val + "' is not a boolean. Check configuration.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId4Param.EXCEPTION_CONFIGURATION_WRONG_TYPE, key, "boolean", val, "boolean");
             return defaultVal;
         } else {
             return Boolean.valueOf(val).booleanValue();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/Diagnostic.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/Diagnostic.java
@@ -1,0 +1,49 @@
+package com.openhtmltopdf.util;
+
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+
+public class Diagnostic {
+
+    private static final Pattern MESSAGE_FORMAT_PLACEHOLDER = Pattern.compile("\\{\\}");
+
+    private final Level level;
+    private final LogMessageId logMessageId;
+    private final Object[] args;
+    private final Throwable error;
+
+    Diagnostic(Level level, LogMessageId logMessageId, boolean hasError, Object[] args) {
+        this.level = level;
+        this.logMessageId = logMessageId;
+        this.args = args;
+        this.error = hasError ? (Throwable) args[args.length - 1] : null;
+    }
+
+    public LogMessageId getLogMessageId() {
+        return logMessageId;
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public boolean hasError() {
+        return error != null;
+    }
+
+    public Throwable getError() {
+        return error;
+    }
+
+    public String getFormattedMessage() {
+        if (logMessageId instanceof LogMessageId.LogMessageId0Param) {
+            return logMessageId.getMessageFormat();
+        } else {
+            return String.format(MESSAGE_FORMAT_PLACEHOLDER.matcher(logMessageId.getMessageFormat()).replaceAll("%s"), args);
+        }
+    }
+
+    public Object[] getArgs() {
+        return args;
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/ImageUtil.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/ImageUtil.java
@@ -296,7 +296,7 @@ public class ImageUtil {
             String b64encoded = imageDataUri.substring(b64Index + "base64,".length());
             return Base64.getMimeDecoder().decode(b64encoded);
         } else {
-            XRLog.load(Level.SEVERE, "Embedded data uris must be encoded in base 64.");
+            XRLog.log(Level.SEVERE, LogMessageId.LogMessageId0Param.LOAD_EMBEDDED_DATA_URI_MUST_BE_ENCODED_IN_BASE64);
         }
         return null;
     }
@@ -318,7 +318,7 @@ public class ImageUtil {
                 return ImageIO.read(new ByteArrayInputStream(buffer));
             }
         } catch (IOException ex) {
-            XRLog.exception("Can't read XHTML embedded image", ex);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_CANT_READ_XHTML_EMBEDDED_IMAGE, ex);
         }
         return null;
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -1,0 +1,353 @@
+package com.openhtmltopdf.util;
+
+public interface LogMessageId {
+
+    Enum<?> getEnum();
+    String getWhere();
+    String getMessageFormat();
+
+    enum LogMessageId0Param implements LogMessageId {
+        CSS_PARSE_MUST_PROVIDE_AT_LEAST_A_FONT_FAMILY_AND_SRC_IN_FONT_FACE_RULE(XRLog.CSS_PARSE, "Must provide at least a font-family and src in @font-face rule"),
+
+        RENDER_BUG_FONT_DIDNT_CONTAIN_EXPECTED_CHARACTER(XRLog.RENDER, "BUG. Font didn't contain expected character."),
+        RENDER_FONT_LIST_IS_EMPTY(XRLog.RENDER, "Font list is empty."),
+        RENDER_FONT_IS_NULL(XRLog.RENDER, "Font is null."),
+
+        LOAD_UNABLE_TO_DISABLE_XML_EXTERNAL_ENTITIES(XRLog.LOAD, "Unable to disable XML External Entities, which might put you at risk to XXE attacks"),
+        LOAD_COULD_NOT_SET_VALIDATION_NAMESPACE_FEATURES_FOR_XML_PARSER(XRLog.LOAD, "Could not set validation/namespace features for XML parser, exception thrown."),
+        LOAD_SAX_PARSER_BY_REQUEST_NOT_CHANGING_PARSER_FEATURES(XRLog.LOAD, "SAX Parser: by request, not changing any parser features."),
+        LOAD_PAGE_DOES_NOT_EXIST_FOR_PDF_IN_IMG_TAG(XRLog.LOAD, "Page does not exist for pdf in img tag. Ignoring!"),
+        LOAD_EMBEDDED_DATA_URI_MUST_BE_ENCODED_IN_BASE64(XRLog.LOAD, "Embedded data uris must be encoded in base 64."),
+        LOAD_FALLING_BACK_ON_THE_DEFAULT_PARSER(XRLog.LOAD, "falling back on the default parser"),
+        LOAD_BASE_URL_IS_NULL_TRYING_TO_CONFIGURE_ONE(XRLog.LOAD, "Base url is null, trying to configure one now."),
+
+        RENDER_TRIED_TO_SET_NON_INVERTIBLE_CSS_TRANSFORM(XRLog.RENDER, "Tried to set a non-invertible CSS transform. Ignored."),
+        RENDER_LINEAR_GRADIENT_IS_NOT_SUPPORTED(XRLog.RENDER, "linear-gradient(...) is not supported in this output device"),
+
+        GENERAL_EXCEPTION_SHAPING_TEXT(XRLog.GENERAL, "Exception while shaping text"),
+        GENERAL_EXCEPTION_DESHAPING_TEXT(XRLog.GENERAL, "Exception while deshaping text"),
+
+        LAYOUT_ERROR_PARSING_SHAPE_COORDS(XRLog.LAYOUT, "Error while parsing shape coords"),
+        LAYOUT_NO_SOURCE_PROVIDED_FOR_IMG_ELEMENT(XRLog.LAYOUT, "No source provided for img element."),
+        LAYOUT_NO_CONTENT_LIMIT_FOUND(XRLog.LAYOUT, "No content limit found"),
+        LAYOUT_BOX_HAS_NO_PAGE(XRLog.LAYOUT, "Box has no page"),
+
+        CASCADE_IS_ABSOLUTE_CSS_UNKNOWN_GIVEN(XRLog.CASCADE, "Asked whether type was absolute, given CSS_UNKNOWN as the type. " +
+                "Might be one of those funny values like background-position."),
+
+        MATCH_TRYING_TO_SET_MORE_THAN_ONE_PSEUDO_ELEMENT(XRLog.MATCH, "Trying to set more than one pseudo-element"),
+
+        GENERAL_IMPORT_FONT_FACE_RULES_HAS_NOT_BEEN_CALLED(XRLog.GENERAL, "importFontFaceRules has not been called for this pdf transcoder"),
+        GENERAL_NO_OP_REPAINT_REQUESTED(XRLog.GENERAL, "No-op repaint requested"),
+        GENERAL_PDF_ACCESSIBILITY_NO_ALT_ATTRIBUTE_PROVIDED_FOR_IMAGE(XRLog.GENERAL, "No alt attribute provided for image/replaced in PDF/UA document."),
+        GENERAL_PDF_SPECIFIED_FONTS_DONT_CONTAIN_A_SPACE_CHARACTER(XRLog.GENERAL, "Specified fonts don't contain a space character!"),
+        GENERAL_PDF_USING_FAST_MODE(XRLog.GENERAL, "Using fast-mode renderer. Prepare to fly."),
+        GENERAL_PDF_ACCESSIBILITY_NO_DOCUMENT_TITLE_PROVIDED(XRLog.GENERAL, "No document title provided. Document will not be PDF/UA compliant."),
+        GENERAL_PDF_USING_GET_REQUEST_FOR_FORM(XRLog.GENERAL, "Using GET request method for form. You probably meant to add a method=\"post\" attribute to your form"),
+        GENERAL_PDF_ACROBAT_READER_DOES_NOT_SUPPORT_FORMS_WITH_FILE_INPUT(XRLog.GENERAL, "Acrobat Reader does not support forms with file input controls"),
+
+        EXCEPTION_SVG_COULD_NOT_DRAW(XRLog.EXCEPTION, "Couldn't draw SVG."),
+        EXCEPTION_SVG_COULD_NOT_READ_FONT(XRLog.EXCEPTION, "Couldn't read font"),
+        EXCEPTION_MATHML_COULD_NOT_REGISTER_FONT(XRLog.EXCEPTION, "Could not register font correctly"),
+        EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT(XRLog.EXCEPTION, "Couldn't load font. Please check that it is a valid truetype font."),
+        EXCEPTION_PROBLEM_TRYING_TO_READ_INPUT_XHTML_FILE(XRLog.EXCEPTION, "Problem trying to read input XHTML file"),
+        EXCEPTION_CANT_READ_XHTML_EMBEDDED_IMAGE(XRLog.EXCEPTION, "Can't read XHTML embedded image."),
+        EXCEPTION_COULD_NOT_LOAD_FONT_METRICS(XRLog.EXCEPTION, "Couldn't load font metrics."),
+        EXCEPTION_UNABLE_TO_PARSE_PAGE_OF_IMG_TAG_WITH_PDF(XRLog.EXCEPTION, "Unable to parse page of img tag with PDF!"),
+        EXCEPTION_TRIED_TO_OPEN_A_PASSWORD_PROTECTED_DOCUMENT_AS_SRC_FOR_IMG(XRLog.EXCEPTION, "Tried to open a password protected document as src for an img!"),
+        EXCEPTION_COULD_NOT_READ_PDF_AS_SRC_FOR_IMG(XRLog.EXCEPTION, "Could not read pdf passed as src for img element!"),
+        EXCEPTION_COULD_NOT_PARSE_DEFAULT_STYLESHEET(XRLog.EXCEPTION, "Could not parse default stylesheet"),
+        EXCEPTION_SELECTOR_BAD_SIBLING_AXIS(XRLog.EXCEPTION, "Bad sibling axis"),
+        EXCEPTION_FONT_METRICS_NOT_AVAILABLE(XRLog.EXCEPTION, "Font metrics not available. Probably a bug.");
+
+        private final String where;
+        private final String messageFormat;
+
+        LogMessageId0Param(String where, String messageFormat) {
+            this.where = where;
+            this.messageFormat = messageFormat;
+        }
+
+        @Override
+        public Enum<?> getEnum() {
+            return this;
+        }
+
+        @Override
+        public String getMessageFormat() {
+            return messageFormat;
+        }
+
+        @Override
+        public String getWhere() {
+            return where;
+        }
+
+    }
+
+    enum LogMessageId1Param implements LogMessageId {
+        CSS_PARSE_REMOVING_STYLESHEET_URI_FROM_CACHE_BY_REQUEST(XRLog.CSS_PARSE, "Removing stylesheet '{}' from cache by request."),
+        CSS_PARSE_REQUESTED_REMOVING_STYLESHEET_URI_NOT_IN_CACHE(XRLog.CSS_PARSE, "Requested removing stylesheet '{}', but it's not in cache."),
+
+        XML_ENTITIES_SAX_FEATURE_NOT_SUPPORTED(XRLog.XML_ENTITIES, "SAX feature not supported on this XMLReader: {}"),
+        XML_ENTITIES_SAX_FEATURE_NOT_RECOGNIZED(XRLog.XML_ENTITIES, "SAX feature not recognized on this XMLReader: {}. Feature may be properly named, but not recognized by this parser."),
+        XML_ENTITIES_EXCEPTION_MESSAGE(XRLog.XML_ENTITIES, "{}"),
+        XML_ENTITIES_COULD_NOT_OPEN_XML_CATALOG_FROM_URI(XRLog.XML_ENTITIES, "Could not open XML catalog from URI '{}'"),
+        XML_ENTITIES_ENTITY_PUBLIC_NO_LOCAL_MAPPING(XRLog.XML_ENTITIES, "Entity public: {}, no local mapping. Returning empty entity to avoid pulling from network."),
+
+        INIT_FONT_COULD_NOT_BE_LOADED(XRLog.INIT, "Font {} could not be loaded"),
+
+        RENDER_OP_MUST_NOT_BE_USED_BY_FAST_RENDERER(XRLog.RENDER, "{} MUST not be used by the fast renderer. Please consider reporting this bug."),
+        RENDER_UNKNOWN_PAINT(XRLog.RENDER, "Unknown paint: {}"),
+        RENDER_USING_CSS_IMPLEMENTATION_FROM(XRLog.RENDER, "Using CSS implementation from: {}"),
+
+
+        MATCH_TRYING_TO_APPEND_CONDITIONS_TO_PSEUDO_ELEMENT(XRLog.MATCH, "Trying to append conditions to pseudoElement {}"),
+        MATCH_MATCHER_CREATED_WITH_SELECTOR(XRLog.MATCH, "Matcher created with {} selectors"),
+        MATCH_MEDIA_IS(XRLog.MATCH, "media = {}"),
+
+        LOAD_COULD_NOT_INSTANTIATE_CUSTOM_XML_READER(XRLog.LOAD, "Could not instantiate custom XMLReader class for XML parsing: {}. " +
+                "Please check classpath. Use value 'default' in FS configuration if necessary. Will now try JDK default."),
+        LOAD_UNABLE_TO_LOAD_CSS_FROM_URI(XRLog.LOAD, "Unable to load CSS from {}"),
+        LOAD_PARSE_STYLESHEETS_TIME(XRLog.LOAD, "TIME: parse stylesheets {}ms"),
+        LOAD_REQUESTING_STYLESHEET_AT_URI(XRLog.LOAD, "Requesting stylesheet: {}"),
+        LOAD_UNRECOGNIZED_IMAGE_FORMAT_FOR_URI(XRLog.LOAD, "Unrecognized image format for: {}"),
+        LOAD_URI_RESOLVER_REJECTED_RESOLVING_CSS_IMPORT_AT_URI(XRLog.LOAD, "URI resolver rejected resolving CSS import at ({})"),
+        LOAD_URI_RESOLVER_REJECTED_RESOLVING_URI_AT_URI_IN_CSS_STYLESHEET(XRLog.LOAD, "URI resolver rejected resolving URI at ({}) in CSS stylehseet"),
+        LOAD_PUTTING_KEY_IN_CACHE(XRLog.LOAD, "Putting key({}) in cache."),
+        LOAD_EXCEPTION_MESSAGE(XRLog.LOAD, "{}"),
+        LOAD_SAX_FEATURE_NOT_SUPPORTED(XRLog.LOAD, "SAX feature not supported on this XMLReader: {}"),
+        LOAD_SAX_FEATURE_NOT_RECOGNIZED(XRLog.LOAD, "SAX feature not recognized on this XMLReader: {}. Feature may be properly named, but not recognized by this parser."),
+        LOAD_COULD_NOT_LOAD_PREFERRED_XML(XRLog.LOAD, "Could not load preferred XML {}, using default which may not be secure."),
+        LOAD_LOADED_DOCUMENT_TIME(XRLog.LOAD, "Loaded document in ~{}ms"),
+        LOAD_SAX_XMLREADER_IN_USE(XRLog.LOAD, "SAX XMLReader in use (parser): {}"),
+        LOAD_XMLREADER_CLASS_SPECIFIED_COULD_NOT_BE_FOUND(XRLog.LOAD,"The XMLReader class you specified as a configuration property " +
+                "could not be found. Class.forName() failed on " +
+                "{}. Please check classpath. Use value 'default' in " +
+                "FS configuration if necessary. Will now try JDK default."),
+        LOAD_ICON_REPLACED_IMAGE_REPAINT_REQUESTED(XRLog.LOAD, "Icon: replaced image {}, repaint requested"),
+        LOAD_COULD_NOT_RESOLVE_RELATIVE_URI_BECAUSE_NO_BASE_URI_WAS_PROVIDED(XRLog.LOAD, "Couldn't resolve relative URI({}) because no base URI was provided."),
+        LOAD_CLEARING_PENDING_ITEMS_FROM_LOAD_QUEUE(XRLog.LOAD, "By request, clearing pending items from load queue: {}"),
+        LOAD_LOAD_IMMEDIATE_URI(XRLog.LOAD, "Load immediate: {}"),
+        LOAD_IMAGE_CACHE_MISS_QUEUEING(XRLog.LOAD, "Image cache miss, URI not yet loaded, queueing: {}"),
+
+        LAYOUT_FUNCTION_NOT_IMPLEMENTED(XRLog.LAYOUT, "{} function not implemented at this time"),
+        LAYOUT_UNSUPPORTED_SHAPE(XRLog.LAYOUT, "Unsupported shape: '{}'"),
+        LAYOUT_NO_MAP_NAMED(XRLog.LAYOUT, "No map named: '{}'"),
+        LAYOUT_UNKNOWN_FIELD_TYPE(XRLog.LAYOUT, "Unknown field type: {}"),
+
+        GENERAL_MESSAGE(XRLog.GENERAL, "{}"),
+        GENERAL_INVALID_INTEGER_PASSED_IN_VIEWBOX_ATTRIBUTE_FOR_SVG(XRLog.GENERAL, "Invalid integer passed in viewBox attribute for SVG: {}"),
+        GENERAL_QUEUEING_LOAD_FOR_IMAGE_URI(XRLog.GENERAL, "Queueing load for image uri {}"),
+        GENERAL_INVALID_INTEGER_PASSED_AS_DIMENSION_FOR_SVG(XRLog.GENERAL, "Invalid integer passed as dimension for SVG: {}"),
+        GENERAL_COULD_NOT_FIND_FONT_SPECIFIED_FOR_MATHML_OBJECT_IN_FONT_FACE_RULES(XRLog.GENERAL, "Could not find font ({}) specified for MathML object in font-face rules"),
+        GENERAL_THREAD_REQUESTED_ITEM_BUT_QUEUE_IS_SHUTTING_DOWN(XRLog.GENERAL, "Thread {} requested item, but queue is shutting down; returning kill switch."),
+        GENERAL_MUTABLE_IMAGE_URI_LOADED_REPAINT_REQUESTED(XRLog.GENERAL, "Mutable image {} loaded, repaint requested"),
+        GENERAL_PDF_ACCESSIBILITY_NO_TITLE_TEXT_PROVIDED_FOR(XRLog.GENERAL, "PDF/UA - No title text provided for {}."),
+        GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_BOOKMARK(XRLog.GENERAL, "Could not find valid target for bookmark. Bookmark href = {}"),
+        GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_LINK(XRLog.GENERAL, "Could not find valid target for link. Link href = {}"),
+        GENERAL_PDF_URI_IN_HREF_IS_NOT_A_VALID_URI(XRLog.GENERAL, "'{}' in href is not a valid URI, will be skipped"),
+        GENERAL_PDF_FOUND_FORM_CONTROL_WITH_NO_ENCLOSING_FORM(XRLog.GENERAL, "Found form control ({}) with no enclosing form. Ignoring."),
+        GENERAL_PDF_A_ELEMENT_DOES_NOT_HAVE_OPTION_CHILDREN(XRLog.GENERAL, "A <{}> element does not have <option> children"),
+
+        EXCEPTION_URI_SYNTAX_WHILE_LOADING_EXTERNAL_SVG_RESOURCE(XRLog.EXCEPTION, "URI syntax exception while loading external svg resource: {}"),
+        EXCEPTION_SVG_ERROR_HANDLER(XRLog.EXCEPTION, "SVG {}"),
+        EXCEPTION_PDF_IN_WRITING_METHOD(XRLog.EXCEPTION, "Exception in PDF writing method: {}"),
+        EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI(XRLog.EXCEPTION, "Can't read image file; unexpected problem for URI '{}'"),
+        EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI_NOT_FOUND(XRLog.EXCEPTION, "Can't read image file; image at URI '{}' not found"),
+        EXCEPTION_COULD_NOT_LOAD_FONT(XRLog.EXCEPTION, "Couldn't load font ({}). Please check that it is a valid truetype font."),
+        EXCEPTION_COULD_NOT_CACHE_VALUE_FOR_KEY(XRLog.EXCEPTION, "Could not load cache value for key({})"),
+        EXCEPTION_UNHANDLED(XRLog.EXCEPTION, "Unhandled exception. {}"),
+        EXCEPTION_MALFORMED_URL(XRLog.EXCEPTION, "Bad URL given: {}"),
+        EXCEPTION_ITEM_AT_URI_NOT_FOUND(XRLog.EXCEPTION, "Item at URI {} not found"),
+        EXCEPTION_IO_PROBLEM_FOR_URI(XRLog.EXCEPTION, "IO problem for {}"),
+        EXCEPTION_CSS_UNABLE_TO_DERIVE_INITIAL_VALUE_FOR_CLASSNAME(XRLog.EXCEPTION, "Unable to derive initial value for {}"),
+        EXCEPTION_COULD_NOT_LOAD_FONT_FACE(XRLog.EXCEPTION, "Could not load @font-face font: {}"),
+        EXCEPTION_COULD_NOT_LOAD_DEFAULT_CSS(XRLog.EXCEPTION, "Can't load default CSS from {}. This file must be on your CLASSPATH. Please check before continuing."),
+        EXCEPTION_DEFAULT_USERAGENT_IS_NOT_ABLE_TO_RESOLVE_BASE_URL_FOR(XRLog.EXCEPTION, "The default NaiveUserAgent doesn't know how to resolve the base URL for {}"),
+        EXCEPTION_FAILED_TO_LOAD_BACKGROUND_IMAGE_AT_URI(XRLog.EXCEPTION, "Failed to load background image at uri {}");
+
+        private final String where;
+        private final String messageFormat;
+
+        LogMessageId1Param(String where, String messageFormat) {
+            this.where = where;
+            this.messageFormat = messageFormat;
+        }
+
+        @Override
+        public Enum<?> getEnum() {
+            return this;
+        }
+
+        @Override
+        public String getMessageFormat() {
+            return messageFormat;
+        }
+
+        @Override
+        public String getWhere() {
+            return where;
+        }
+    }
+
+    enum LogMessageId2Param implements LogMessageId {
+        CSS_PARSE_COULDNT_PARSE_STYLESHEET_AT_URI(XRLog.CSS_PARSE, "Couldn't parse stylesheet at URI {}: {}"),
+        CSS_PARSE_GENERIC_MESSAGE(XRLog.CSS_PARSE, "({}) {}"),
+
+        XML_ENTITIES_SAX_FEATURE_SET(XRLog.XML_ENTITIES, "SAX Parser feature: {} set to {}"),
+        XML_ENTITIES_ENTITY_PUBLIC_NOT_FOUND_OR_LOCAL(XRLog.XML_ENTITIES, "Entity public: {} -> {}"),
+        XML_ENTITIES_ENTITY_CANT_FIND_LOCAL_REFERENCE(XRLog.XML_ENTITIES, "Can't find a local reference for Entity for public ID: {}" +
+                " and expected to. The local URL should be: {}. Not finding " +
+                "this probably means a CLASSPATH configuration problem; this resource " +
+                "should be included with the renderer and so not finding it means it is " +
+                "not on the CLASSPATH, and should be. Will let parser use the default in " +
+                "this case."),
+
+        LAYOUT_CSS_PROPERTY_HAS_UNPROCESSABLE_ASSIGNMENT(XRLog.LAYOUT, "Property {}} has an assignment we don't understand, " +
+                "and can't tell if it's an absolute unit or not. Assuming it is not. Exception was: {}"),
+        LAYOUT_FORM_ACTION_PERFORMED(XRLog.LAYOUT, "{} pressed: {}"),
+
+        LOAD_LOADING_FONT_FROM_SUPPLIER(XRLog.LOAD, "Loading font({}) from {} supplier now."),
+        LOAD_CACHE_HIT_STATUS(XRLog.LOAD, "{} key({}) from cache."),
+        LOAD_SAX_FEATURE_SET(XRLog.LOAD, "SAX Parser feature: {} set to {}"),
+        LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI(XRLog.LOAD, "URI resolver rejected loading {} at ({})"),
+        LOAD_COULD_NOT_READ_URI_AT_URL_MAY_BE_RELATIVE(XRLog.LOAD, "Could not read {} as a URL; may be relative. Testing using parent URL {}"),
+        LOAD_WAS_ABLE_TO_READ_FROM_URI_USING_PARENT_URL(XRLog.LOAD, "Was able to read from {} using parent URL {}"),
+        LOAD_IMAGE_LOAD_WORKER_LOADED_WITH_URI(XRLog.LOAD, "{}, loaded {}"),
+
+        GENERAL_FATAL_INFINITE_LOOP_BUG_IN_LINE_BREAKING_ALGO(XRLog.GENERAL, "A fatal infinite loop bug was detected in the line breaking " +
+                "algorithm for break-word! Start-substring=[{}], end={}"),
+        GENERAL_EXPECTING_BOX_CHILDREN_OF_TYPE_BUT_GOT(XRLog.GENERAL, "Expecting box children to be of type ({}) but got ({})."),
+        GENERAL_PDF_FOUND_ELEMENT_WITHOUT_ATTRIBUTE_NAME(XRLog.GENERAL, "found a <{} {}> element without attribute name, the element will not work without this attribute"),
+
+        EXCEPTION_CANT_OPEN_STREAM_FOR_URI(XRLog.EXCEPTION, "Can't open stream for URI '{}': {}"),
+        EXCEPTION_SVG_EXTERNAL_RESOURCE_NOT_ALLOWED(XRLog.EXCEPTION, "Tried to fetch external resource from SVG. Refusing. Details: {}, {}"),
+        EXCEPTION_DEFAULT_USERAGENT_IS_NOT_ABLE_TO_RESOLVE_URL_WITH_BASE_URL(XRLog.EXCEPTION, "The default NaiveUserAgent cannot resolve the URL {} with base URL {}");
+
+        private final String where;
+        private final String messageFormat;
+
+        LogMessageId2Param(String where, String messageFormat) {
+            this.where = where;
+            this.messageFormat = messageFormat;
+        }
+
+        @Override
+        public Enum<?> getEnum() {
+            return this;
+        }
+
+        @Override
+        public String getMessageFormat() {
+            return messageFormat;
+        }
+
+        @Override
+        public String getWhere() {
+            return where;
+        }
+    }
+
+    enum LogMessageId3Param implements LogMessageId {
+
+        LOAD_SWING_IMAGE_REQUESTED_AT_URI(XRLog.LOAD, "Swing: Image {} requested at to {}, {}"),
+
+        GENERAL_THREAD_PULLED_ITEM_FROM_QUEUE(XRLog.GENERAL, "Thread {} pulled item {} from queue, {} remaining"),
+        GENERAL_PDF_ACCESSIBILITY_INCOMPATIBLE_CHILD(XRLog.GENERAL, "Trying to add incompatible child to parent item: " +
+                " child type={}" +
+                ", parent type={}" +
+                ", expected child type={}" +
+                ". Document will not be PDF/UA compliant."),
+
+        EXCEPTION_URI_WITH_BASE_URI_INVALID(XRLog.EXCEPTION, "When trying to load uri({}) with base {} URI({}), one or both were invalid URIs."),
+        EXCEPTION_SVG_SCRIPT_NOT_ALLOWED(XRLog.EXCEPTION, "Tried to run script inside SVG. Refusing. Details: {}, {}, {}");
+
+
+        private final String where;
+        private final String messageFormat;
+
+        LogMessageId3Param(String where, String messageFormat) {
+            this.where = where;
+            this.messageFormat = messageFormat;
+        }
+
+        @Override
+        public Enum<?> getEnum() {
+            return this;
+        }
+
+        @Override
+        public String getMessageFormat() {
+            return messageFormat;
+        }
+
+        @Override
+        public String getWhere() {
+            return where;
+        }
+    }
+
+    enum LogMessageId4Param implements LogMessageId {
+        LOAD_IMAGE_LOADER_SCALING_URI_TO(XRLog.LOAD, "{}, scaling {} to {}, {}"),
+
+        CASCADE_UNKNOWN_DATATYPE_FOR_RELATIVE_TO_ABSOLUTE(XRLog.CASCADE, "Asked to convert {} from relative to absolute, don't recognize the datatype '{}' {}({})"),
+        CASCADE_CALC_FLOAT_PROPORTIONAL_VALUE_INFO_FONT_SIZE(XRLog.CASCADE, "{}, relative= {} ({}), absolute= {}"),
+
+        EXCEPTION_CONFIGURATION_WRONG_TYPE(XRLog.EXCEPTION, "Property '{}' was requested as a {}, but value of '{}' is not a {}. Check configuration."),;
+
+
+
+        private final String where;
+        private final String messageFormat;
+
+        LogMessageId4Param(String where, String messageFormat) {
+            this.where = where;
+            this.messageFormat = messageFormat;
+        }
+
+        @Override
+        public Enum<?> getEnum() {
+            return this;
+        }
+
+        @Override
+        public String getMessageFormat() {
+            return messageFormat;
+        }
+
+        @Override
+        public String getWhere() {
+            return where;
+        }
+    }
+
+    enum LogMessageId5Param implements LogMessageId {
+
+        CASCADE_CALC_FLOAT_PROPORTIONAL_VALUE_INFO(XRLog.CASCADE, "{}, relative= {} ({}), absolute= {} using base={}");
+
+        private final String where;
+        private final String messageFormat;
+
+        LogMessageId5Param(String where, String messageFormat) {
+            this.where = where;
+            this.messageFormat = messageFormat;
+        }
+
+        @Override
+        public Enum<?> getEnum() {
+            return this;
+        }
+
+        @Override
+        public String getMessageFormat() {
+            return messageFormat;
+        }
+
+        @Override
+        public String getWhere() {
+            return where;
+        }
+
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/StreamResource.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/StreamResource.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.BufferedInputStream;
 import java.net.URLConnection;
 import java.net.URL;
+import java.util.logging.Level;
 
 /**
  * Created by IntelliJ IDEA.
@@ -31,24 +32,24 @@ public class StreamResource {
             // If using Java 5+ you can set timeouts for the URL connection--useful if the remote
             // server is down etc.; the default timeout is pretty long
             //
-            //uc.setConnectTimeout(10 * 1000);
-            //uc.setReadTimeout(30 * 1000);
+            _conn.setConnectTimeout(10 * 1000);
+            _conn.setReadTimeout(30 * 1000);
             //
             // TODO:CLEAN-JDK1.4
             // Since we target 1.4, we use a couple of system properties--note these are only supported
             // in the Sun JDK implementation--see the Net properties guide in the JDK
             // e.g. file:///usr/java/j2sdk1.4.2_17/docs/guide/net/properties.html
-            System.setProperty("sun.net.client.defaultConnectTimeout", String.valueOf(10 * 1000));
-            System.setProperty("sun.net.client.defaultReadTimeout", String.valueOf(30 * 1000));
+            //System.setProperty("sun.net.client.defaultConnectTimeout", String.valueOf(10 * 1000));
+            //System.setProperty("sun.net.client.defaultReadTimeout", String.valueOf(30 * 1000));
 
             _conn.connect();
             _slen = _conn.getContentLength();
         } catch (java.net.MalformedURLException e) {
-            XRLog.exception("bad URL given: " + _uri, e);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_MALFORMED_URL, _uri, e);
         } catch (FileNotFoundException e) {
-            XRLog.exception("item at URI " + _uri + " not found");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_ITEM_AT_URI_NOT_FOUND, _uri, e);
         } catch (IOException e) {
-            XRLog.exception("IO problem for " + _uri, e);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_IO_PROBLEM_FOR_URI, _uri, e);
         }
     }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/ThreadCtx.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/ThreadCtx.java
@@ -2,27 +2,42 @@ package com.openhtmltopdf.util;
 
 import com.openhtmltopdf.layout.SharedContext;
 
+import java.io.Closeable;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+
 /**
  * Because OpenHTMLtoPDF is designed to run in a single thread at all times for one invocation,
  * we can use a ThreadLocal to store pseudo global variables.
  * This MUST be set up in the appropriate renderer.
  */
 public class ThreadCtx {
-	private static final ThreadLocal<ThreadData> data = new ThreadLocal<ThreadCtx.ThreadData>() {
-		@Override
-		protected ThreadData initialValue() {
-			return new ThreadData();
-		}
-	};
-	
+
+	private static final ThreadLocal<ThreadData> data = ThreadLocal.withInitial(() -> new ThreadData());
+	private static final ThreadLocal<Consumer<Diagnostic>> diagnosticConsumer = new ThreadLocal();
+
+
+
 	public static ThreadData get() {
 		return data.get();
+	}
+
+	static void addDiagnostic(Diagnostic diagnostic) {
+		Consumer<Diagnostic> consumer = diagnosticConsumer.get();
+		if (consumer != null) {
+			consumer.accept(diagnostic);
+		}
 	}
 	
 	public static void cleanup() {
 		data.remove();
 	}
-	
+
+	public static Closeable applyDiagnosticConsumer(Consumer<Diagnostic> consumer) {
+		diagnosticConsumer.set(consumer);
+		return () -> diagnosticConsumer.remove();
+	}
+
 	public static class ThreadData {
 		private ThreadData() { }
 		private SharedContext sharedContext;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLog.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLog.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
  * @author empty
  */
 public class XRLog {
-    private static final List<String> LOGGER_NAMES = new ArrayList<String>(20);
+    private static final List<String> LOGGER_NAMES = new ArrayList<>(20);
     public final static String CONFIG = registerLoggerByName("com.openhtmltopdf.config");
     public final static String EXCEPTION = registerLoggerByName("com.openhtmltopdf.exception");
     public final static String GENERAL = registerLoggerByName("com.openhtmltopdf.general");
@@ -66,176 +66,59 @@ public class XRLog {
      */
     public static List<String> listRegisteredLoggers() {
         // defensive copy
-        return new ArrayList<String>(LOGGER_NAMES);
+        return new ArrayList<>(LOGGER_NAMES);
     }
 
-
-    public static void cssParse(String msg) {
-        cssParse(Level.INFO, msg);
+    public static void log(Level level, LogMessageId.LogMessageId0Param logMessageId) {
+        log(level, logMessageId, false);
     }
 
-    public static void cssParse(Level level, String msg) {
-        log(CSS_PARSE, level, msg);
+    public static void log(Level level, LogMessageId.LogMessageId0Param logMessageId, Throwable t) {
+        log(level, logMessageId, true, t);
     }
 
-    public static void cssParse(Level level, String msg, Throwable th) {
-        log(CSS_PARSE, level, msg, th);
+    public static void log(Level level, LogMessageId.LogMessageId1Param logMessageId, Object arg) {
+        log(level, logMessageId, false, arg);
     }
 
-    public static void xmlEntities(String msg) {
-        xmlEntities(Level.INFO, msg);
+    public static void log(Level level, LogMessageId.LogMessageId1Param logMessageId, Object arg, Throwable throwable) {
+        log(level, logMessageId, true, arg, throwable);
     }
 
-    public static void xmlEntities(Level level, String msg) {
-        log(XML_ENTITIES, level, msg);
+    public static void log(Level level, LogMessageId.LogMessageId2Param logMessageId, Object arg1, Object arg2) {
+        log(level, logMessageId, false, arg1, arg2);
     }
 
-    public static void xmlEntities(Level level, String msg, Throwable th) {
-        log(XML_ENTITIES, level, msg, th);
+    public static void log(Level level, LogMessageId.LogMessageId2Param logMessageId, Object arg1, Object arg2, Throwable throwable) {
+        log(level, logMessageId, true, arg1, arg2, throwable);
     }
 
-    public static void cascade(String msg) {
-        cascade(Level.INFO, msg);
+    public static void log(Level level, LogMessageId.LogMessageId3Param logMessageId, Object arg1, Object arg2, Object arg3) {
+        log(level, logMessageId, false, arg1, arg2, arg3);
     }
 
-    public static void cascade(Level level, String msg) {
-        log(CASCADE, level, msg);
+    public static void log(Level level, LogMessageId.LogMessageId3Param logMessageId, Object arg1, Object arg2, Object arg3, Throwable throwable) {
+        log(level, logMessageId, true, arg1, arg2, arg3, throwable);
     }
 
-    public static void cascade(Level level, String msg, Throwable th) {
-        log(CASCADE, level, msg, th);
+    public static void log(Level level, LogMessageId.LogMessageId4Param logMessageId, Object arg1, Object arg2, Object arg3, Object arg4) {
+        log(level, logMessageId, false, arg1, arg2, arg3, arg4);
     }
 
-    public static void exception(String msg) {
-        exception(msg, null);
+    public static void log(Level level, LogMessageId.LogMessageId5Param logMessageId, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        log(level, logMessageId, false, arg1, arg2, arg3, arg4, arg5);
     }
 
-    public static void exception(String msg, Throwable th) {
-        log(EXCEPTION, Level.WARNING, msg, th);
-    }
-
-    public static void general(String msg) {
-        general(Level.INFO, msg);
-    }
-
-    public static void general(Level level, String msg) {
-        log(GENERAL, level, msg);
-    }
-
-    public static void general(Level level, String msg, Throwable th) {
-        log(GENERAL, level, msg, th);
-    }
-
-    public static void init(String msg) {
-        init(Level.INFO, msg);
-    }
-
-    public static void init(Level level, String msg) {
-        log(INIT, level, msg);
-    }
-
-    public static void init(Level level, String msg, Throwable th) {
-        log(INIT, level, msg, th);
-    }
-
-    public static void junit(String msg) {
-        junit(Level.FINEST, msg);
-    }
-
-    public static void junit(Level level, String msg) {
-        log(JUNIT, level, msg);
-    }
-
-    public static void junit(Level level, String msg, Throwable th) {
-        log(JUNIT, level, msg, th);
-    }
-
-    public static void load(String msg) {
-        load(Level.INFO, msg);
-    }
-
-    public static void load(Level level, String msg) {
-        log(LOAD, level, msg);
-    }
-
-    public static void load(Level level, String msg, Throwable th) {
-        log(LOAD, level, msg, th);
-    }
-
-    public static void match(String msg) {
-        match(Level.INFO, msg);
-    }
-
-    public static void match(Level level, String msg) {
-        log(MATCH, level, msg);
-    }
-
-    public static void match(Level level, String msg, Throwable th) {
-        log(MATCH, level, msg, th);
-    }
-
-    public static void layout(String msg) {
-        layout(Level.INFO, msg);
-    }
-
-    public static void layout(Level level, String msg) {
-        log(LAYOUT, level, msg);
-    }
-
-    public static void layout(Level level, String msg, Throwable th) {
-        log(LAYOUT, level, msg, th);
-    }
-
-    public static void render(String msg) {
-        render(Level.INFO, msg);
-    }
-
-    public static void render(Level level, String msg) {
-        log(RENDER, level, msg);
-    }
-
-    public static void render(Level level, String msg, Throwable th) {
-        log(RENDER, level, msg, th);
-    }
-
-    public static synchronized void log(String where, Level level, String msg) {
+    private static void log(Level level, LogMessageId logMessageId, boolean hasError, Object... args) {
         if (initPending) {
             init();
         }
         if (isLoggingEnabled()) {
-            loggerImpl.log(where, level, msg);
-        }
-    }
-
-    public static synchronized void log(String where, Level level, String msg, Throwable th) {
-        if (initPending) {
-            init();
-        }
-        if (isLoggingEnabled()) {
-            loggerImpl.log(where, level, msg, th);
-        }
-    }
-
-    public static void main(String args[]) {
-        try {
-            XRLog.cascade("Cascade msg");
-            XRLog.cascade(Level.WARNING, "Cascade msg");
-            XRLog.exception("Exception msg");
-            XRLog.exception("Exception msg", new Exception());
-            XRLog.general("General msg");
-            XRLog.general(Level.WARNING, "General msg");
-            XRLog.init("Init msg");
-            XRLog.init(Level.WARNING, "Init msg");
-            XRLog.load("Load msg");
-            XRLog.load(Level.WARNING, "Load msg");
-            XRLog.match("Match msg");
-            XRLog.match(Level.WARNING, "Match msg");
-            XRLog.layout("Layout msg");
-            XRLog.layout(Level.WARNING, "Layout msg");
-            XRLog.render("Render msg");
-            XRLog.render(Level.WARNING, "Render msg");
-        } catch (Exception ex) {
-            ex.printStackTrace();
+            Diagnostic diagnostic = new Diagnostic(level, logMessageId, hasError, args);
+            if (loggerImpl.isLogLevelEnabled(diagnostic)) {
+                loggerImpl.log(diagnostic);
+            }
+            ThreadCtx.addDiagnostic(diagnostic);
         }
     }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLogger.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLogger.java
@@ -25,8 +25,24 @@ import java.util.logging.Level;
  * An interface whose implementations log Flying Saucer log messages.
  */
 public interface XRLogger {
-    public void log(String where, Level level, String msg);
-    public void log(String where, Level level, String msg, Throwable th);
-    
-    public void setLevel(String logger, Level level);
+    void log(String where, Level level, String msg);
+    void log(String where, Level level, String msg, Throwable th);
+    void setLevel(String logger, Level level);
+
+    boolean isLogLevelEnabled(Diagnostic diagnostic);
+
+    /**
+     * Default slow (!) implementation for logging a Diagnostic object.
+     *
+     * Concrete implementation must/should override it.
+     *
+     * @param diagnostic
+     */
+    default void log(Diagnostic diagnostic) {
+        if (diagnostic.hasError()) {
+            log(diagnostic.getLogMessageId().getWhere(), diagnostic.getLevel(), diagnostic.getFormattedMessage(), diagnostic.getError());
+        } else {
+            log(diagnostic.getLogMessageId().getWhere(), diagnostic.getLevel(), diagnostic.getFormattedMessage());
+        }
+    }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRRuntimeException.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRRuntimeException.java
@@ -21,6 +21,8 @@
 package com.openhtmltopdf.util;
 
 
+import java.util.logging.Level;
+
 /**
  * General runtime exception used in XHTMLRenderer. Auto-logs messages to
  * plumbing.exception hierarchy.
@@ -58,7 +60,7 @@ public class XRRuntimeException extends RuntimeException {
      * @param msg  Message for the log.
      */
     private void log( String msg ) {
-        XRLog.exception( "Unhandled exception. " + msg );
+        XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_UNHANDLED, msg);
     }
 
     /**
@@ -70,7 +72,7 @@ public class XRRuntimeException extends RuntimeException {
      *      IOException.
      */
     private void log( String msg, Throwable cause ) {
-        XRLog.exception( "Unhandled exception. " + msg, cause );
+        XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_UNHANDLED, msg, cause);
     }
 }
 

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/XRLogTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/XRLogTest.java
@@ -3,13 +3,15 @@ package com.openhtmltopdf.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.logging.Level;
+
 public class XRLogTest {
 
 	@Test
 	public void testDisableLogBeforeFirstLog() {
 		XRLog.setLoggingEnabled(false);
 		Assert.assertFalse(XRLog.isLoggingEnabled());
-		XRLog.load("First log");
+		XRLog.log(Level.INFO, LogMessageId.LogMessageId0Param.LOAD_UNABLE_TO_DISABLE_XML_EXTERNAL_ENTITIES);
 		Assert.assertFalse(XRLog.isLoggingEnabled());
 	}
 	

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -13,6 +13,7 @@ import javax.imageio.ImageIO;
 
 import com.openhtmltopdf.latexsupport.LaTeXDOMMutator;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
+import com.openhtmltopdf.util.Diagnostic;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.util.Charsets;
 import org.w3c.dom.Element;
@@ -157,6 +158,11 @@ public class TestcaseRunner {
 		XRLog.setLoggerImpl(new XRLogger() {
 			@Override
 			public void setLevel(String logger, Level level) {
+			}
+
+			@Override
+			public boolean isLogLevelEnabled(Diagnostic diagnostic) {
+				return true;
 			}
 
 			@Override

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/visualtest/TestSupport.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/visualtest/TestSupport.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.openhtmltopdf.util.Diagnostic;
 import org.w3c.dom.Element;
 
 import com.openhtmltopdf.bidi.support.ICUBidiReorderer;
@@ -71,7 +72,12 @@ public class TestSupport {
             this.delegate = delegate;
             this.sb = sb;
         }
-        
+
+        @Override
+        public boolean isLogLevelEnabled(Diagnostic diagnostic) {
+            return true;
+        }
+
         @Override
         public void setLevel(String logger, Level level) {
         }

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
@@ -33,6 +33,7 @@ import com.openhtmltopdf.outputdevice.helper.FontFamily;
 import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 import com.openhtmltopdf.outputdevice.helper.MinimalFontDescription;
 import com.openhtmltopdf.render.FSFont;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.awt.Font;
@@ -54,7 +55,7 @@ import java.util.logging.Level;
 public class Java2DFontResolver implements FontResolver {
 
     private static abstract class FontDescription implements MinimalFontDescription {
-        protected static final String FAIL_MSG = "Couldn't load font. Please check that it is a valid truetype font.";
+        //protected static final String FAIL_MSG = "Couldn't load font. Please check that it is a valid truetype font.";
         protected final int _weight;
         protected final IdentValue _style;
         protected Font _font;
@@ -102,7 +103,7 @@ public class Java2DFontResolver implements FontResolver {
                 try {
                     _font = Font.createFont(Font.TRUETYPE_FONT, is);
                 } catch (IOException|FontFormatException e) {
-                    XRLog.exception(FAIL_MSG, e);
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
                     return false;
                 } finally {
                     try {
@@ -130,8 +131,8 @@ public class Java2DFontResolver implements FontResolver {
                 try {
                     _font = Font.createFont(Font.TRUETYPE_FONT, _fontFile);
                     _fontFile = null;
-                } catch (IOException|FontFormatException e) {
-                    XRLog.exception(FAIL_MSG, e);
+                } catch (IOException | FontFormatException e) {
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
                     return false;
                 }
             }
@@ -205,7 +206,7 @@ public class Java2DFontResolver implements FontResolver {
             if (rule.hasFontFamily()) {
                 fontFamily = style.valueByName(CSSName.FONT_FAMILY).asString();
             } else {
-                XRLog.cssParse(Level.WARNING, "Must provide at least a font-family and src in @font-face rule");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.CSS_PARSE_MUST_PROVIDE_AT_LEAST_A_FONT_FAMILY_AND_SRC_IN_FONT_FACE_RULE);
                 continue;
             }
 

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DOutputDevice.java
@@ -31,6 +31,7 @@ import com.openhtmltopdf.java2d.api.Java2DRendererBuilder;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.swing.AWTFSImage;
 import com.openhtmltopdf.swing.ImageReplacedElement;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import java.awt.*;
@@ -227,7 +228,7 @@ public class Java2DOutputDevice extends AbstractOutputDevice implements OutputDe
 				gfxTransform.concatenate(transform);
 			}
 		} catch (NoninvertibleTransformException e) {
-			XRLog.render(Level.WARNING, "Tried to set a non-invertible CSS transform. Ignored.");
+		    XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_TRIED_TO_SET_NON_INVERTIBLE_CSS_TRANSFORM);
 		}
 		_graphics.setTransform(gfxTransform);
 		return inverse;

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
@@ -4,7 +4,10 @@ import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.io.*;
 import java.util.List;
+import java.util.logging.Level;
+
 import com.openhtmltopdf.java2d.api.Java2DRendererBuilderState;
+import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -181,7 +184,7 @@ public class Java2DRenderer implements Closeable {
             try {
                 this.setDocument(doc.file);
             } catch (IOException e) {
-                XRLog.exception("Problem trying to read input XHTML file", e);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_PROBLEM_TRYING_TO_READ_INPUT_XHTML_FILE, e);
                 throw new RuntimeException("File IO problem", e);
             }
         }

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
@@ -65,13 +65,16 @@ public class Java2DRenderer implements Closeable {
     private final int _initialPageNo;
     private final short _pagingMode;
 
+    private final Closeable diagnosticConsumer;
+
 
     /**
 	 * Subject to change. Not public API. Used exclusively by the Java2DRendererBuilder class. 
 	 */
 	public Java2DRenderer(BaseDocument doc, UnicodeImplementation unicode, PageDimensions pageSize,
-			Java2DRendererBuilderState state) {
+			Java2DRendererBuilderState state, Closeable diagnosticConsumer) {
 
+	    this.diagnosticConsumer = diagnosticConsumer;
 	    _pagingMode = state._pagingMode;
 		_pageProcessor = state._pageProcessor;
 		_initialPageNo = state._initialPageNumber;		
@@ -439,6 +442,12 @@ public class Java2DRenderer implements Closeable {
     public void close() {
         _sharedContext.removeFromThread();
         ThreadCtx.cleanup();
+
+        try {
+            diagnosticConsumer.close();
+        } catch (IOException e) {
+
+        }
 
         if (_svgImpl != null) {
             try {

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -89,8 +89,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @throws Exception
 	 */
 	public void runPaged() throws Exception {
-		try (Closeable d = this.applyDiagnosticConsumer()) {
-			Java2DRenderer renderer = this.buildJava2DRenderer();
+		try (Closeable d = this.applyDiagnosticConsumer(); Java2DRenderer renderer = this.buildJava2DRenderer(d)) {
 			renderer.layout();
 			if (state._pagingMode == Layer.PAGED_MODE_PRINT)
 				renderer.writePages();
@@ -108,8 +107,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @throws Exception
 	 */
 	public void runFirstPage() throws Exception {
-		try (Closeable d = this.applyDiagnosticConsumer()) {
-			Java2DRenderer renderer = this.buildJava2DRenderer();
+		try (Closeable d = this.applyDiagnosticConsumer(); Java2DRenderer renderer = this.buildJava2DRenderer(d)) {
 			renderer.layout();
 			if (state._pagingMode == Layer.PAGED_MODE_PRINT)
 				renderer.writePage(0);
@@ -119,6 +117,10 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	}
 
 	public Java2DRenderer buildJava2DRenderer() {
+		return buildJava2DRenderer(this.applyDiagnosticConsumer());
+	}
+
+	public Java2DRenderer buildJava2DRenderer(Closeable diagnosticConsumer) {
 
 		UnicodeImplementation unicode = new UnicodeImplementation(state._reorderer, state._splitter, state._lineBreaker,
 				state._unicodeToLowerTransformer, state._unicodeToUpperTransformer, state._unicodeToTitleTransformer, state._textDirection,
@@ -136,7 +138,7 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 			state._layoutGraphics = bf.createGraphics();
 		}
 
-		return new Java2DRenderer(doc, unicode,  pageSize, state);
+		return new Java2DRenderer(doc, unicode,  pageSize, state, diagnosticConsumer);
 	}
 
 	/**

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -2,6 +2,8 @@ package com.openhtmltopdf.java2d.api;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.io.Closeable;
+
 import com.openhtmltopdf.extend.OutputDevice;
 import com.openhtmltopdf.java2d.Java2DRenderer;
 import com.openhtmltopdf.layout.Layer;
@@ -87,12 +89,14 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @throws Exception
 	 */
 	public void runPaged() throws Exception {
-		Java2DRenderer renderer = this.buildJava2DRenderer();
-		renderer.layout();
-		if (state._pagingMode == Layer.PAGED_MODE_PRINT)
-			renderer.writePages();
-		else
-			renderer.writeSinglePage();
+		try (Closeable d = this.applyDiagnosticConsumer()) {
+			Java2DRenderer renderer = this.buildJava2DRenderer();
+			renderer.layout();
+			if (state._pagingMode == Layer.PAGED_MODE_PRINT)
+				renderer.writePages();
+			else
+				renderer.writeSinglePage();
+		}
 	}
 
 	/**
@@ -104,12 +108,14 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
 	 * @throws Exception
 	 */
 	public void runFirstPage() throws Exception {
-		Java2DRenderer renderer = this.buildJava2DRenderer();
-		renderer.layout();
-		if (state._pagingMode == Layer.PAGED_MODE_PRINT)
-			renderer.writePage(0);
-		else
-			renderer.writeSinglePage();
+		try (Closeable d = this.applyDiagnosticConsumer()) {
+			Java2DRenderer renderer = this.buildJava2DRenderer();
+			renderer.layout();
+			if (state._pagingMode == Layer.PAGED_MODE_PRINT)
+				renderer.writePage(0);
+			else
+				renderer.writeSinglePage();
+		}
 	}
 
 	public Java2DRenderer buildJava2DRenderer() {

--- a/openhtmltopdf-mathml-support/src/main/java/com/openhtmltopdf/mathmlsupport/MathMLDrawer.java
+++ b/openhtmltopdf-mathml-support/src/main/java/com/openhtmltopdf/mathmlsupport/MathMLDrawer.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
 import net.sourceforge.jeuclid.font.DefaultFontFactory;
 import net.sourceforge.jeuclid.font.FontFactory;
 
@@ -81,23 +82,21 @@ public class MathMLDrawer implements SVGDrawer {
 		}
 		
 		if (!_availabelFontFamilies.containsKey(family)) {
-			XRLog.general(Level.WARNING, "Could not find font (" + family + ") specifed for MathML object in font-face rules");
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_COULD_NOT_FIND_FONT_SPECIFIED_FOR_MATHML_OBJECT_IN_FONT_FACE_RULES,family);
 			return;
 		}
 		
 		for (String src : _availabelFontFamilies.get(family)) {
 			byte[] font1 = _sharedCtx.getUserAgentCallback().getBinaryResource(src);
 			if (font1 == null) {
-				XRLog.exception("Could not load font " + src);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, src);
 				continue;
 			}
 		
 			try {
 				_fontFactory.registerFont(Font.TRUETYPE_FONT, new ByteArrayInputStream(font1));
-			} catch (IOException e) {
-				XRLog.exception("Couldn't read memory!", e);
-			} catch (FontFormatException e) {
-				XRLog.exception("Could not read font correctly", e);
+			} catch (IOException | FontFormatException e) {
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_MATHML_COULD_NOT_REGISTER_FONT, e);
 			}
 		}
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSInteger;
@@ -266,7 +267,7 @@ public class PdfBoxAccessibilityHelper {
             
             String alternate = box.getElement() != null ? box.getElement().getAttribute("title") : "";
             if (alternate.isEmpty()) {
-                XRLog.general("PDF/UA - No title text provided for link.");
+                XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.GENERAL_PDF_ACCESSIBILITY_NO_TITLE_TEXT_PROVIDED_FOR, "link");
             }
             child.elem.setAlternateDescription(alternate);
             
@@ -300,7 +301,7 @@ public class PdfBoxAccessibilityHelper {
                         child.elem.setExpandedForm(expanded);
                     }
                 } else {
-                    XRLog.general("PDF/UA - No title text provided for abbr tag.");
+                    XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.GENERAL_PDF_ACCESSIBILITY_NO_TITLE_TEXT_PROVIDED_FOR, "abbr tag");
                 }
                 
                 handleLangAttribute();
@@ -721,7 +722,7 @@ public class PdfBoxAccessibilityHelper {
             // Add alt text.
             String alternateText = child.box.getElement() == null ? "" : box.getElement().getAttribute("alt");
             if (alternateText.isEmpty()) {
-                XRLog.general(Level.WARNING, "No alt attribute provided for image/replaced in PDF/UA document.");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.GENERAL_PDF_ACCESSIBILITY_NO_ALT_ATTRIBUTE_PROVIDED_FOR_IMAGE);
             }
             child.elem.setAlternateDescription(alternateText);
             
@@ -779,12 +780,7 @@ public class PdfBoxAccessibilityHelper {
     }
     
     private static void logIncompatibleChild(AbstractTreeItem parent, AbstractTreeItem child, Class<?> expected) {
-        XRLog.general(Level.WARNING,
-                "Trying to add incompatible child to parent item: " +
-                " child type=" + child.getClass().getSimpleName() + 
-                ", parent type=" + parent.getClass().getSimpleName() +
-                ", expected child type=" + expected.getSimpleName() +
-                ". Document will not be PDF/UA compliant.");
+        XRLog.log(Level.WARNING, LogMessageId.LogMessageId3Param.GENERAL_PDF_ACCESSIBILITY_INCOMPATIBLE_CHILD, child.getClass().getSimpleName(), parent.getClass().getSimpleName(), expected.getSimpleName());
     }
     
     /**

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxBookmarkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxBookmarkManager.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDDestination;
@@ -80,7 +81,7 @@ public class PdfBoxBookmarkManager {
         }
         
         if (target == null) {
-            XRLog.general(Level.WARNING, "Could not find valid target for bookmark. Bookmark href = " + href);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_BOOKMARK, href);
         }
 
         PDOutlineItem outline = new PDOutlineItem();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -10,6 +10,7 @@ import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.render.displaylist.PagedBoxCollector;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -229,7 +230,7 @@ public class PdfBoxFastLinkManager {
 
 				addLinkToPage(page, annot, box, target);
 			} else {
-			    XRLog.general(Level.WARNING, "Could not find valid target for link. Link href = " + uri);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_LINK, uri);
 			}
 		} else if (isURI(uri)) {
 			PDActionURI uriAct = new PDActionURI();
@@ -252,7 +253,7 @@ public class PdfBoxFastLinkManager {
 		try {
 			return URI.create(uri) != null;
 		} catch (IllegalArgumentException e) {
-			XRLog.general(Level.INFO, "'"+uri+"' in href is not a valid URI, will be skipped");
+			XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.GENERAL_PDF_URI_IN_HREF_IS_NOT_A_VALID_URI, uri);
 			return false;
 		}
 	}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -41,6 +41,7 @@ import com.openhtmltopdf.pdfboxout.PdfBoxSlowOutputDevice.Metadata;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.simple.extend.ReplacedElementScaleHelper;
 import com.openhtmltopdf.util.ArrayUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import de.rototor.pdfbox.graphics2d.PdfBoxGraphics2D;
 import de.rototor.pdfbox.graphics2d.PdfBoxGraphics2DFontTextDrawer;
@@ -415,7 +416,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
                                (run.otherCharacterCount * info.getNonSpaceAdjust());
                 }
             } catch (Exception e) {
-                XRLog.render(Level.WARNING, "BUG. Font didn't contain expected character.", e);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_BUG_FONT_DIDNT_CONTAIN_EXPECTED_CHARACTER, e);
             }
         }
     }
@@ -733,7 +734,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
 
     public void clip(Shape s) {
         if (isFastRenderer()) {
-            XRLog.render(Level.SEVERE, "clip MUST not be used by the fast renderer. Please consider reporting this bug.");
+            XRLog.log(Level.SEVERE, LogMessageId.LogMessageId1Param.RENDER_OP_MUST_NOT_BE_USED_BY_FAST_RENDERER, "clip");
             return;
         }
         
@@ -1268,7 +1269,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
             Color c = (Color) paint;
             this.setColor(new FSRGBColor(c.getRed(), c.getGreen(), c.getBlue()));
         } else {
-            XRLog.render(Level.WARNING, "Unknown paint: " + paint.getClass().getCanonicalName());
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.RENDER_UNKNOWN_PAINT, paint.getClass().getCanonicalName());
         }
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -36,6 +36,7 @@ import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 import com.openhtmltopdf.outputdevice.helper.MinimalFontDescription;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.PdfAConformance;
 import com.openhtmltopdf.render.FSFont;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import org.apache.fontbox.ttf.TrueTypeCollection;
@@ -148,7 +149,7 @@ public class PdfBoxFontResolver implements FontResolver {
             if (rule.hasFontFamily()) {
                 fontFamily = style.valueByName(CSSName.FONT_FAMILY).asString();
             } else {
-                XRLog.cssParse(Level.WARNING, "Must provide at least a font-family and src in @font-face rule");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.CSS_PARSE_MUST_PROVIDE_AT_LEAST_A_FONT_FAMILY_AND_SRC_IN_FONT_FACE_RULE);
                 continue;
             }
 
@@ -297,7 +298,7 @@ public class PdfBoxFontResolver implements FontResolver {
 			try {
 				return PDType0Font.load(_doc, _fontFile);
 			} catch (IOException e) {
-			    XRLog.exception("Couldn't load font (" + _fontFile.getAbsolutePath() + "). Please check that it is a valid truetype font.", e);                                                        
+			    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, _fontFile.getAbsoluteFile(), e);
 			    return null;
 			}
 		}
@@ -701,7 +702,7 @@ public class PdfBoxFontResolver implements FontResolver {
             try {
                 _metrics = PdfBoxRawPDFontMetrics.fromPdfBox(font, descriptor);
             } catch (IOException e) {
-                XRLog.exception("Couldn't load font metrics.", e);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_COULD_NOT_LOAD_FONT_METRICS, e);
             }
         }
 
@@ -745,16 +746,15 @@ public class PdfBoxFontResolver implements FontResolver {
                 putFontMetricsInCache(_family, _weight, _style, _metrics);
                 return true;
             } catch (IOException e) {
-                XRLog.exception(
-                        "Couldn't load font. Please check that it is a valid truetype font.");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, _family);
                 return false;
             }
         }
 
         private boolean realizeFont() {
             if (_font == null && _fontSupplier != null) {
-                XRLog.load(Level.INFO, "Loading font(" + _family + ") from PDFont supplier now.");
-                
+                XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_LOADING_FONT_FROM_SUPPLIER, _family, "PDFont");
+
                 _font = _fontSupplier.supply();
 		_fontSupplier = null;
 		
@@ -765,8 +765,8 @@ public class PdfBoxFontResolver implements FontResolver {
 	    }
             
             if (_font == null && _supplier != null) {
-                XRLog.load(Level.INFO, "Loading font(" + _family + ") from InputStream supplier now.");
-                
+                XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_LOADING_FONT_FROM_SUPPLIER, _family, "InputStream");
+
                 InputStream is = _supplier.supply();
                 _supplier = null; // We only try once.
                 
@@ -781,7 +781,7 @@ public class PdfBoxFontResolver implements FontResolver {
                         return loadMetrics();
                     }
                 } catch (IOException e) {
-                    XRLog.exception("Couldn't load font. Please check that it is a valid truetype font.");
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, _family);
                     return false;
                 } finally {
                     try {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxForm.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxForm.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
@@ -266,7 +267,7 @@ public class PdfBoxForm {
     private String populateOptions(Element e, List<String> labels, List<String> values, List<Integer> selectedIndices) {
         List<Element> opts = DOMUtil.getChildren(e, "option");
         if (opts == null) {
-            XRLog.general(Level.WARNING, "A <"+e.getTagName() + "> element does not have <option> children");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_PDF_A_ELEMENT_DOES_NOT_HAVE_OPTION_CHILDREN, e.getTagName());
             return "";
         }
         String selected = "";
@@ -449,7 +450,7 @@ public class PdfBoxForm {
         } else if (ctrl.box.getElement().getAttribute("type").equals("password")) {
             field.setPassword(true);
         } else if (ctrl.box.getElement().getAttribute("type").equals("file")) {
-            XRLog.general(Level.WARNING, "Acrobat Reader does not support forms with file input controls");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.GENERAL_PDF_ACROBAT_READER_DOES_NOT_SUPPORT_FORMS_WITH_FILE_INPUT);
             field.setFileSelect(true);
         }
         
@@ -745,7 +746,7 @@ public class PdfBoxForm {
 
             if (!element.getAttribute("method").equalsIgnoreCase("post")) {
                 // Default method is get.
-                XRLog.general(Level.WARNING, "Using GET request method for form. You probably meant to add a method=\"post\" attribute to your form");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.GENERAL_PDF_USING_GET_REQUEST_FOR_FORM);
                 submit.setFlags(FLAG_USE_GET | FLAG_USE_HTML_SUBMIT);
             } else {
                 submit.setFlags(FLAG_USE_HTML_SUBMIT);
@@ -776,7 +777,7 @@ public class PdfBoxForm {
                 Node item = attributes.item(i);
                 sb.append(' ').append(item.getNodeName()).append("=\"").append(item.getNodeValue()).append('"');
             }
-            XRLog.general(Level.WARNING, "found a <" + element.getTagName() + sb.toString() +"> element without attribute name, the element will not work without this attribute");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.GENERAL_PDF_FOUND_ELEMENT_WITHOUT_ATTRIBUTE_NAME, element.getTagName(), sb.toString());
         }
     }
     

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
@@ -9,6 +9,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 
 import com.openhtmltopdf.extend.FSImage;
@@ -49,7 +50,7 @@ public class PdfBoxImage implements FSImage {
                         || type.equalsIgnoreCase("jpg") || type
                         .equalsIgnoreCase("jfif"));
             } else {
-                XRLog.load(Level.WARNING, "Unrecognized image format for: " + uri);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_UNRECOGNIZED_IMAGE_FORMAT_FOR_URI, uri);
                 // TODO: Avoid throw here.
                 throw new IOException("Unrecognized Image format");
             }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxPDFReplacedElement.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxPDFReplacedElement.java
@@ -27,6 +27,7 @@ import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.swing.ImageMapParser;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import org.apache.pdfbox.multipdf.LayerUtility;
@@ -65,7 +66,7 @@ public class PdfBoxPDFReplacedElement implements PdfBoxReplacedElement, IPdfBoxE
         try {
             return Integer.parseInt(e.getAttribute("page")) - 1;
         } catch (NumberFormatException e1) {
-            XRLog.exception("Unable to parse page of img tag with PDF!", e1);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_UNABLE_TO_PARSE_PAGE_OF_IMG_TAG_WITH_PDF, e1);
         }
 
         return 0;
@@ -75,7 +76,7 @@ public class PdfBoxPDFReplacedElement implements PdfBoxReplacedElement, IPdfBoxE
         try (PDDocument srcDocument = PDDocument.load(pdfBytes)){
             int pageNo = parsePage(e);
             if (pageNo >= srcDocument.getNumberOfPages()) {
-                XRLog.load(Level.WARNING, "Page does not exist for pdf in img tag. Ignoring!");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LOAD_PAGE_DOES_NOT_EXIST_FOR_PDF_IN_IMG_TAG);
                 return null;
             }
             
@@ -89,9 +90,9 @@ public class PdfBoxPDFReplacedElement implements PdfBoxReplacedElement, IPdfBoxE
             
             return new PdfBoxPDFReplacedElement(formXObject, e, box, ctx, shared, width, height);
         } catch (InvalidPasswordException e1) {
-            XRLog.exception("Tried to open a password protected document as src for an img!", e1);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_TRIED_TO_OPEN_A_PASSWORD_PROTECTED_DOCUMENT_AS_SRC_FOR_IMG, e1);
         } catch (IOException e1) {
-            XRLog.exception("Could not read pdf passed as src for img element!", e1);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_COULD_NOT_READ_PDF_AS_SRC_FOR_IMG, e1);
         }
         
         return null;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxPerDocumentFormState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxPerDocumentFormState.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -194,8 +195,7 @@ public class PdfBoxPerDocumentFormState {
             return forms.get(frmElement);
         }
 
-        XRLog.general(Level.WARNING, "Found form control ("
-                + e.getNodeName() + ") with no enclosing form. Ignoring.");
+        XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_PDF_FOUND_FORM_CONTROL_WITH_NO_ENCLOSING_FORM, e.getNodeName());
         return null;
     }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -130,12 +130,16 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
     private final boolean _useFastMode;
 
     private PageSupplier _pageSupplier;
+
+    private final Closeable diagnosticConsumer;
     
     /**
      * This method is constantly changing as options are added to the builder.
      */
     PdfBoxRenderer(BaseDocument doc, UnicodeImplementation unicode,
-            PageDimensions pageSize, PdfRendererBuilderState state) {
+            PageDimensions pageSize, PdfRendererBuilderState state, Closeable diagnosticConsumer) {
+
+        this.diagnosticConsumer = diagnosticConsumer;
 
         _pdfDoc = state.pddocument != null ? state.pddocument : new PDDocument();
         _pdfDoc.setVersion(state._pdfVersion);
@@ -1052,6 +1056,10 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
     public void cleanup() {
         _outputDevice.close();
         _sharedContext.removeFromThread();
+        try {
+            diagnosticConsumer.close();
+        } catch (IOException e) {
+        }
         ThreadCtx.cleanup();
 
         // Close all still open font files

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -49,6 +49,7 @@ import com.openhtmltopdf.render.displaylist.DisplayListContainer.DisplayListPage
 import com.openhtmltopdf.resource.XMLResource;
 import com.openhtmltopdf.simple.extend.XhtmlNamespaceHandler;
 import com.openhtmltopdf.util.Configuration;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.ThreadCtx;
 import com.openhtmltopdf.util.XRLog;
 
@@ -248,7 +249,7 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
             try {
                 this.setDocumentP(doc.file);
             } catch (IOException e) {
-                XRLog.exception("Problem trying to read input XHTML file", e);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_PROBLEM_TRYING_TO_READ_INPUT_XHTML_FILE, e);
                 throw new RuntimeException("File IO problem", e);
             }
         }
@@ -521,9 +522,9 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
      */
     private void createPdfFast(boolean finish) throws IOException {
         boolean success = false;
-        
-        XRLog.general(Level.INFO, "Using fast-mode renderer. Prepare to fly.");
-        
+
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId0Param.GENERAL_PDF_USING_FAST_MODE);
+
         try {
             // renders the layout if it wasn't created
             if (_root == null) {
@@ -724,7 +725,7 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
             String title = info.getTitle() != null ? info.getTitle() : "";
             
             if (title.isEmpty()) {
-                XRLog.general(Level.WARNING, "No document title provided. Document will not be PDF/UA compliant.");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.GENERAL_PDF_ACCESSIBILITY_NO_DOCUMENT_TITLE_PROVIDED);
             }
             
             XMPMetadata xmp = XMPMetadata.createXMPMetadata();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSlowOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSlowOutputDevice.java
@@ -39,6 +39,7 @@ import com.openhtmltopdf.pdfboxout.PdfBoxPerDocumentFormState;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.util.ArrayUtil;
 import com.openhtmltopdf.util.Configuration;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import de.rototor.pdfbox.graphics2d.PdfBoxGraphics2D;
 import de.rototor.pdfbox.graphics2d.PdfBoxGraphics2DFontTextDrawer;
@@ -394,7 +395,7 @@ public class PdfBoxSlowOutputDevice extends AbstractOutputDevice implements Outp
             try {
                 xOffset += (run.des.getFont().getStringWidth(run.str) / 1000f) * _font.getSize2D();
             } catch (Exception e) {
-                XRLog.render(Level.WARNING, "BUG. Font didn't contain expected character.", e);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_BUG_FONT_DIDNT_CONTAIN_EXPECTED_CHARACTER, e);
             }
         }
     }
@@ -717,7 +718,7 @@ public class PdfBoxSlowOutputDevice extends AbstractOutputDevice implements Outp
 
     public void clip(Shape s) {
         if (isFastRenderer()) {
-            XRLog.render(Level.SEVERE, "clip MUST not be used by the fast renderer. Please consider reporting this bug.");
+            XRLog.log(Level.SEVERE, LogMessageId.LogMessageId1Param.RENDER_OP_MUST_NOT_BE_USED_BY_FAST_RENDERER, "clip");
             return;
         }
         
@@ -736,7 +737,7 @@ public class PdfBoxSlowOutputDevice extends AbstractOutputDevice implements Outp
 
     public Shape getClip() {
         if (isFastRenderer()) {
-            XRLog.render(Level.SEVERE, "getClip MUST not be used by the fast renderer. Please consider reporting this bug.");
+            XRLog.log(Level.SEVERE, LogMessageId.LogMessageId1Param.RENDER_OP_MUST_NOT_BE_USED_BY_FAST_RENDERER, "getClip");
             return null;
         }
         
@@ -765,7 +766,7 @@ public class PdfBoxSlowOutputDevice extends AbstractOutputDevice implements Outp
     @Override
     public void setClip(Shape s) {
         if (isFastRenderer()) {
-            XRLog.render(Level.SEVERE, "setClip MUST not be used by the fast renderer. Please consider reporting this bug.");
+            XRLog.log(Level.SEVERE, LogMessageId.LogMessageId1Param.RENDER_OP_MUST_NOT_BE_USED_BY_FAST_RENDERER, "setClip");
             return;
         }
 
@@ -1418,7 +1419,7 @@ public class PdfBoxSlowOutputDevice extends AbstractOutputDevice implements Outp
                 _cp.applyPdfMatrix(normalized);
             }
         } catch (NoninvertibleTransformException e) {
-            XRLog.render(Level.WARNING, "Tried to set a non-invertible CSS transform. Ignored.");
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_TRIED_TO_SET_NON_INVERTIBLE_CSS_TRANSFORM);
         }
         return inverse;
     }
@@ -1454,7 +1455,7 @@ public class PdfBoxSlowOutputDevice extends AbstractOutputDevice implements Outp
             Color c = (Color) paint;
             this.setColor(new FSRGBColor(c.getRed(), c.getGreen(), c.getBlue()));
         } else {
-            XRLog.render(Level.WARNING, "Unknown paint: " + paint.getClass().getCanonicalName());
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.RENDER_UNKNOWN_PAINT, paint.getClass().getCanonicalName());
         }
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxTextRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxTextRenderer.java
@@ -33,6 +33,7 @@ import com.openhtmltopdf.pdfboxout.PdfBoxSlowOutputDevice.FontRun;
 import com.openhtmltopdf.render.FSFont;
 import com.openhtmltopdf.render.FSFontMetrics;
 import com.openhtmltopdf.render.JustificationInfo;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.OpenUtil;
 import com.openhtmltopdf.util.ThreadCtx;
 import com.openhtmltopdf.util.XRLog;
@@ -74,7 +75,7 @@ public class PdfBoxTextRenderer implements TextRenderer {
                 PdfBoxRawPDFontMetrics metrics = des.getFontMetrics();
 
                 if (metrics == null) {
-                    XRLog.exception("Font metrics not available. Probably a bug.");
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_FONT_METRICS_NOT_AVAILABLE);
                     continue;
                 }
                 
@@ -172,7 +173,7 @@ public class PdfBoxTextRenderer implements TextRenderer {
         }
     
         // Really?, no font support for either replacement text or space!
-        XRLog.general("Specified fonts don't contain a space character!");
+        XRLog.log(Level.INFO, LogMessageId.LogMessageId0Param.GENERAL_PDF_SPECIFIED_FONTS_DONT_CONTAIN_A_SPACE_CHARACTER);
         ReplacementChar replace = new ReplacementChar();
         replace.replacement = "";
         replace.fontDescription = descriptions.get(0);
@@ -302,7 +303,7 @@ public class PdfBoxTextRenderer implements TextRenderer {
             try {
                 strWidth += run.des.getFont().getStringWidth(run.str);
             } catch (Exception e) {
-                XRLog.render(Level.WARNING, "BUG. Font didn't contain expected character.", e);
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_BUG_FONT_DIDNT_CONTAIN_EXPECTED_CHARACTER, e);
             }
         }
 
@@ -316,7 +317,7 @@ public class PdfBoxTextRenderer implements TextRenderer {
         try {
             if (((PdfBoxFSFont) font).getFontDescription() == null 
                     || ((PdfBoxFSFont) font).getFontDescription().isEmpty()) {
-              XRLog.render(Level.WARNING, "Font list is empty.");
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_FONT_LIST_IS_EMPTY);
             } else {
               // Go through the list of font descriptions
               for (FontDescription fd : ((PdfBoxFSFont) font).getFontDescription()) {
@@ -324,7 +325,7 @@ public class PdfBoxTextRenderer implements TextRenderer {
                    result = fd.getFont().getStringWidth(string) / 1000f * font.getSize2D();
                    break;
                  } else {
-                   XRLog.render(Level.WARNING, "Font is null.");
+                     XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.RENDER_FONT_IS_NULL);
                  }
               }
             }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
@@ -32,6 +32,7 @@ import com.openhtmltopdf.resource.ImageResource;
 import com.openhtmltopdf.swing.FSCacheKey;
 import com.openhtmltopdf.swing.NaiveUserAgent;
 import com.openhtmltopdf.util.ImageUtil;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 public class PdfBoxUserAgent extends NaiveUserAgent {
@@ -59,7 +60,7 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
         String uriResolved = resolveURI(uriStr);
         
         if (uriResolved == null) {
-           XRLog.load(Level.INFO, "URI resolver rejected loading image at (" + uriStr + ")");
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "image", uriStr);
            return new ImageResource(uriStr, null);
         }
         
@@ -106,9 +107,7 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
                     }
                     _imageCache.put(uriResolved, resource);
                 } catch (Exception e) {
-                    XRLog.exception(
-                            "Can't read image file; unexpected problem for URI '"
-                                    + uriStr + "'", e);
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI, uriStr, e);
                 } finally {
                     try {
                         is.close();
@@ -134,7 +133,7 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
             scaleToOutputResolution(fsImage);
             return new ImageResource(null, fsImage);
         } catch (Exception e) {
-            XRLog.exception("Can't read XHTML embedded image.", e);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_CANT_READ_XHTML_EMBEDDED_IMAGE, e);
         }
         return new ImageResource(null, null);
     }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
@@ -1,5 +1,6 @@
 package com.openhtmltopdf.pdfboxout;
 
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import org.apache.pdfbox.cos.COSDictionary;
@@ -16,6 +17,7 @@ import org.apache.pdfbox.util.Matrix;
 
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
+import java.util.logging.Level;
 
 public class PdfContentStreamAdapter {
     private final PDPageContentStream cs;
@@ -30,7 +32,7 @@ public class PdfContentStreamAdapter {
     }
 
     private void logAndThrow(String method, IOException e) {
-        XRLog.exception("Exception in PDF writing method: " + method, e);
+        XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_PDF_IN_WRITING_METHOD, method, e);
         throw new PdfException(method, e);
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -37,15 +37,9 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	 * @throws IOException
 	 */
 	public void run() throws IOException {
-		PdfBoxRenderer renderer = null;
-		try (Closeable d = applyDiagnosticConsumer()){
-			renderer = this.buildPdfRenderer();
+		try (Closeable d = applyDiagnosticConsumer(); PdfBoxRenderer renderer = this.buildPdfRenderer(d)){
 			renderer.layout();
 			renderer.createPDF();
-		} finally {
-			if (renderer != null) {
-				renderer.close();
-			}
 		}
 	}
 
@@ -56,6 +50,10 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	 * @return
 	 */
 	public PdfBoxRenderer buildPdfRenderer() {
+		return buildPdfRenderer(applyDiagnosticConsumer());
+	}
+
+	public PdfBoxRenderer buildPdfRenderer(Closeable diagnosticConsumer) {
 		UnicodeImplementation unicode = new UnicodeImplementation(state._reorderer, state._splitter, state._lineBreaker,
 				state._unicodeToLowerTransformer, state._unicodeToUpperTransformer, state._unicodeToTitleTransformer, state._textDirection,
 				state._charBreaker);
@@ -64,7 +62,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 
 		BaseDocument doc = new BaseDocument(state._baseUri, state._html, state._document, state._file, state._uri);
 
-		PdfBoxRenderer renderer = new PdfBoxRenderer(doc, unicode, pageSize, state);
+		PdfBoxRenderer renderer = new PdfBoxRenderer(doc, unicode, pageSize, state, diagnosticConsumer);
 
 		/*
 		 * Register all Fonts

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -8,10 +8,12 @@ import com.openhtmltopdf.outputdevice.helper.BaseDocument;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
 import com.openhtmltopdf.outputdevice.helper.PageDimensions;
 import com.openhtmltopdf.outputdevice.helper.UnicodeImplementation;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.logging.Level;
@@ -36,13 +38,14 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	 */
 	public void run() throws IOException {
 		PdfBoxRenderer renderer = null;
-		try {
+		try (Closeable d = applyDiagnosticConsumer()){
 			renderer = this.buildPdfRenderer();
 			renderer.layout();
 			renderer.createPDF();
 		} finally {
-			if (renderer != null)
+			if (renderer != null) {
 				renderer.close();
+			}
 		}
 	}
 
@@ -91,7 +94,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 				try {
 					resolver.addFont(font.fontFile, font.family, font.weight, fontStyle, font.subset);
 				} catch (Exception e) {
-					XRLog.init(Level.WARNING, "Font " + font.fontFile + " could not be loaded", e);
+					XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.INIT_FONT_COULD_NOT_BE_LOADED, font.fontFile.getPath(), e);
 				}
 			}
 		}
@@ -204,7 +207,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 		state._producer = producer;
 		return this;
 	}
-	
+
 	/**
 	 * List of caches available.
 	 */

--- a/openhtmltopdf-rtl-support/src/main/java/com/openhtmltopdf/bidi/support/ICUBidiReorderer.java
+++ b/openhtmltopdf-rtl-support/src/main/java/com/openhtmltopdf/bidi/support/ICUBidiReorderer.java
@@ -6,6 +6,7 @@ import com.ibm.icu.text.ArabicShaping;
 import com.ibm.icu.text.ArabicShapingException;
 import com.ibm.icu.text.Bidi;
 import com.openhtmltopdf.bidi.BidiReorderer;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
 public class ICUBidiReorderer implements BidiReorderer {
@@ -22,7 +23,7 @@ public class ICUBidiReorderer implements BidiReorderer {
 		try {
 			return shaper.shape(text);
 		} catch (ArabicShapingException e) {
-			XRLog.general(Level.WARNING, "Exception while shaping text", e);
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.GENERAL_EXCEPTION_SHAPING_TEXT, e);
 			return text;
 		}
 	}
@@ -32,7 +33,7 @@ public class ICUBidiReorderer implements BidiReorderer {
 		try {
 			return deshaper.shape(text);
 		} catch (ArabicShapingException e) {
-			XRLog.general(Level.WARNING, "Exception while deshaping text", e);
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.GENERAL_EXCEPTION_DESHAPING_TEXT, e);
 			return text;
 		}
 	}

--- a/openhtmltopdf-slf4j/src/main/java/com/openhtmltopdf/slf4j/Slf4jLogger.java
+++ b/openhtmltopdf-slf4j/src/main/java/com/openhtmltopdf/slf4j/Slf4jLogger.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.util.Diagnostic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ public class Slf4jLogger implements XRLogger {
     
     private static final Map<String, String> LOGGER_NAME_MAP;
     static {
-        LOGGER_NAME_MAP = new HashMap<String, String>();
+        LOGGER_NAME_MAP = new HashMap<>();
         
         LOGGER_NAME_MAP.put(XRLog.CONFIG, "com.openhtmltopdf.config");
         LOGGER_NAME_MAP.put(XRLog.EXCEPTION, "com.openhtmltopdf.exception");
@@ -52,7 +53,42 @@ public class Slf4jLogger implements XRLogger {
     
     private String _defaultLoggerName = DEFAULT_LOGGER_NAME;
     private Map<String, String> _loggerNameMap = LOGGER_NAME_MAP;
-    
+
+    @Override
+    public boolean isLogLevelEnabled(Diagnostic diagnostic) {
+        Level level = diagnostic.getLevel();
+        Logger logger = LoggerFactory.getLogger(getLoggerName(diagnostic.getLogMessageId().getWhere()));
+        if (level == Level.SEVERE) {
+            return logger.isErrorEnabled();
+        } else if (level == Level.WARNING) {
+            return logger.isWarnEnabled();
+        } else if (level == Level.INFO || level == Level.CONFIG) {
+            return logger.isInfoEnabled();
+        } else if (level == Level.FINE || level == Level.FINER || level == Level.FINEST) {
+            return logger.isDebugEnabled();
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public void log(Diagnostic diagnostic) {
+        Logger logger = LoggerFactory.getLogger(getLoggerName(diagnostic.getLogMessageId().getWhere()));
+        Level level = diagnostic.getLevel();
+        String msg = diagnostic.getLogMessageId().getMessageFormat();
+        Object[] args = diagnostic.getArgs();
+        if (level == Level.SEVERE)
+            logger.error(msg, args);
+        else if (level == Level.WARNING)
+            logger.warn(msg, args);
+        else if (level == Level.INFO || level == Level.CONFIG)
+            logger.info(msg, args);
+        else if (level == Level.FINE || level == Level.FINER || level == Level.FINEST)
+            logger.debug(msg, args);
+        else
+            logger.info(msg, args);
+    }
+
     @Override
     public void log(String where, Level level, String msg) {
     	Logger logger = LoggerFactory.getLogger(getLoggerName(where));

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGImage.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGImage.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.logging.Level;
 
 import com.openhtmltopdf.extend.UserAgentCallback;
+import com.openhtmltopdf.util.LogMessageId;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.transcoder.SVGAbstractTranscoder;
 import org.apache.batik.transcoder.TranscoderException;
@@ -117,9 +118,7 @@ public class BatikSVGImage implements SVGImage {
         try {
             return Integer.valueOf(attrValue);
         } catch (NumberFormatException e) {
-            XRLog.general(Level.WARNING,
-                    "Invalid integer passed as dimension for SVG: "
-                            + attrValue);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_INVALID_INTEGER_PASSED_AS_DIMENSION_FOR_SVG, attrValue);
             return null;
         }
     }
@@ -160,8 +159,7 @@ public class BatikSVGImage implements SVGImage {
 
         OpenHtmlFontResolver fontResolver = this.fontResolver;
         if (fontResolver == null) {
-            XRLog.general(Level.INFO,
-                    "importFontFaceRules has not been called for this pdf transcoder");
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId0Param.GENERAL_IMPORT_FONT_FACE_RULES_HAS_NOT_BEEN_CALLED);
             fontResolver = new OpenHtmlFontResolver();
         }
 
@@ -191,7 +189,7 @@ public class BatikSVGImage implements SVGImage {
             TranscoderInput in = new TranscoderInput(newDocument);
             pdfTranscoder.transcode(in, null);
         } catch (TranscoderException e) {
-            XRLog.exception("Couldn't draw SVG.", e);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_SVG_COULD_NOT_DRAW, e);
         }
     }
 }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlDocumentLoader.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlDocumentLoader.java
@@ -1,6 +1,7 @@
 package com.openhtmltopdf.svgsupport;
 
 import com.openhtmltopdf.extend.UserAgentCallback;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import org.apache.batik.bridge.DocumentLoader;
 import org.apache.batik.bridge.UserAgent;
@@ -10,6 +11,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.logging.Level;
 
 public class OpenHtmlDocumentLoader extends DocumentLoader {
 
@@ -33,7 +35,7 @@ public class OpenHtmlDocumentLoader extends DocumentLoader {
                 uri = userAgentCallback.resolveURI(uri);
             }
         } catch (URISyntaxException uriSyntaxException) {
-            XRLog.exception("URI syntax exception while loading external svg resource: " + uri, uriSyntaxException);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_URI_SYNTAX_WHILE_LOADING_EXTERNAL_SVG_RESOURCE, uri, uriSyntaxException);
         }
         return super.loadDocument(uri, new ByteArrayInputStream(userAgentCallback.getBinaryResource(uri)));
     }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlUserAgent.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlUserAgent.java
@@ -1,5 +1,6 @@
 package com.openhtmltopdf.svgsupport;
 
+import com.openhtmltopdf.util.LogMessageId;
 import org.apache.batik.bridge.FontFamilyResolver;
 import org.apache.batik.bridge.UserAgentAdapter;
 import org.apache.batik.util.ParsedURL;
@@ -8,6 +9,7 @@ import com.openhtmltopdf.svgsupport.PDFTranscoder.OpenHtmlFontResolver;
 import com.openhtmltopdf.util.XRLog;
 
 import java.util.Set;
+import java.util.logging.Level;
 
 public class OpenHtmlUserAgent extends UserAgentAdapter {
 
@@ -31,7 +33,7 @@ public class OpenHtmlUserAgent extends UserAgentAdapter {
     @Override
     public void checkLoadScript(String scriptType, ParsedURL scriptURL, ParsedURL docURL) throws SecurityException {
         if (!this.allowScripts) {
-            XRLog.exception("Tried to run script inside SVG. Refusing. Details: " + scriptType + ", " + scriptURL + ", " + docURL);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId3Param.EXCEPTION_SVG_SCRIPT_NOT_ALLOWED, scriptType, scriptURL, docURL);
             throw new SecurityException("Tried to run script inside SVG!");
         }
     }
@@ -39,7 +41,7 @@ public class OpenHtmlUserAgent extends UserAgentAdapter {
     @Override
     public void checkLoadExternalResource(ParsedURL resourceURL, ParsedURL docURL) throws SecurityException {
         if (!this.allowExternalResources && (allowedProtocols == null || !allowedProtocols.contains(resourceURL.getProtocol()))) {
-            XRLog.exception("Tried to fetch external resource from SVG. Refusing. Details: " + resourceURL + ", " + docURL);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.EXCEPTION_SVG_EXTERNAL_RESOURCE_NOT_ALLOWED,resourceURL, docURL);
             throw new SecurityException("Tried to fetch external resource (" + resourceURL + ") from SVG. Refused!");
         }
     }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
@@ -12,6 +12,7 @@ import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.simple.extend.ReplacedElementScaleHelper;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import org.apache.batik.bridge.BridgeContext;
 import org.apache.batik.bridge.FontFace;
@@ -32,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 
 public class PDFTranscoder extends SVGAbstractTranscoder {
 	private OpenHtmlFontResolver fontResolver;
@@ -179,7 +181,7 @@ public class PDFTranscoder extends SVGAbstractTranscoder {
 
 		         byte[] font1 = ctx.getUserAgentCallback().getBinaryResource(src.asString());
 		         if (font1 == null) {
-		             XRLog.exception("Could not load font " + src.asString());
+		         	XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, src.asString());
 		             continue;
 		         }
 		         
@@ -202,7 +204,7 @@ public class PDFTranscoder extends SVGAbstractTranscoder {
 		         try {
 					addFontFaceFont(fontFamily, fontWeight, fontStyle, src.asString(), font1);
 				} catch (FontFormatException e) {
-					XRLog.exception("Couldn't read font", e);
+		         	XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_SVG_COULD_NOT_READ_FONT, e);
 					continue;
 				}
 		    }
@@ -271,17 +273,17 @@ public class PDFTranscoder extends SVGAbstractTranscoder {
 		return new ErrorHandler() {
 			@Override
 			public void warning(TranscoderException arg0) throws TranscoderException {
-				XRLog.exception("SVG WARN", arg0);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_SVG_ERROR_HANDLER, "WARN", arg0);
 			}
 			
 			@Override
 			public void fatalError(TranscoderException arg0) throws TranscoderException {
-				XRLog.exception("SVG FATAL", arg0);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_SVG_ERROR_HANDLER, "FATAL", arg0);
 			}
 			
 			@Override
 			public void error(TranscoderException arg0) throws TranscoderException {
-				XRLog.exception("SVG ERROR", arg0);
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_SVG_ERROR_HANDLER, "ERROR", arg0);
 			}
 		};
 	}


### PR DESCRIPTION
Hi @danfickle , this PR is still a work in progress, but the main functionality should be here.

As you described in the issue #76 (https://github.com/danfickle/openhtmltopdf/issues/76#issuecomment-284936563) , adding a way to fetch all logged values programmatically is quite a nice feature, this PR enable that.

I still need to do:

 - check if the cleanup is right in all cases
 - expose the Diagnostic values (add getters)
 - maybe add an option to enable the recording of log in the builder, instead of doing it by default
 - tests

What do you think ? :)