### PR TITLE
Finer grained external resources access control

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/UserAgentCallback.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/UserAgentCallback.java
@@ -131,10 +131,9 @@ public interface UserAgentCallback {
      *
      * @param type
      * @param uri
+     * @param protocol protocol part of the uri
      * @return
      */
-	default boolean isAllowed(ExternalResourceType type, String uri) {
-	    return true;
-    }
+	boolean isAllowed(ExternalResourceType type, String uri, String protocol);
 }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/UserAgentCallback.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/UserAgentCallback.java
@@ -20,6 +20,7 @@
 package com.openhtmltopdf.extend;
 
 import com.openhtmltopdf.resource.CSSResource;
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.resource.ImageResource;
 import com.openhtmltopdf.resource.XMLResource;
 
@@ -51,7 +52,11 @@ public interface UserAgentCallback {
      * @param uri Location of the CSS
      * @return A CSSResource for the content at the URI.
      */
-    CSSResource getCSSResource(String uri);
+    default CSSResource getCSSResource(String uri) {
+        return getCSSResource(uri, ExternalResourceType.CSS);
+    }
+
+    CSSResource getCSSResource(String uri, ExternalResourceType type);
 
     /**
      * Retrieves the Image at the given URI. This is a synchronous call.
@@ -59,7 +64,11 @@ public interface UserAgentCallback {
      * @param uri Location of the image
      * @return An ImageResource for the content at the URI.
      */
-    ImageResource getImageResource(String uri);
+    default ImageResource getImageResource(String uri) {
+        return getImageResource(uri, ExternalResourceType.IMAGE);
+    }
+
+    ImageResource getImageResource(String uri, ExternalResourceType type);
 
     /**
      * Retrieves the XML at the given URI. This is a synchronous call.
@@ -67,13 +76,21 @@ public interface UserAgentCallback {
      * @param uri Location of the XML
      * @return A XMLResource for the content at the URI.
      */
-    XMLResource getXMLResource(String uri);
+    default XMLResource getXMLResource(String uri) {
+        return getXMLResource(uri, ExternalResourceType.XML);
+    }
+
+    XMLResource getXMLResource(String uri, ExternalResourceType type);
     
     /**
      * Retrieves a binary resource located at a given URI and returns its contents
      * as a byte array or <code>null</code> if the resource could not be loaded.
      */
-    byte[] getBinaryResource(String uri);
+    default byte[] getBinaryResource(String uri) {
+        return getBinaryResource(uri, ExternalResourceType.BINARY);
+    }
+
+    byte[] getBinaryResource(String uri, ExternalResourceType type);
 
     /**
      * Normally, returns true if the user agent has visited this URI. UserAgent should consider
@@ -108,5 +125,16 @@ public interface UserAgentCallback {
     String resolveURI(String uri);
 
 	String resolveUri(String baseUri, String uri);
+
+    /**
+     * Check if an external resource is allowed to be downloaded.
+     *
+     * @param type
+     * @param uri
+     * @return
+     */
+	default boolean isAllowed(ExternalResourceType type, String uri) {
+	    return true;
+    }
 }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplier.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplier.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 
 import com.openhtmltopdf.extend.FSSupplier;
 import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
