### PR TITLE
#599 Increment _end in trimLeadingSpace

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/InlineBoxing.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/InlineBoxing.java
@@ -1170,6 +1170,7 @@ public class InlineBoxing {
             i++;
         }
         lbContext.setStart(lbContext.getStart() + i);
+        lbContext.setEnd(lbContext.getEnd() + i);
     }
 
     private static LineBox newLine(LayoutContext c, LineBox previousLine, Box box) {


### PR DESCRIPTION
Increment LineBreakContext ending when trimming leading space. When a tag only has spaces, e.g. an &nbsp; entity, the result was an ending smaller than a start, causing a RuntimeException.