### PR TITLE
log message id format: use static final + add test

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageIdFormat.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageIdFormat.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 class LogMessageIdFormat {
 
-    private final Object PLACEHOLDER = new Object();
+    private static final Object PLACEHOLDER = new Object();
 
 
     private final List<Object> tokens;
@@ -34,12 +34,13 @@ class LogMessageIdFormat {
 
     String formatMessage(Object[] args) {
         StringBuilder sb = new StringBuilder();
+        int argsLength = args == null ? 0 : args.length;
         int size = tokens.size();
         int argsUse = 0;
         for (int i = 0; i < size; i++) {
             Object f = tokens.get(i);
             if (f == PLACEHOLDER) {
-                Object argument = args[argsUse];
+                Object argument = argsUse < argsLength ? args[argsUse] : "";
                 sb.append(argument);
                 argsUse++;
             } else {

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/LogMessageIdFormatTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/LogMessageIdFormatTest.java
@@ -1,0 +1,21 @@
+package com.openhtmltopdf.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogMessageIdFormatTest {
+
+    @Test
+    public void testFormats() {
+        Assert.assertEquals("", new LogMessageIdFormat("").formatMessage(new Integer[]{1,2,3}));
+        Assert.assertEquals("abcd", new LogMessageIdFormat("abcd").formatMessage(null));
+        Assert.assertEquals("1a2b3", new LogMessageIdFormat("1{}2{}3").formatMessage(new String[]{"a", "b"}));
+        Assert.assertEquals("123", new LogMessageIdFormat("{}{}{}").formatMessage(new Integer[]{1,2,3}));
+        Assert.assertEquals("A1a2b3B", new LogMessageIdFormat("{}1{}2{}3{}").formatMessage(new String[]{"A", "a", "b", "B"}));
+
+        Assert.assertEquals("A123", new LogMessageIdFormat("{}1{}2{}3{}").formatMessage(new String[]{"A"}));
+
+        Assert.assertEquals("", new LogMessageIdFormat("{}{}{}").formatMessage(new Integer[]{}));
+        Assert.assertEquals("", new LogMessageIdFormat("{}{}{}").formatMessage(null));
+    }
+}


### PR DESCRIPTION
I noticed that in #552 that I forgot to set as "static" the placeholder. 

Additionally, I've added some tests.