@@ -20,7 +21,7 @@ public class FontFaceFontSupplier implements FSSupplier<InputStream> {
     
     @Override
     public InputStream supply() {
-        byte[] font1 = ctx.getUserAgentCallback().getBinaryResource(src);
+        byte[] font1 = ctx.getUserAgentCallback().getBinaryResource(src, ExternalResourceType.FONT);
         
         if (font1 == null) {
             XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT_FACE, src);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/ExternalResourceType.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/ExternalResourceType.java
@@ -1,0 +1,10 @@
+package com.openhtmltopdf.resource;
+
+public enum ExternalResourceType {
+    FONT,
+    FILE_EMBED,
+    CSS,
+    IMAGE,
+    XML,
+    BINARY;
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -263,7 +263,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         } else {
             String resolved = _resolver.resolveURI(this._baseUri, uri);
 
-            if (!isAllowed(type, uri)) {
+            if (!isAllowed(type, resolved)) {
             	// FIXME
 			}
             
@@ -324,7 +324,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
     public XMLResource getXMLResource(String uri, ExternalResourceType type) {
     	String resolved = _resolver.resolveURI(this._baseUri, uri);
 
-		if (!isAllowed(type, uri)) {
+		if (!isAllowed(type, resolved)) {
 			//FIXME
 		}
     	

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -349,7 +349,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 
         String resolved = _resolver.resolveURI(this._baseUri, uri);
 
-		if (! isAllowed(type, uri)) {
+		if (! isAllowed(type, resolved)) {
 			//FIXME
 		}
     	

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -232,14 +232,15 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
     public CSSResource getCSSResource(String uri, ExternalResourceType type) {
     	String resolved = _resolver.resolveURI(this._baseUri, uri);
 
-    	if (!isAllowed(type, resolved)) {
-    		//FIXME
-		}
-    	
     	if (resolved == null) {
     		XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "CSS resource", uri);
     		return null;
     	}
+
+		if (!isAllowed(type, resolved)) {
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.LOAD_URI_NOT_ALLOWED, resolved, type);
+			return null;
+		}
     	
 		return new CSSResource(openReader(resolved));
     }
@@ -262,15 +263,16 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
             return new ImageResource(null, AWTFSImage.createImage(image));
         } else {
             String resolved = _resolver.resolveURI(this._baseUri, uri);
-
-            if (!isAllowed(type, resolved)) {
-            	// FIXME
-			}
             
             if (resolved == null) {
             	XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "image resource", uri);
         		return null;
         	}
+
+			if (!isAllowed(type, resolved)) {
+				XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.LOAD_URI_NOT_ALLOWED, resolved, type);
+				return null;
+			}
             
             // First, we check the internal per run cache.
             ir = _imageCache.get(resolved);
@@ -323,15 +325,16 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
     @Override
     public XMLResource getXMLResource(String uri, ExternalResourceType type) {
     	String resolved = _resolver.resolveURI(this._baseUri, uri);
-
-		if (!isAllowed(type, resolved)) {
-			//FIXME
-		}
     	
     	if (resolved == null) {
     		XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "XML resource", uri);
     		return null;
     	}
+
+		if (!isAllowed(type, resolved)) {
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.LOAD_URI_NOT_ALLOWED, resolved, type);
+			return null;
+		}
     	
         try (Reader inputReader = openReader(resolved)) {
             return inputReader == null ? null : XMLResource.load(inputReader);
@@ -348,15 +351,16 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         }
 
         String resolved = _resolver.resolveURI(this._baseUri, uri);
-
-		if (! isAllowed(type, resolved)) {
-			//FIXME
-		}
     	
     	if (resolved == null) {
 			XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "binary resource", uri);
     		return null;
     	}
+
+		if (!isAllowed(type, resolved)) {
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.LOAD_URI_NOT_ALLOWED, resolved, type);
+			return null;
+		}
     	
         InputStream is = openStream(resolved);
         if (is == null) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -44,6 +44,7 @@ import com.openhtmltopdf.extend.FSStreamFactory;
 import com.openhtmltopdf.extend.FSStream;
 import com.openhtmltopdf.extend.UserAgentCallback;
 import com.openhtmltopdf.resource.CSSResource;
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.resource.ImageResource;
 import com.openhtmltopdf.resource.XMLResource;
 import com.openhtmltopdf.util.ImageUtil;
@@ -224,11 +225,16 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
      * The result is packed up into an CSSResource for later consumption.
      *
      * @param uri Location of the CSS source.
+	 * @param type External resource type
      * @return A CSSResource containing the CSS reader or null if not available.
      */
     @Override
