### PR TITLE
#594 #458 Fix for repeating content and PDF/UA crash.

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
@@ -1092,6 +1092,10 @@ public class Layer {
         pages.add(pageBox);
     }
 
+    public PageBox getFirstPage(CssContext c, int absY) {
+        return getPage(c, absY);
+    }
+
     public PageBox getFirstPage(CssContext c, Box box) {
         return getPage(c, box.getAbsY());
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/Layer.java
@@ -1092,11 +1092,33 @@ public class Layer {
         pages.add(pageBox);
     }
 
+    /**
+     * Returns the page box for a Y position.
+     * If the y position is less than 0 then the first page will
+     * be returned if available.
+     * Returns null if there are no pages available or absY
+     * is past the last page.
+     */
     public PageBox getFirstPage(CssContext c, int absY) {
-        return getPage(c, absY);
+        PageBox page = getPage(c, absY);
+
+        if (page == null && absY < 0) {
+            List<PageBox> pages = getPages();
+
+            if (!pages.isEmpty()) {
+                return pages.get(0);
+            }
+        }
+
+        return page;
     }
 
     public PageBox getFirstPage(CssContext c, Box box) {
+        if (box instanceof LineBox) {
+            LineBox lb = (LineBox) box;
+            return getPage(c, lb.getMinPaintingTop());
+        }
+
         return getPage(c, box.getAbsY());
     }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/Box.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/Box.java
@@ -756,13 +756,17 @@ public abstract class Box implements Styleable, DisplayListItem {
     }
 
     public int forcePageBreakBefore(LayoutContext c, IdentValue pageBreakValue, boolean pendingPageName) {
-        PageBox page = c.getRootLayer().getFirstPage(c, this);
+        return forcePageBreakBefore(c, pageBreakValue, pendingPageName, getAbsY());
+    }
+
+    public int forcePageBreakBefore(LayoutContext c, IdentValue pageBreakValue, boolean pendingPageName, int absY) {
+        PageBox page = c.getRootLayer().getFirstPage(c, absY);
         if (page == null) {
             XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.LAYOUT_BOX_HAS_NO_PAGE);
             return 0;
         } else {
             int pageBreakCount = 1;
-            if (page.getTop() == getAbsY()) {
+            if (page.getTop() == absY) {
                 pageBreakCount--;
                 if (pendingPageName && page == c.getRootLayer().getLastPage()) {
                     c.getRootLayer().removeLastPage();
@@ -783,7 +787,7 @@ public abstract class Box implements Styleable, DisplayListItem {
                 c.setPageName(c.getPendingPageName());
             }
 
-            int delta = page.getBottom() + c.getExtraSpaceTop() - getAbsY();
+            int delta = page.getBottom() + c.getExtraSpaceTop() - absY;
             if (page == c.getRootLayer().getLastPage()) {
                 c.getRootLayer().addPage(c);
             }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/LineBox.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/LineBox.java
@@ -419,6 +419,20 @@ public class LineBox extends Box implements InlinePaintable {
         _paintingTop = paintingTop;
     }
 
+    public int getMinPaintingTop() {
+        int paintingAbsTop = getAbsY() + getPaintingTop();
+        int lineAbsTop = getAbsY();
+
+        return Math.min(lineAbsTop, paintingAbsTop);
+    }
+
+    public int getMaxPaintingBottom() {
+        int paintingAbsBottom = getAbsY() + getPaintingTop() + getPaintingHeight();
+        int lineAbsBottom = getAbsY() + getHeight();
+
+        return Math.max(paintingAbsBottom, lineAbsBottom);
+    }
+
     public void addAllChildren(List<? super Box> list, Layer layer) {
         for (int i = 0; i < getChildCount(); i++) {
             Box child = getChild(i);
@@ -650,12 +664,12 @@ public class LineBox extends Box implements InlinePaintable {
         container.updateTop(c, getAbsY());
         container.updateBottom(c, getAbsY() + getHeight());
     }
-    
+
     public void checkPagePosition(LayoutContext c, boolean alwaysBreak) {
         if (! c.isPageBreaksAllowed()) {
             return;
         }
-        
+
         PageBox pageBox = c.getRootLayer().getFirstPage(c, this);
         if (pageBox != null) {
             // We need to force a page break if any of our content goes over a page break,
@@ -663,14 +677,8 @@ public class LineBox extends Box implements InlinePaintable {
             // printed on both pages).
 
             // Painting top and bottom take account of line-height other than 1.
-            int paintingAbsTop = getAbsY() + getPaintingTop();
-            int paintingAbsBottom = paintingAbsTop + getPaintingHeight();
-
-            int lineAbsTop = getAbsY();
-            int lineAbsBottom = lineAbsTop + getHeight();
-
-            int leastAbsY = Math.min(paintingAbsTop, lineAbsTop);
-            int greatestAbsY = Math.max(paintingAbsBottom, lineAbsBottom);
+            int greatestAbsY = getMaxPaintingBottom();
+            int leastAbsY = getMinPaintingTop();
 
             boolean needsPageBreak = 
                 alwaysBreak || greatestAbsY >= pageBox.getBottom() - c.getExtraSpaceBottom();
@@ -680,7 +688,6 @@ public class LineBox extends Box implements InlinePaintable {
                calcCanvasLocation();
            } else if (pageBox.getTop() + c.getExtraSpaceTop() > getAbsY()) {
                int diff = pageBox.getTop() + c.getExtraSpaceTop() - getAbsY();
-               
                setY(getY() + diff);
                calcCanvasLocation();
            }

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/pr-610-force-page-break-line.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/pr-610-force-page-break-line.pdf
@@ -1,0 +1,203 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20201128212029+11'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R 5 0 R 6 0 R]
+/Count 3
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 112.5 75.0]
+/Parent 2 0 R
+/Contents 7 0 R
+/Resources 8 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 112.5 75.0]
+/Parent 2 0 R
+/Contents 9 0 R
+/Resources 10 0 R
+>>
+endobj
+6 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 112.5 75.0]
+/Parent 2 0 R
+/Contents 11 0 R
+/Resources 12 0 R
+>>
+endobj
+7 0 obj
+<<
+/Length 177
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+11.25 63.75 m
+101.25 63.75 l
+101.25 11.2875 l
+11.25 11.2875 l
+11.25 63.75 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 12 Tf
+1 0 0 1 11.25 52.9875 Tm
+(SPACER) Tj
+ET
+Q
+
+endstream
+endobj
+8 0 obj
+<<
+/Font 13 0 R
+>>
+endobj
+9 0 obj
+<<
+/Length 175
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+11.25 63.75 m
+101.25 63.75 l
+101.25 11.2875 l
+11.25 11.2875 l
+11.25 63.75 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 45 Tf
+1 0 0 1 11.25 23.325 Tm
+(Line ) Tj
+ET
+Q
+
+endstream
+endobj
+10 0 obj
+<<
+/Font 14 0 R
+>>
+endobj
+11 0 obj
+<<
+/Length 173
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+11.25 63.75 m
+101.25 63.75 l
+101.25 11.2875 l
+11.25 11.2875 l
+11.25 63.75 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 45 Tf
+1 0 0 1 11.25 23.325 Tm
+(One) Tj
+ET
+Q
+
+endstream
+endobj
+12 0 obj
+<<
+/Font 15 0 R
+>>
+endobj
+13 0 obj
+<<
+/F1 16 0 R
+>>
+endobj
+14 0 obj
+<<
+/F1 16 0 R
+>>
+endobj
+15 0 obj
+<<
+/F1 16 0 R
+>>
+endobj
+16 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 17
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000238 00000 n
+0000000349 00000 n
+0000000461 00000 n
+0000000574 00000 n
+0000000804 00000 n
+0000000838 00000 n
+0000001066 00000 n
+0000001101 00000 n
+0000001328 00000 n
+0000001363 00000 n
+0000001396 00000 n
+0000001429 00000 n
+0000001462 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<C8FC34A2646D8891F07861E183E3F709> <C8FC34A2646D8891F07861E183E3F709>]
+/Size 17
+>>
+startxref
+1562
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-594-content-repeated.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-594-content-repeated.html
@@ -8,6 +8,12 @@
     body {
         margin: 0;
     }
+    td {
+      background-color: red;
+    }
+    span {
+      background-color: blue;
+    }
 </style>
 </head>
     <body style="line-height: 0.8;">
@@ -17,7 +23,7 @@
               <td>One</td><td>1</td>
           </tr>
           <tr>
-              <td>Abcdefghij2</td><td>2</td>
+              <td><span>Abcdefghij2</span></td><td>2</td>
           </tr>
         </table>
     </body>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/pr-610-force-page-break-line.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/pr-610-force-page-break-line.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<style>
+    @page {
+        size: 150px 100px;
+        margin: 15px;
+    }
+    body {
+        margin: 0;
+    }
+</style>
+</head>
+  <body>
+    <div style="height: 20px;">SPACER</div>
+    <div style="line-height: 20px; font-size: 60px;">Line One</div>
+  </body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -819,12 +819,11 @@ public class NonVisualRegressionTest {
      * Table row repeating on two pages. See issue 594.
      */
     @Test
-    @Ignore // The second row is repeating on both pages.
     public void testIssue594RepeatingContentTableRow() throws IOException {
         try (PDDocument doc = run("issue-594-content-repeated")) {
             PDFTextStripper stripper = new PDFTextStripper();
             String text = stripper.getText(doc).replaceAll("(\\r|\\n)", "");
-            String expected = "One" + "Abcdefghij2";
+            String expected = "One 1" + "Abcdefghij2 2";
 
             assertEquals(expected, text);
         }

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1286,6 +1286,15 @@ public class VisualRegressionTest {
         assertTrue(vt.runTest("issue-599-trim-leading-space-exception"));
     }
 
+    /**
+     * Tests auto page break before line-box with content
+     * much larger than line-height.
+     */
+    @Test
+    public void testPr610ForcePageBreakLine() throws IOException {
+        assertTrue(vt.runTest("pr-610-force-page-break-line"));
+    }
+
     // TODO:
     // + Elements that appear just on generated overflow pages.
     // + content property (page counters, etc)


### PR DESCRIPTION
#594 #458 

This fixes repeating content in page margins when line-height is other than one. It also fixes the PDF UA crash caused by the repeating content.

However, it is a behavior changing fix. Documents with text split over two pages (usually undesired) will now get a forced page break before the split text.

I have created this PR as I still need to add some tests where line-height is very small or very large.