### PR TITLE
move setting of initPending to false only after initializing the jdk log manager, fix #646

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/JDKXRLogger.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/JDKXRLogger.java
@@ -107,10 +107,11 @@ public class JDKXRLogger implements XRLogger {
             if (!initPending) {
                 return;
             }
-            //now change this immediately, in case something fails
-            initPending = false;
-
-            initializeJDKLogManager(useParent, level, handler, formatter);
+            try {
+                initializeJDKLogManager(useParent, level, handler, formatter);
+            } finally {
+                initPending = false;
+            }
     }
 
     private void initializeJDKLogManager(boolean useParent, Level level, Handler handler, Formatter formatter) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/JDKXRLogger.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/JDKXRLogger.java
@@ -35,11 +35,11 @@ import java.util.Arrays;
  * https://github.com/danfickle/openhtmltopdf/wiki/Logging
  */
 public class JDKXRLogger implements XRLogger {
-    private boolean initPending = true;
+    private volatile boolean initPending = true;
 
     // Keep a map of Loggers so they are not garbage collected
     // which makes them lose their settings we have applied.
-    private Map<String, Logger> loggers;
+    private volatile Map<String, Logger> loggers;
 
     private final boolean useParent;
     private final Level level;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLog.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/XRLog.java
@@ -52,8 +52,8 @@ public class XRLog {
         return loggerName;
     }
 
-    private static boolean initPending = true;
-    private static XRLogger loggerImpl;
+    private static volatile boolean initPending = true;
+    private static volatile XRLogger loggerImpl;
 
     private static volatile Boolean loggingEnabled;
 

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/XRLogTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/util/XRLogTest.java
@@ -3,6 +3,8 @@ package com.openhtmltopdf.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 public class XRLogTest {
@@ -13,6 +15,32 @@ public class XRLogTest {
 		Assert.assertFalse(XRLog.isLoggingEnabled());
 		XRLog.log(Level.INFO, LogMessageId.LogMessageId0Param.LOAD_UNABLE_TO_DISABLE_XML_EXTERNAL_ENTITIES);
 		Assert.assertFalse(XRLog.isLoggingEnabled());
+	}
+
+	/**
+	 * See issue https://github.com/danfickle/openhtmltopdf/issues/646
+	 */
+	@Test
+	public void testConcurrentInitLog() throws InterruptedException {
+		int p = 20;
+		CountDownLatch latch = new CountDownLatch(p);
+		CountDownLatch end = new CountDownLatch(p);
+		AtomicInteger counter = new AtomicInteger();
+		for (int i = 0; i < p;i++) {
+			new Thread(() -> {
+				latch.countDown();
+				try {
+					latch.await();
+					XRLog.log(Level.SEVERE, LogMessageId.LogMessageId0Param.CASCADE_IS_ABSOLUTE_CSS_UNKNOWN_GIVEN);
+					counter.incrementAndGet();
+					end.countDown();
+				} catch (Throwable e) {
+					end.countDown();
+				}
+			}).start();
+		}
+		end.await();
+		Assert.assertEquals(p, counter.get()); //we expect 0 NPE -> counter = 20
 	}
 	
 }


### PR DESCRIPTION
Seems to fix the issue as generated by the test case. Not 100% sure it cover all cases.

Fix issue #646 .

To be noted, we may need to cleanup the init part of the logging...