### PR TITLE
expose field/method for use by docx4j-ImportXHTML

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -114,7 +114,11 @@ public class CalculatedStyle {
      */
     private final FSDerivedValue[] _derivedValuesById;
 
-    /**
+    public FSDerivedValue[] getderivedValuesById() {
+		return _derivedValuesById;
+	}
+
+	/**
      * The derived Font for this style
      */
     private FontSpecification _font;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/LengthValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/derived/LengthValue.java
@@ -50,7 +50,11 @@ public class LengthValue extends DerivedValue {
      */
     private short _lengthPrimitiveType;
     
-    public LengthValue(CalculatedStyle style, CSSName name, PropertyValue value) {
+    public short getLengthPrimitiveType() {
+		return _lengthPrimitiveType;
+	}
+
+	public LengthValue(CalculatedStyle style, CSSName name, PropertyValue value) {
         super(name, value.getPrimitiveType(), value.getCssText(), value.getCssText());
         
         _style = style;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/newtable/TableCellBox.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/newtable/TableCellBox.java
@@ -152,7 +152,7 @@ public class TableCellBox extends BlockBox {
         return _table;
     }
     
-    protected TableSectionBox getSection() {
+    public TableSectionBox getSection() {
         if (_section == null) {
             _section = (TableSectionBox)getParent().getParent();
         }


### PR DESCRIPTION
https://github.com/plutext/docx4j-ImportXHTML is a library for converting well formed HTML to Microsoft Word content (OpenXML).  We have just migrated it from a patched version of Flying Saucer, to openhtmltopdf.

See https://github.com/plutext/docx4j-ImportXHTML/tree/openhtmltopdf and https://www.docx4java.org/forums/announces/docx4j-importxhtml-8-2-0-released-t2967.html

In doing so, there are 3 places we had to use reflection.   This PR, if merged, would allow us to make a release which didn't use reflection.  Thank you Dan.