-    public CSSResource getCSSResource(String uri) {
+    public CSSResource getCSSResource(String uri, ExternalResourceType type) {
     	String resolved = _resolver.resolveURI(this._baseUri, uri);
+
+    	if (!isAllowed(type, resolved)) {
+    		//FIXME
+		}
     	
     	if (resolved == null) {
     		XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "CSS resource", uri);
@@ -244,10 +250,11 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
      * The result is packed up into an ImageResource for later consumption.
      *
      * @param uri Location of the image source.
+	 * @param type External resource type.
      * @return An ImageResource containing the image.
      */
     @Override
-    public ImageResource getImageResource(String uri) {
+    public ImageResource getImageResource(String uri, ExternalResourceType type) {
         ImageResource ir;
         
         if (ImageUtil.isEmbeddedBase64Image(uri)) {
@@ -255,6 +262,10 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
             return new ImageResource(null, AWTFSImage.createImage(image));
         } else {
             String resolved = _resolver.resolveURI(this._baseUri, uri);
+
+            if (!isAllowed(type, uri)) {
+            	// FIXME
+			}
             
             if (resolved == null) {
             	XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "image resource", uri);
@@ -306,11 +317,16 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
      * configured for Flying Saucer. The result is packed up into an XMLResource for later consumption.
      *
      * @param uri Location of the XML source.
+	 * @param type External resource type
      * @return An XMLResource containing the image.
      */
     @Override
-    public XMLResource getXMLResource(String uri) {
+    public XMLResource getXMLResource(String uri, ExternalResourceType type) {
     	String resolved = _resolver.resolveURI(this._baseUri, uri);
+
+		if (!isAllowed(type, uri)) {
+			//FIXME
+		}
     	
     	if (resolved == null) {
     		XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "XML resource", uri);
@@ -318,8 +334,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
     	}
     	
         try (Reader inputReader = openReader(resolved)) {
-            return inputReader == null ? null :
-                        XMLResource.load(inputReader);
+            return inputReader == null ? null : XMLResource.load(inputReader);
         } catch (IOException e) {
             // On auto close, swallow.
             return null;
@@ -327,12 +342,16 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
     }
 
     @Override
-    public byte[] getBinaryResource(String uri) {
+    public byte[] getBinaryResource(String uri, ExternalResourceType type) {
         if (ImageUtil.isDataUri(uri)) {
             return ImageUtil.getEmbeddedDataUri(uri);
         }
 
         String resolved = _resolver.resolveURI(this._baseUri, uri);
+
+		if (! isAllowed(type, uri)) {
+			//FIXME
+		}
     	
     	if (resolved == null) {
 			XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "binary resource", uri);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -462,7 +462,19 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 		}
 	}
 
-    /**
+
+	protected boolean isAllowed(ExternalResourceType type, String uri) {
+		String protocol = uri != null && uri.indexOf(':') > 0 ? uri.substring(0, uri.indexOf(':')) : null;
+		return isAllowed(type, uri, protocol);
+	}
+
+
+	@Override
+	public boolean isAllowed(ExternalResourceType type, String uri, String protocol) {
+		return true;
+	}
+
+	/**
      * Returns the current baseUrl for this class.
      */
     @Override

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/swing/NaiveUserAgent.java
@@ -464,7 +464,8 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 
 
 	protected boolean isAllowed(ExternalResourceType type, String uri) {
-		String protocol = uri != null && uri.indexOf(':') > 0 ? uri.substring(0, uri.indexOf(':')) : null;
+    	int protocolSeparatorIdx = uri.indexOf(':');
+		String protocol = uri != null &&  protocolSeparatorIdx > 0 ? uri.substring(0, protocolSeparatorIdx) : null;
 		return isAllowed(type, uri, protocol);
 	}
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -202,6 +202,7 @@ public interface LogMessageId {
         LOAD_CACHE_HIT_STATUS(XRLog.LOAD, "{} key({}) from cache."),
         LOAD_SAX_FEATURE_SET(XRLog.LOAD, "SAX Parser feature: {} set to {}"),
         LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI(XRLog.LOAD, "URI resolver rejected loading {} at ({})"),
+        LOAD_URI_NOT_ALLOWED(XRLog.LOAD, "URI {} with type {} is not allowed to be loaded"),
         LOAD_COULD_NOT_READ_URI_AT_URL_MAY_BE_RELATIVE(XRLog.LOAD, "Could not read {} as a URL; may be relative. Testing using parent URL {}"),
         LOAD_WAS_ABLE_TO_READ_FROM_URI_USING_PARENT_URL(XRLog.LOAD, "Was able to read from {} using parent URL {}"),
 

--- a/openhtmltopdf-mathml-support/src/main/java/com/openhtmltopdf/mathmlsupport/MathMLDrawer.java
+++ b/openhtmltopdf-mathml-support/src/main/java/com/openhtmltopdf/mathmlsupport/MathMLDrawer.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.util.LogMessageId;
 import net.sourceforge.jeuclid.font.DefaultFontFactory;
 import net.sourceforge.jeuclid.font.FontFactory;
@@ -87,7 +88,7 @@ public class MathMLDrawer implements SVGDrawer {
 		}
 		
 		for (String src : _availabelFontFamilies.get(family)) {
-			byte[] font1 = _sharedCtx.getUserAgentCallback().getBinaryResource(src);
+			byte[] font1 = _sharedCtx.getUserAgentCallback().getBinaryResource(src, ExternalResourceType.FONT);
 			if (font1 == null) {
 				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, src);
 				continue;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxReplacedElementFactory.java
@@ -22,6 +22,7 @@ package com.openhtmltopdf.pdfboxout;
 import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.layout.LayoutContext;
 import com.openhtmltopdf.render.BlockBox;
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.resource.XMLResource;
 
 import com.openhtmltopdf.util.ImageUtil;
@@ -77,7 +78,7 @@ public class PdfBoxReplacedElementFactory implements ReplacedElementFactory {
 
                     return null;
                 } else if (srcAttr.endsWith(".pdf")) {
-                    byte[] pdfBytes = uac.getBinaryResource(srcAttr);
+                    byte[] pdfBytes = uac.getBinaryResource(srcAttr, ExternalResourceType.IMAGE);
                     
                     if (pdfBytes != null) {
                         return PdfBoxPDFReplacedElement.create(_outputDevice.getWriter(), pdfBytes, e, box, c, c.getSharedContext());

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.logging.Level;
 
 import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.resource.ImageResource;
 import com.openhtmltopdf.swing.NaiveUserAgent;
 import com.openhtmltopdf.util.ImageUtil;
@@ -54,9 +55,14 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
         out.close();
         return out.toByteArray();
     }
-    
-    public ImageResource getImageResource(String uriStr) {
+
+    @Override
+    public ImageResource getImageResource(String uriStr, ExternalResourceType type) {
         String uriResolved = resolveURI(uriStr);
+
+        if (!isAllowed(type, uriResolved)) {
+            //FIXME
+        }
         
         if (uriResolved == null) {
             XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "image", uriStr);

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
@@ -60,13 +60,14 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
     public ImageResource getImageResource(String uriStr, ExternalResourceType type) {
         String uriResolved = resolveURI(uriStr);
 
-        if (!isAllowed(type, uriResolved)) {
-            //FIXME
-        }
-        
         if (uriResolved == null) {
             XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "image", uriStr);
-           return new ImageResource(uriStr, null);
+            return new ImageResource(uriStr, null);
+        }
+
+        if (!isAllowed(type, uriResolved)) {
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.LOAD_URI_NOT_ALLOWED, uriResolved, type);
+            return new ImageResource(uriStr, null);
         }
         
         ImageResource resource = _imageCache.get(uriResolved);

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlDocumentLoader.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlDocumentLoader.java
@@ -1,6 +1,7 @@
 package com.openhtmltopdf.svgsupport;
 
 import com.openhtmltopdf.extend.UserAgentCallback;
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import org.apache.batik.bridge.DocumentLoader;
@@ -37,6 +38,6 @@ public class OpenHtmlDocumentLoader extends DocumentLoader {
         } catch (URISyntaxException uriSyntaxException) {
             XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_URI_SYNTAX_WHILE_LOADING_EXTERNAL_SVG_RESOURCE, uri, uriSyntaxException);
         }
-        return super.loadDocument(uri, new ByteArrayInputStream(userAgentCallback.getBinaryResource(uri)));
+        return super.loadDocument(uri, new ByteArrayInputStream(userAgentCallback.getBinaryResource(uri, ExternalResourceType.XML)));
     }
 }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
@@ -11,6 +11,7 @@ import com.openhtmltopdf.extend.UserAgentCallback;
 import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.render.Box;
 import com.openhtmltopdf.render.RenderingContext;
+import com.openhtmltopdf.resource.ExternalResourceType;
 import com.openhtmltopdf.simple.extend.ReplacedElementScaleHelper;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
@@ -179,7 +180,7 @@ public class PDFTranscoder extends SVGAbstractTranscoder {
 		            continue;
 		         }
 
-		         byte[] font1 = ctx.getUserAgentCallback().getBinaryResource(src.asString());
+		         byte[] font1 = ctx.getUserAgentCallback().getBinaryResource(src.asString(), ExternalResourceType.FONT);
 		         if (font1 == null) {
 		         	XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, src.asString());
 		             continue;


### PR DESCRIPTION
Hi @danfickle this PR is an initial work as discussed in #508 for adding some kind of context when checking the access of external resource.

I've added some stubs for defining the new interfaces. It should be retro compatible. The objective is, for example in the case of #508, to call the more precise `getResourceXYZ(uri, type)` instead of the generic one.

WDYT? :)