### PR TITLE
Adding ability to specify 'UserStyleSheetURI' for an SVGDrawer, this …

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/SVGDrawer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/SVGDrawer.java
@@ -20,6 +20,8 @@ public interface SVGDrawer extends Closeable {
 
     default void withUserAgent(UserAgentCallback userAgentCallback) {}
 
+    default void withUserStyleSheetURI(String userStyleSheetURI) {}
+
     interface SVGImage {
         int getIntrinsicWidth();
 

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGDrawer.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGDrawer.java
@@ -22,6 +22,7 @@ public class BatikSVGDrawer implements SVGDrawer {
     private final boolean allowScripts;
     private final boolean allowExternalResources;
     private UserAgentCallback userAgentCallback;
+    private String userStyleSheetURI;
     
     public enum SvgScriptMode {
         SECURE,
@@ -84,6 +85,9 @@ public class BatikSVGDrawer implements SVGDrawer {
     }
 
     @Override
+    public void withUserStyleSheetURI(String userStyleSheetURI) { this.userStyleSheetURI = userStyleSheetURI; }
+
+    @Override
     public SVGImage buildSVGImage(Element svgElement, Box box, CssContext c,
     		double cssWidth, double cssHeight, double dotsPerPixel) {
     	
@@ -91,7 +95,7 @@ public class BatikSVGDrawer implements SVGDrawer {
     	double cssMaxHeight = CalculatedStyle.getCSSMaxHeight(c, box);
     	
         BatikSVGImage img = new BatikSVGImage(svgElement, box, cssWidth, cssHeight,
-                cssMaxWidth, cssMaxHeight, dotsPerPixel);
+                cssMaxWidth, cssMaxHeight, dotsPerPixel, userStyleSheetURI);
         img.setFontResolver(fontResolver);
         img.setUserAgentCallback(userAgentCallback);
         img.setSecurityOptions(allowScripts, allowExternalResources, allowedProtocols);

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGImage.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/BatikSVGImage.java
@@ -33,7 +33,7 @@ public class BatikSVGImage implements SVGImage {
     private UserAgentCallback userAgentCallback;
 
     public BatikSVGImage(Element svgElement, Box box, double cssWidth, double cssHeight,
-            double cssMaxWidth, double cssMaxHeight, double dotsPerPixel) {
+            double cssMaxWidth, double cssMaxHeight, double dotsPerPixel, String userStyleSheetURI) {
         this.svgElement = svgElement;
         this.dotsPerPixel = dotsPerPixel;
 
@@ -57,6 +57,11 @@ public class BatikSVGImage implements SVGImage {
             this.pdfTranscoder.addTranscodingHint(
                     SVGAbstractTranscoder.KEY_MAX_HEIGHT,
                     (float) (cssMaxHeight / dotsPerPixel));
+        }
+        if(userStyleSheetURI != null) {
+            this.pdfTranscoder.addTranscodingHint(
+                    SVGAbstractTranscoder.KEY_USER_STYLESHEET_URI,
+                    userStyleSheetURI);
         }
         
         Point dimensions = parseDimensions(svgElement);

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlUserAgent.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlUserAgent.java
@@ -12,12 +12,14 @@ import java.util.Set;
 public class OpenHtmlUserAgent extends UserAgentAdapter {
 
 	private final OpenHtmlFontResolver resolver;
+    private final String userStyleSheetURI;
     private final boolean allowScripts;
     private final boolean allowExternalResources;
     private final Set<String> allowedProtocols;
 
-    public OpenHtmlUserAgent(OpenHtmlFontResolver resolver, boolean allowScripts, boolean allowExternalResources, Set<String> allowedProtocols) {
+    public OpenHtmlUserAgent(OpenHtmlFontResolver resolver, String userStyleSheetURI, boolean allowScripts, boolean allowExternalResources, Set<String> allowedProtocols) {
 		this.resolver = resolver;
+        this.userStyleSheetURI = userStyleSheetURI;
         this.allowScripts = allowScripts;
         this.allowExternalResources = allowExternalResources;
         this.allowedProtocols = allowedProtocols;
@@ -42,5 +44,10 @@ public class OpenHtmlUserAgent extends UserAgentAdapter {
             XRLog.exception("Tried to fetch external resource from SVG. Refusing. Details: " + resourceURL + ", " + docURL);
             throw new SecurityException("Tried to fetch external resource (" + resourceURL + ") from SVG. Refused!");
         }
+    }
+
+    @Override
+    public String getUserStyleSheetURI() {
+        return userStyleSheetURI;
     }
 }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
@@ -226,10 +226,12 @@ public class PDFTranscoder extends SVGAbstractTranscoder {
 
 	@Override
 	protected void transcode(Document svg, String uri, TranscoderOutput out) throws TranscoderException {
-		
+
+		String userStyleSheetURI = (String)hints.get(SVGAbstractTranscoder.KEY_USER_STYLESHEET_URI);
+
 		// Note: We have to initialize user agent here and not in ::createUserAgent() as method
 		// is called before our constructor is called in the super constructor.
-		this.userAgent = new OpenHtmlUserAgent(this.fontResolver, this.allowScripts, this.allowExternalResources, this.allowedProtocols);
+		this.userAgent = new OpenHtmlUserAgent(this.fontResolver, userStyleSheetURI, this.allowScripts, this.allowExternalResources, this.allowedProtocols);
 		super.transcode(svg, uri, out);
 		
         Rectangle contentBounds = box.getContentAreaEdge(box.getAbsX(), box.getAbsY(), ctx);


### PR DESCRIPTION
…allows SVGs to render without requiring styles to be inline.
Fixes #493

Hi  @danfickle,

So I was trying to find a solution to issue 493 where in order for SVG elements to render with the correct css, the styles are required to be declared inline in the SVG.  Ideally, SVG elements would be able to reference an external stylesheet to pull their styles as well.  This was possible in the older itext/flying saucer implementation by providing a transcoder hint for the svg/png transcoder used by Batik.

Eventually I tracked down the issue in the Batik BridgeContext class, specifically the 'initializeDocument' method tries to set up the CSSEngine on the SVGDOMImplementation using the UserAgent.

The problem that I was running into was the implementation of UserAgent, OpenHtmlUserAgent doesn't override the method 'getUserStyleSheetURI' from its base class UserAgentAdapter and thus always returns null for that method call.  That method is what's used in the BridgeContext to setup the CSSEngine for the SVG.

To get the value I needed injected down to the UserAgent class I had to pass it through a number of other classes starting at the public interface point which is the BatikSVGDrawer:
BatikSVGDrawer > BatikSVGImage > PDFTranscoder > OpenHtmlUserAgent

I'm not super familiar with this library, so there may have been a more elegant implementation path that I missed, also unsure of any potential side affects this may have caused but I tried to be as minimal and backwards compatible as possible.  Only obvious breaking change I can see is the modification of the existing constructor in OpenHtmlUserAgent which could be breaking if that class is used outside the library, but that could be alleviated by adding the new constructor along side the existing constructor.  Using the new stylesheet property would also require the user to construct the BatikSVGDrawer with the argument SvgExternalResourceMode.INSECURE_ALLOW_EXTERNAL_RESOURCE_REQUESTS which may not be ideal.

Example usage:

```
BufferedOutputStream outputStream = null;
        try {
            outputStream = new BufferedOutputStream(new FileOutputStream(output));
            PdfRendererBuilder builder = new PdfRendererBuilder();
            builder.useFastMode();
            builder.withHtmlContent(html,executingUri);
            builder.toStream(outputStream);

            BatikSVGDrawer svgDrawer = new BatikSVGDrawer(BatikSVGDrawer.SvgScriptMode.SECURE, 
     BatikSVGDrawer.SvgExternalResourceMode.INSECURE_ALLOW_EXTERNAL_RESOURCE_REQUESTS);
            
            //new method added to inject external style sheet for SVG            
            svgDrawer.withUserStyleSheetURI("classpath://SOME_PATH/svgStyles.css");
            builder.useSVGDrawer(svgDrawer);
            builder.run();

        } catch (Exception e) {
            logger.error("Exception rendering pdf", e);
        }
        finally {
            outputStream.close();
        }
```

Thank you for the review and consideration!