### PR TITLE
Use the PDFBox builtin image direct embedding

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -60,12 +60,10 @@ import org.apache.pdfbox.pdmodel.graphics.shading.PDShading;
 import org.apache.pdfbox.pdmodel.graphics.state.RenderingMode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import javax.imageio.ImageIO;
+
 import java.awt.*;
 import java.awt.RenderingHints.Key;
 import java.awt.geom.*;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -794,15 +792,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
     public void realizeImage(PdfBoxImage img) {
         PDImageXObject xobject;
         try {
-            if (img.isJpeg()) {
-                xobject = JPEGFactory.createFromStream(_writer,
-                        new ByteArrayInputStream(img.getBytes()));
-            } else {
-                BufferedImage buffered = ImageIO.read(new ByteArrayInputStream(
-                        img.getBytes()));
-
-                xobject = LosslessFactory.createFromImage(_writer, buffered);
-            }
+            xobject = PDImageXObject.createFromByteArray(_writer, img.getBytes(), img.getUri());
         } catch (IOException e) {
             throw new PdfContentStreamAdapter.PdfException("realizeImage", e);
         }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
@@ -22,8 +22,6 @@ public class PdfBoxImage implements FSImage {
     private float _intrinsicWidth;
     private float _intrinsicHeight;
 
-    private final boolean _isJpeg;
-
     private PDImageXObject _xobject;
     
     public PdfBoxImage(byte[] image, String uri) throws IOException {
@@ -40,12 +38,6 @@ public class PdfBoxImage implements FSImage {
                 reader.setInput(in);
                 _intrinsicWidth = reader.getWidth(0);
                 _intrinsicHeight = reader.getHeight(0);
-
-                String type = reader.getFormatName();
-
-                _isJpeg = (type.equalsIgnoreCase("jpeg")
-                        || type.equalsIgnoreCase("jpg") || type
-                        .equalsIgnoreCase("jfif"));
             } else {
                 XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_UNRECOGNIZED_IMAGE_FORMAT_FOR_URI, uri);
                 // TODO: Avoid throw here.
@@ -58,12 +50,11 @@ public class PdfBoxImage implements FSImage {
     }
 
     public PdfBoxImage(byte[] bytes, String uri, float width, float height,
-            boolean isJpeg, PDImageXObject xobject) {
+            PDImageXObject xobject) {
         this._bytes = bytes;
         this._uri = uri;
         this._intrinsicWidth = width;
         this._intrinsicHeight = height;
-        this._isJpeg = isJpeg;
         this._xobject = xobject;
     }
 
@@ -77,7 +68,7 @@ public class PdfBoxImage implements FSImage {
             height *= factor;
         }
 
-        return new PdfBoxImage(_bytes, _uri, width, height, _isJpeg, _xobject);
+        return new PdfBoxImage(_bytes, _uri, width, height, _xobject);
     }
 
     @Override
@@ -140,9 +131,5 @@ public class PdfBoxImage implements FSImage {
     
     public String getUri() {
         return _uri;
-    }
-
-    public boolean isJpeg() {
-        return _isJpeg;
     }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSlowOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxSlowOutputDevice.java
@@ -803,15 +803,7 @@ public class PdfBoxSlowOutputDevice extends AbstractOutputDevice implements Outp
     public void realizeImage(PdfBoxImage img) {
         PDImageXObject xobject;
         try {
-            if (img.isJpeg()) {
-                xobject = JPEGFactory.createFromStream(_writer,
-                        new ByteArrayInputStream(img.getBytes()));
-            } else {
-                BufferedImage buffered = ImageIO.read(new ByteArrayInputStream(
-                        img.getBytes()));
-
-                xobject = LosslessFactory.createFromImage(_writer, buffered);
-            }
+            xobject = PDImageXObject.createFromByteArray(_writer, img.getBytes(), img.getUri());
         } catch (IOException e) {
             throw new PdfContentStreamAdapter.PdfException("realizeImage", e);
         }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxUserAgent.java
@@ -66,7 +66,7 @@ public class PdfBoxUserAgent extends NaiveUserAgent {
         if (resource != null && resource.getImage() instanceof PdfBoxImage) {
             // Make copy of PdfBoxImage so we don't stuff up the cache.
             PdfBoxImage original = (PdfBoxImage) resource.getImage();
-            PdfBoxImage copy = new PdfBoxImage(original.getBytes(), original.getUri(), original.getWidth(), original.getHeight(), original.isJpeg(), original.getXObject());
+            PdfBoxImage copy = new PdfBoxImage(original.getBytes(), original.getUri(), original.getWidth(), original.getHeight(), original.getXObject());
             return new ImageResource(resource.getImageUri(), copy);
         }
         


### PR DESCRIPTION
And don't try to do this ourself. Since some releases PDFBox is able
to not only directly (i.e. without re-encoding) embed images, but
also to directly embed PNG images. TIFF images are supported if
they are in CCITT (i.e. Fax) format.

Note: The PNG direct embedding only works for some PNG encodings,
for details see https://issues.apache.org/jira/browse/PDFBOX-4341

This allows to manually optimise Images using e.g. ImageOptim and benefit
from this optimized images.

If it is not possible to directly embed an image PDFBox falls back to
ImageIO.read() and the LosslessFactory.createFromImage().

In the worst case, this patch may make PDFs bigger, as the
provided image files may be in a worse compression quality
(file size wise) then the LosslessFactory would do when compressing.

But in the best case the PDF writing gets faster, as not every image
needs to be decompressed and compressed again. And the PDFs could get
smaller if the images have been preoptimized.