### PR TITLE
#508 add support for embedded file

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -1214,7 +1214,7 @@ public class PdfBoxAccessibilityHelper {
         PDAnnotation annotation;
     }
 
-    public void addLink(Box anchor, Box target, PDAnnotationLink annotation, PDPage page) {
+    public void addLink(Box anchor, Box target, PDAnnotation annotation, PDPage page) {
         PDStructureElement struct = getStructualElementForBox(anchor);
         if (struct != null) {
             // We have to append the link annotationobject reference as a kid of its associated structure element.

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -253,7 +253,8 @@ public class PdfBoxFastLinkManager {
 					try {
 						PDComplexFileSpecification fs = new PDComplexFileSpecification();
 						PDEmbeddedFile embeddedFile = new PDEmbeddedFile(_od.getWriter(), new ByteArrayInputStream(file));
-						embeddedFile.setSubtype(elem.getAttribute("data-content-type") != null ? elem.getAttribute("data-content-type") : "application/octet-stream");
+						String contentType = "".equals(elem.getAttribute("data-content-type")) ? "application/octet-stream" : elem.getAttribute("data-content-type");
+						embeddedFile.setSubtype(contentType);
 						fs.setEmbeddedFile(embeddedFile);
 						String fileName = Paths.get(uri).getFileName().toString();
 						fs.setFile(fileName);

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -10,7 +10,6 @@ import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.render.displaylist.PagedBoxCollector;
-import com.openhtmltopdf.util.Util;
 import com.openhtmltopdf.util.XRLog;
 
 import org.apache.pdfbox.pdmodel.PDPage;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -14,6 +14,7 @@ import com.openhtmltopdf.util.Util;
 import com.openhtmltopdf.util.XRLog;
 
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
@@ -21,10 +22,7 @@ import org.apache.pdfbox.pdmodel.interactive.action.PDAction;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionGoTo;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionJavaScript;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDBorderStyleDictionary;
+import org.apache.pdfbox.pdmodel.interactive.annotation.*;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
 import org.w3c.dom.Element;
 
@@ -263,6 +261,15 @@ public class PdfBoxFastLinkManager {
 						fs.setFileUnicode(fileName);
 						PDAnnotationFileAttachment annotationFileAttachment = new PDAnnotationFileAttachment();
 						annotationFileAttachment.setFile(fs);
+
+						// hide the pin icon used by various pdf reader for signaling an embedded file
+						PDAppearanceDictionary appearanceDictionary = new PDAppearanceDictionary();
+						PDAppearanceStream appearanceStream = new PDAppearanceStream(_od.getWriter());
+						appearanceStream.setResources(new PDResources());
+						appearanceDictionary.setNormalAppearance(appearanceStream);
+						annotationFileAttachment.setAppearance(appearanceDictionary);
+						//
+
 						annot = new PDAnnotationFileAttachmentContainer(annotationFileAttachment);
 					} catch (IOException e) {
 						XRLog.exception("Was not able to create an embedded file for embedding with uri " + uri, e);


### PR DESCRIPTION
hi, this PR implement the support of embedding files in the pdf.

You can see in https://github.com/danfickle/openhtmltopdf/issues/508#issuecomment-655509628 how it work. Basically, adding the attribute `data-embed-file="true"` to a link will make the linked resource embedded.

As written in https://github.com/danfickle/openhtmltopdf/issues/508#issuecomment-655504301 , the support from the pdf viewer is, uh, variable. ~~Especially the icon is quite ugly, and at the moment I'm not able to hide it.~~ Edit: I was able to customize it. Seems to globally work, except for the viewer from IE/Edge. But at least adobe reader seems to work.

Note: there are security implication if a third party user has control over the html. Maybe we need to add an explicit list of embeddable uri resource in the builder?

I still need to add some kind of test.

WDYT?