### PR TITLE
Implementation of file-embed link.

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -111,6 +111,7 @@ public interface LogMessageId {
         LOAD_COULD_NOT_INSTANTIATE_CUSTOM_XML_READER(XRLog.LOAD, "Could not instantiate custom XMLReader class for XML parsing: {}. " +
                 "Please check classpath. Use value 'default' in FS configuration if necessary. Will now try JDK default."),
         LOAD_UNABLE_TO_LOAD_CSS_FROM_URI(XRLog.LOAD, "Unable to load CSS from {}"),
+        LOAD_COULD_NOT_LOAD_EMBEDDED_FILE(XRLog.LOAD, "Was not able to load an embedded file for embedding with uri {}"),
         LOAD_PARSE_STYLESHEETS_TIME(XRLog.LOAD, "TIME: parse stylesheets {}ms"),
         LOAD_REQUESTING_STYLESHEET_AT_URI(XRLog.LOAD, "Requesting stylesheet: {}"),
         LOAD_UNRECOGNIZED_IMAGE_FORMAT_FOR_URI(XRLog.LOAD, "Unrecognized image format for: {}"),
@@ -161,7 +162,8 @@ public interface LogMessageId {
         EXCEPTION_COULD_NOT_LOAD_FONT_FACE(XRLog.EXCEPTION, "Could not load @font-face font: {}"),
         EXCEPTION_COULD_NOT_LOAD_DEFAULT_CSS(XRLog.EXCEPTION, "Can't load default CSS from {}. This file must be on your CLASSPATH. Please check before continuing."),
         EXCEPTION_DEFAULT_USERAGENT_IS_NOT_ABLE_TO_RESOLVE_BASE_URL_FOR(XRLog.EXCEPTION, "The default NaiveUserAgent doesn't know how to resolve the base URL for {}"),
-        EXCEPTION_FAILED_TO_LOAD_BACKGROUND_IMAGE_AT_URI(XRLog.EXCEPTION, "Failed to load background image at uri {}");
+        EXCEPTION_FAILED_TO_LOAD_BACKGROUND_IMAGE_AT_URI(XRLog.EXCEPTION, "Failed to load background image at uri {}"),
+        EXCEPTION_COULD_NOT_LOAD_EMBEDDED_FILE(XRLog.EXCEPTION, "Was not able to create an embedded file for embedding with uri {}");
 
         private final String where;
         private final String messageFormat;

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-508-file-embed.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-508-file-embed.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<style>
+@page {
+  size: 200px 200px;
+}
+</style>
+</head>
+<body>
+Embedded <a href="stylesheets/basic.css" download="basic.css" data-content-type="text/plain">text <br/> document</a>.
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -24,6 +24,7 @@ import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionGoTo;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
@@ -39,6 +40,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.openhtmltopdf.outputdevice.helper.ExternalResourceControlPriority;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.openhtmltopdf.testcases.TestcaseRunner;
 import com.openhtmltopdf.util.Diagnostic;
@@ -1060,6 +1062,28 @@ public class NonVisualRegressionTest {
                   .allMatch(diag -> !diag.getFormattedMessage().isEmpty()));
     }
 
+    @Test
+    public void testIssue508FileEmbed() throws IOException {
+        try (PDDocument doc = run("issue-508-file-embed",
+                builder -> {
+                    // File embeds are blocked by default, allow everything.
+                    builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_AFTER_RESOLVING_URI);
+                    builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_BEFORE_RESOLVING_URI);
+                })) {
+            // TODO: Renable this assertion when we have figured out a way
+            // to avoid duplicate file embeds when the link is broken
+            // up into boxes (eg. multiple lines).
+            // assertThat(doc.getPage(0).getAnnotations().size(), equalTo(1));
+
+            PDAnnotationFileAttachment fileAttach = (PDAnnotationFileAttachment) doc.getPage(0).getAnnotations().get(0);
+            assertThat(fileAttach.getFile().getFile(), equalTo("basic.css"));
+
+            // TODO:
+            // More asserts.
+
+            remove("issue-508-file-embed", doc);
+        }
+    }
 
     // TODO:
     // + More form controls.

--- a/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfATester.java
+++ b/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfATester.java
@@ -28,6 +28,7 @@ import org.verapdf.pdfa.results.TestAssertion.Status;
 import org.verapdf.pdfa.results.TestAssertion;
 import org.verapdf.pdfa.results.ValidationResult;
 
+import com.openhtmltopdf.outputdevice.helper.ExternalResourceControlPriority;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.PdfAConformance;
 
