### PR TITLE
add failing test that highlight the infinite loop issue in the inline box layout algorithm #482

### DIFF
--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-482-infinite-loop-table.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-482-infinite-loop-table.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<style>
+    * {
+        font-family: 'Liberation Sans', sans-serif;
+        margin: 0;
+        padding: 0;
+    }
+
+    .content {
+        word-wrap: break-word;
+        white-space:pre-wrap;
+    }
+</style>
+</head>
+<body>
+<table class="content"><tbody><tr><td width="10">­</td></tr></tbody></table>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1154,6 +1154,15 @@ public class VisualRegressionTest {
         })));
     }
 
+    @Test
+    @Ignore
+    public void testIssue482InfiniteLoopTable() throws IOException {
+        assertTrue(vt.runTest("issue-482-infinite-loop-table", builder -> {
+            builder.useFont(() -> VisualRegressionTest.class.getClassLoader().getResourceAsStream("org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"),
+                    "Liberation Sans");
+        }));
+    }
+
     // TODO:
     // + Elements that appear just on generated overflow pages.
     // + content property (page counters, etc)


### PR DESCRIPTION
Hi @danfickle , I've added another failing test that cause an infinite loop somewhere in ~~the table layout algorithm.~~ the inline box layout algorithm

I've finally managed to reduce it in a more minimal case. As described in https://github.com/danfickle/openhtmltopdf/issues/482#issuecomment-633999078 there are multiple elements in play here:

 - the fonts seems to have an impact
 - it seems to be still a `SOFT_HYPHEN` issue
 - the defined width of the `td` element seems to have an impact too

I'll try to understand what is true culprit :)