### PR TITLE
fix issue #474 NPE when base64 decoding fail

### DIFF
--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-474-npe-image-decoding.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-474-npe-image-decoding.pdf
@@ -1,0 +1,111 @@
+%PDF-1.4
+%цдья
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20200525145518+02'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 30.0 30.0]
+/Parent 2 0 R
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 240
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+0 30 m
+30 30 l
+30 0.0375 l
+0 0.0375 l
+0 30 l
+h
+W
+n
+1 0 0 rg
+-0.0375 30 m
+-0.0375 0 l
+30 0 l
+30 30 l
+h
+f
+0 0 0 rg
+BT
+/F1 12 Tf
+1 0 0 1 6 13.2375 Tm
+(a) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 11.3625 13.2375 Tm
+(b) Tj
+ET
+Q
+
+endstream
+endobj
+6 0 obj
+<<
+/Font 7 0 R
+>>
+endobj
+7 0 obj
+<<
+/F1 8 0 R
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000226 00000 n
+0000000336 00000 n
+0000000629 00000 n
+0000000662 00000 n
+0000000693 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<6248A855C31AD1CFC458F200DA5F6909> <6248A855C31AD1CFC458F200DA5F6909>]
+/Size 9
+>>
+startxref
+792
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-474-npe-image-decoding.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-474-npe-image-decoding.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+    <style>
+@page  {
+    size: 40px 40px;
+    margin: 0;
+    padding:0;
+}
+body {
+    background-color:red;
+}
+</style>
+</head>
+<body>
+<div>a<img src="data:image/png;base64,iVB"/>b</div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1167,6 +1167,18 @@ public class VisualRegressionTest {
         }));
     }
 
+    /**
+     * Ensure there is no NPE exception launched if the decoding of an image fail (base64 case).
+     *
+     * See issue https://github.com/danfickle/openhtmltopdf/issues/474
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testIssue474NpeImageDecoding() throws IOException {
+        assertTrue(vt.runTest("issue-474-npe-image-decoding"));
+    }
+
     // TODO:
     // + Elements that appear just on generated overflow pages.
     // + content property (page counters, etc)

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
@@ -74,8 +74,11 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
         
         if (ImageUtil.isEmbeddedBase64Image(uriResolved)) {
             resource = loadEmbeddedBase64ImageResource(uriResolved);
-            _outputDevice.realizeImage((PdfBoxImage) resource.getImage());
-            _imageCache.put(uriResolved, resource);
+            // see issue 474: getImage can be null, as the loading of the embedded base64 resource may fail.
+            if (resource.getImage() != null) {
+                _outputDevice.realizeImage((PdfBoxImage) resource.getImage());
+                _imageCache.put(uriResolved, resource);
+            }
         } else {
             InputStream is = openStream(uriResolved);
             


### PR DESCRIPTION
Hi @danfickle , this fix the issue #474 . When `loadEmbeddedBase64ImageResource` fail, it will return a `ImageResource` with a null image. We check before calling `realize()`