@@ -65,7 +66,11 @@ public class PdfATester {
             builder.usePdfAConformance(conform);
             builder.useFont(new File("target/test/artefacts/Karla-Bold.ttf"), "TestFont");
             builder.withHtmlContent(html, PdfATester.class.getResource("/html/").toString());
-    
+
+            // File embeds are blocked by default, allow everything.
+            builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_AFTER_RESOLVING_URI);
+            builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_BEFORE_RESOLVING_URI);
+
             try (InputStream colorProfile = PdfATester.class.getResourceAsStream("/colorspaces/sRGB.icc")) {
                 byte[] colorProfileBytes = IOUtils.toByteArray(colorProfile);
                 builder.useColorProfile(colorProfileBytes);
@@ -128,5 +133,12 @@ public class PdfATester {
     public void testAllInOnePdfA2u() throws Exception {
         assertTrue(run("all-in-one", PDFAFlavour.PDFA_2_U, PdfAConformance.PDFA_2_U));
     }
-    
+
+    /**
+     * File embedding is allowed as of PDF/A3.
+     */
+    @Test
+    public void testFileEmbedA3b() throws Exception {
+        assertTrue(run("file-embed", PDFAFlavour.PDFA_3_B, PdfAConformance.PDFA_3_B));
+    }
 }

--- a/openhtmltopdf-pdfa-testing/src/test/resources/html/file-embed.html
+++ b/openhtmltopdf-pdfa-testing/src/test/resources/html/file-embed.html
@@ -1,0 +1,36 @@
+<html lang="EN-US">
+<head>
+  <title>File embed testcase</title>
+  <meta name="subject" content="PDF/A3 file embed"/>
+  <meta name="author" content="openhtmltopdf.com team"/>
+  <meta name="description" content="An example for file embed"/>
+
+  <bookmarks>
+   <bookmark name="File embed" href="#file"/>
+  </bookmarks>
+
+  <style>
+  body {
+    margin: 0;
+    font-family: 'TestFont'; /* Font provided with builder. */
+    font-size: 15px;
+  }
+  </style>
+</head>
+<body>
+ <h1 id="file">File embed example</h1>
+
+ <p>
+   <a href="file-embed.html"
+      download="source.html"
+      data-content-type="text/html"
+      title="File embedded"
+      relationship="Source">
+
+      File embed
+
+   </a>
+ </p>
+
+</body>
+</html>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/AnnotationContainer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/AnnotationContainer.java
@@ -1,0 +1,64 @@
+package com.openhtmltopdf.pdfboxout;
+
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDBorderStyleDictionary;
+
+public abstract class AnnotationContainer {
+    public void setRectangle(PDRectangle rectangle) {
+        getPdAnnotation().setRectangle(rectangle);
+    }
+
+    public void setPrinted(boolean printed) {
+        getPdAnnotation().setPrinted(printed);
+    }
+
+    public void setQuadPoints(float[] quadPoints) {};
+
+    public abstract void setBorderStyle(PDBorderStyleDictionary styleDict);
+
+    public abstract PDAnnotation getPdAnnotation();
+
+    public static class PDAnnotationFileAttachmentContainer extends AnnotationContainer {
+        private final PDAnnotationFileAttachment pdAnnotationFileAttachment;
+
+        public PDAnnotationFileAttachmentContainer(PDAnnotationFileAttachment pdAnnotationFileAttachment) {
+            this.pdAnnotationFileAttachment = pdAnnotationFileAttachment;
+        }
+
+        @Override
+        public PDAnnotation getPdAnnotation() {
+            return pdAnnotationFileAttachment;
+        }
+
+        @Override
+        public void setBorderStyle(PDBorderStyleDictionary styleDict) {
+            pdAnnotationFileAttachment.setBorderStyle(styleDict);
+        }
+    }
+
+    public static class PDAnnotationLinkContainer extends AnnotationContainer {
+        private final PDAnnotationLink pdAnnotationLink;
+
+        public PDAnnotationLinkContainer(PDAnnotationLink pdAnnotationLink) {
+            this.pdAnnotationLink = pdAnnotationLink;
+        }
+
+        @Override
+        public PDAnnotation getPdAnnotation() {
+            return pdAnnotationLink;
+        }
+
+        @Override
+        public void setQuadPoints(float[] quadPoints) {
+            pdAnnotationLink.setQuadPoints(quadPoints);
+        }
+
+        @Override
+        public void setBorderStyle(PDBorderStyleDictionary styleDict) {
+            pdAnnotationLink.setBorderStyle(styleDict);
+        }
+    }
+}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -1210,17 +1210,17 @@ public class PdfBoxAccessibilityHelper {
         PDAnnotation annotation;
     }
 
-    public void addLink(Box anchor, Box target, PDAnnotationLink annotation, PDPage page) {
+    public void addLink(Box anchor, Box target, PDAnnotation pdAnnotation, PDPage page) {
         PDStructureElement struct = getStructualElementForBox(anchor);
         if (struct != null) {
             // We have to append the link annotationobject reference as a kid of its associated structure element.
             PDObjectReference ref = new PDObjectReference();
-            ref.setReferencedObject(annotation);
+            ref.setReferencedObject(pdAnnotation);
             struct.appendKid(ref);  
             
             // We also need to save the pair so we can add it to the number tree for reverse lookup.
             AnnotationWithStructureParent annotStructParentPair = new AnnotationWithStructureParent();
-            annotStructParentPair.annotation = annotation;
+            annotStructParentPair.annotation = pdAnnotation;
             annotStructParentPair.structureParent = struct;
             
             _pageItems._pageAnnotations.add(annotStructParentPair);


### PR DESCRIPTION
#508 #509 #636

Based heavily on code by @syjer whom I'm indebted to. Thanks.

Still todo:
+ [x] Prevent duplicate file embeds. Possibly create a map of uris to PDComplexFileSpecification and reuse if encountered again. I have to peruse the PDF spec to see if this is allowed.
+ [x] Logging on fail.