### PR TITLE
optimize the log formatter

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/Diagnostic.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/Diagnostic.java
@@ -36,11 +36,7 @@ public class Diagnostic {
     }
 
     public String getFormattedMessage() {
-        if (logMessageId instanceof LogMessageId.LogMessageId0Param) {
-            return logMessageId.getMessageFormat();
-        } else {
-            return String.format(MESSAGE_FORMAT_PLACEHOLDER.matcher(logMessageId.getMessageFormat()).replaceAll("%s"), args);
-        }
+        return logMessageId.formatMessage(args);
     }
 
     public Object[] getArgs() {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -5,6 +5,7 @@ public interface LogMessageId {
     Enum<?> getEnum();
     String getWhere();
     String getMessageFormat();
+    String formatMessage(Object[] args);
 
     enum LogMessageId0Param implements LogMessageId {
         CSS_PARSE_MUST_PROVIDE_AT_LEAST_A_FONT_FAMILY_AND_SRC_IN_FONT_FACE_RULE(XRLog.CSS_PARSE, "Must provide at least a font-family and src in @font-face rule"),
@@ -81,6 +82,10 @@ public interface LogMessageId {
             return where;
         }
 
+        @Override
+        public String formatMessage(Object[] args) {
+            return getMessageFormat();
+        }
     }
 
     enum LogMessageId1Param implements LogMessageId {
@@ -160,10 +165,12 @@ public interface LogMessageId {
 
         private final String where;
         private final String messageFormat;
+        private final LogMessageIdFormat logMessageIdFormat;
 
         LogMessageId1Param(String where, String messageFormat) {
             this.where = where;
             this.messageFormat = messageFormat;
+            this.logMessageIdFormat = new LogMessageIdFormat(messageFormat);
         }
 
         @Override
@@ -179,6 +186,11 @@ public interface LogMessageId {
         @Override
         public String getWhere() {
             return where;
+        }
+
+        @Override
+        public String formatMessage(Object[] args) {
+            return logMessageIdFormat.formatMessage(args);
         }
     }
 
@@ -216,10 +228,12 @@ public interface LogMessageId {
 
         private final String where;
         private final String messageFormat;
+        private final LogMessageIdFormat logMessageIdFormat;
 
         LogMessageId2Param(String where, String messageFormat) {
             this.where = where;
             this.messageFormat = messageFormat;
+            this.logMessageIdFormat = new LogMessageIdFormat(messageFormat);
         }
 
         @Override
@@ -230,6 +244,11 @@ public interface LogMessageId {
         @Override
         public String getMessageFormat() {
             return messageFormat;
+        }
+
+        @Override
+        public String formatMessage(Object[] args) {
+            return logMessageIdFormat.formatMessage(args);
         }
 
         @Override
@@ -252,10 +271,12 @@ public interface LogMessageId {
 
         private final String where;
         private final String messageFormat;
+        private final LogMessageIdFormat logMessageIdFormat;
 
         LogMessageId3Param(String where, String messageFormat) {
             this.where = where;
             this.messageFormat = messageFormat;
+            this.logMessageIdFormat = new LogMessageIdFormat(messageFormat);
         }
 
         @Override
@@ -271,6 +292,11 @@ public interface LogMessageId {
         @Override
         public String getWhere() {
             return where;
+        }
+
+        @Override
+        public String formatMessage(Object[] args) {
+            return logMessageIdFormat.formatMessage(args);
         }
     }
 
@@ -286,10 +312,12 @@ public interface LogMessageId {
 
         private final String where;
         private final String messageFormat;
+        private final LogMessageIdFormat logMessageIdFormat;
 
         LogMessageId4Param(String where, String messageFormat) {
             this.where = where;
             this.messageFormat = messageFormat;
+            this.logMessageIdFormat = new LogMessageIdFormat(messageFormat);
         }
 
         @Override
@@ -305,6 +333,11 @@ public interface LogMessageId {
         @Override
         public String getWhere() {
             return where;
+        }
+
+        @Override
+        public String formatMessage(Object[] args) {
+            return logMessageIdFormat.formatMessage(args);
         }
     }
 
@@ -314,10 +347,12 @@ public interface LogMessageId {
 
         private final String where;
         private final String messageFormat;
+        private final LogMessageIdFormat logMessageIdFormat;
 
         LogMessageId5Param(String where, String messageFormat) {
             this.where = where;
             this.messageFormat = messageFormat;
+            this.logMessageIdFormat = new LogMessageIdFormat(messageFormat);
         }
 
         @Override
@@ -333,6 +368,11 @@ public interface LogMessageId {
         @Override
         public String getWhere() {
             return where;
+        }
+
+        @Override
+        public String formatMessage(Object[] args) {
+            return logMessageIdFormat.formatMessage(args);
         }
 
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageIdFormat.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageIdFormat.java
@@ -1,0 +1,51 @@
+package com.openhtmltopdf.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class LogMessageIdFormat {
+
+    private final Object PLACEHOLDER = new Object();
+
+
+    private final List<Object> tokens;
+
+    LogMessageIdFormat(String message) {
+        this.tokens = prepareFormatter(message);
+    }
+
+    private List<Object> prepareFormatter(String messageFormat) {
+        List<Object> v = new ArrayList<>();
+        int idx = 0;
+        while(true) {
+            int newIdx = messageFormat.indexOf("{}", idx);
+            String messageSegment = newIdx == -1 ? messageFormat.substring(idx) : messageFormat.substring(idx, newIdx);
+            if (!messageSegment.isEmpty()) {
+                v.add(messageSegment);
+            }
+            if (newIdx == -1) {
+                break;
+            }
+            idx = newIdx + 2;
+            v.add(PLACEHOLDER);
+        }
+        return v;
+    }
+
+    String formatMessage(Object[] args) {
+        StringBuilder sb = new StringBuilder();
+        int size = tokens.size();
+        int argsUse = 0;
+        for (int i = 0; i < size; i++) {
+            Object f = tokens.get(i);
+            if (f == PLACEHOLDER) {
+                Object argument = args[argsUse];
+                sb.append(argument);
+                argsUse++;
+            } else {
+                sb.append(f);
+            }
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Hi @danfickle , this PR try to optimize JDKXRLogger and especially the XRSimpleLogFormatter.

On the JDKXRLogger, we keep a Map so we don't need to go through  `Logger.getLogger` which is kinda slow.

On the XRSimpleLogFormatter side, the biggest win is to avoid calling if necessary:

 - record.getSourceClassName
 - record.getSourceMethodName
 - printing the stacktrace

Both the `record` methods call internally `inferCaller` which it has is own complexity.

To identify which of the parameters are effectively used for the format, I went to the "ugly" route as I'm not aware of any API to check if a parameter is present or not.

I've also aligned the default from the configuration file (see Configuration.valueFor( "xr.simple-log-format") at the bottom).

Generally all this work avoid the quite heavy stacktrace walking, which could be quite long in the cases of deeply nested tables.

Additionally, I've optimized also the formatting of the "diagnostic" message. I've removed the use of String.format. See `LogMessageIdFormat`: this will avoid to call `String.format(MESSAGE_FORMAT_PLACEHOLDER.matcher(logMessageId.getMessageFormat()).replaceAll("%s"), args);` on each message formatting, which is  used quite often if the user use the jdklogger.