### PR TITLE
#642 Solution for double ups of inline-blocks

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/displaylist/DisplayListPainter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/displaylist/DisplayListPainter.java
@@ -120,13 +120,15 @@ public class DisplayListPainter {
 				OperatorSetClip setClip = (OperatorSetClip) dli;
 				setClip(c, setClip);
 			} else if (dli instanceof BlockBox) {
-			    // Inline blocks need to be painted as a layer.
-			    BlockBox bb = (BlockBox) dli;
-			    List<PageBox> pageBoxes = bb.getContainingLayer().getPages();
-			    DisplayListCollector dlCollector = new DisplayListCollector(pageBoxes);
-			    DisplayListPageContainer pageInstructions = dlCollector.collectInlineBlock(c, bb, EnumSet.noneOf(CollectFlags.class), c.getShadowPageNumber());
-			
-			    paint(c, pageInstructions);
+                // Inline blocks need to be painted as a layer, if not already done so.
+                BlockBox bb = (BlockBox) dli;
+                if (!bb.getStyle().requiresLayer()) {
+                    List<PageBox> pageBoxes = bb.getContainingLayer().getPages();
+                    DisplayListCollector dlCollector = new DisplayListCollector(pageBoxes);
+                    DisplayListPageContainer pageInstructions = dlCollector.collectInlineBlock(c, bb, EnumSet.noneOf(CollectFlags.class), c.getShadowPageNumber());
+
+                    paint(c, pageInstructions);
+               }
 			} else {
                 InlinePaintable paintable = (InlinePaintable) dli;
                 Object token = c.getOutputDevice().startStructure(StructureType.INLINE, (Box) dli);

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-642-inline-blocks.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-642-inline-blocks.pdf
@@ -1,0 +1,271 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20210301225758+11'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R 5 0 R]
+/Count 2
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 112.5 375.0]
+/Parent 2 0 R
+/Contents 6 0 R
+/Resources 7 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 112.5 150.0]
+/Parent 2 0 R
+/Contents 8 0 R
+/Resources 9 0 R
+>>
+endobj
+6 0 obj
+<<
+/Length 945
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+0 375 m
+112.5 375 l
+112.5 0.03751 l
+0 0.03751 l
+0 375 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 12 Tf
+1 0 0 1 7.5 175.3875 Tm
+(EIGHT) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 7.5 206.7375 Tm
+(SPACER) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 9.75 191.0625 Tm
+(SEVEN) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 7.5 161.96249 Tm
+(NINE) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 95.25 148.53749 Tm
+( ) Tj
+ET
+q
+2 0 0 1 -56.25 0 cm
+BT
+/F1 12 Tf
+1 0 0 1 30 135.11249 Tm
+(TWELVE) Tj
+ET
+q
+-1 0 -0 -1 118.72501 251.47501 cm
+BT
+/F1 12 Tf
+1 0 0 1 30 121.68749 Tm
+(THIRTEEN) Tj
+ET
+Q
+Q
+BT
+/F1 12 Tf
+1 0 0 1 7.5 148.53749 Tm
+(TEN) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 48.5625 148.53749 Tm
+(ELEVEN) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 0.0375 364.20001 Tm
+(ONE) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 0.0375 326.70001 Tm
+(TWO ) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 30.375 326.70001 Tm
+(THREE) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 0 289.23749 Tm
+(FOUR) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 0 251.7375 Tm
+(FIVE ) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 29.7 251.7375 Tm
+(SIX) Tj
+ET
+Q
+
+endstream
+endobj
+7 0 obj
+<<
+/Font 10 0 R
+>>
+endobj
+8 0 obj
+<<
+/Length 620
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+0 0 0 rg
+BT
+/F1 12 Tf
+1 0 0 1 0 138.45 Tm
+(SIX) Tj
+ET
+q
+0.93969 0.34202 -0.34202 0.93969 50.82978 -3.27002 cm
+BT
+/F1 12 Tf
+1 0 0 1 19.35 138.45 Tm
+(TEEN) Tj
+ET
+Q
+q
+0 135 m
+112.5 135 l
+112.5 0.03749 l
+0 0.03749 l
+0 135 l
+h
+W
+n
+BT
+/F1 12 Tf
+1 0 0 1 7.5 49.2375 Tm
+(NEW PAGE) Tj
+ET
+q
+2 0 0 1 -56.25 0 cm
+BT
+/F1 12 Tf
+1 0 0 1 30 35.8125 Tm
+(FOURTEEN) Tj
+ET
+q
+-1 0 -0 -1 108.00001 52.875 cm
+BT
+/F1 12 Tf
+1 0 0 1 30 22.3875 Tm
+(FIFTEEN) Tj
+ET
+Q
+Q
+BT
+/F1 12 Tf
+1 0 0 1 0.0375 124.2 Tm
+(ONE) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 0.0375 86.7 Tm
+(TWO ) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 30.375 86.7 Tm
+(THREE) Tj
+ET
+Q
+
+endstream
+endobj
+9 0 obj
+<<
+/Font 11 0 R
+>>
+endobj
+10 0 obj
+<<
+/F1 12 0 R
+>>
+endobj
+11 0 obj
+<<
+/F1 12 0 R
+>>
+endobj
+12 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 13
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000232 00000 n
+0000000344 00000 n
+0000000456 00000 n
+0000001454 00000 n
+0000001488 00000 n
+0000002161 00000 n
+0000002195 00000 n
+0000002228 00000 n
+0000002261 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<51802187E6A0E7030BD8975A9B6865A5> <51802187E6A0E7030BD8975A9B6865A5>]
+/Size 13
+>>
+startxref
+2361
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-642-transform-inline.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/issue-642-transform-inline.pdf
@@ -1,0 +1,120 @@
+%PDF-1.4
+%цдья
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+>>
+endobj
+3 0 obj
+<<
+/CreationDate (D:20210218233005+11'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R]
+/Count 1
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 112.5 75.0]
+/Parent 2 0 R
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 360
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+0 75 m
+112.5 75 l
+112.5 0.0375 l
+0 0.0375 l
+0 75 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 12 Tf
+1 0 0 1 6 44.8125 Tm
+(T W O) Tj
+ET
+BT
+/F1 12 Tf
+1 0 0 1 6 31.3875 Tm
+(T H R E E) Tj
+ET
+q
+2 0 0 2 -21.375 -62.2875 cm
+BT
+/F1 12 Tf
+1 0 0 1 6 58.2375 Tm
+(O N E) Tj
+ET
+Q
+q
+2 0 0 2 -26.55 -22.0125 cm
+BT
+/F1 12 Tf
+1 0 0 1 6 17.9625 Tm
+(F O U R) Tj
+ET
+Q
+Q
+
+endstream
+endobj
+6 0 obj
+<<
+/Font 7 0 R
+>>
+endobj
+7 0 obj
+<<
+/F1 8 0 R
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000015 00000 n
+0000000169 00000 n
+0000000078 00000 n
+0000000226 00000 n
+0000000337 00000 n
+0000000750 00000 n
+0000000783 00000 n
+0000000814 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 3 0 R
+/ID [<91E287CE5BF291C05CCC49EAFEB13599> <91E287CE5BF291C05CCC49EAFEB13599>]
+/Size 9
+>>
+startxref
+913
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-642-inline-blocks.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-642-inline-blocks.html
@@ -1,0 +1,56 @@
+<html>
+<head>
+<style>
+@page {
+  size: 150px 200px;
+  margin: 0;
+  margin-top: 20px;
+
+  @top-left {
+    content: element(runner);
+  }
+}
+@page:first {
+  size: 150px 500px;
+  @top-left {
+    content: none;
+  }
+  margin-top: 0;
+}
+body {
+  margin: 10px;
+  max-width: 130px;
+}
+</style>
+</head>
+<body>
+<!-- inline block running element -->
+<div style="display: inline-block; position: running(runner);">
+SIX<span style="display: inline-block; transform: rotate(-20deg);">TEEN</span>
+</div>
+<!-- fixed inline block -->
+<div style="position:fixed;top:0;left:0;display:inline-block;">ONE</div>
+<!-- inline block inside fixed -->
+<div style="position:fixed;top:50px;left:0;">TWO <span style="display:inline-block;">THREE</span></div>
+<!-- absolute inline block -->
+<div style="position:absolute;top:100px;left:0;display:inline-block;">FOUR</div>
+<!-- inline block inside absolute -->
+<div style="position:absolute;top:150px;left:0;">FIVE <span style="display:inline-block;">SIX</span></div>
+<div></div>
+<div style="margin-top: 200px;">SPACER</div>
+<!-- inline block inside table -->
+<table><tr><td><span style="display: inline-block;">SEVEN</span></td></tr></table>
+<!-- floating inline block -->
+<span style="display: inline-block;float: left;">EIGHT</span>
+<!-- cleared inline block -->
+<span style="display: block; clear: both;"><span style="display: inline-block;">NINE</span></span>
+<!-- absolute inside inline block -->
+<span style="display: inline-block; position: relative; width: 90%;">TEN <div style="position: absolute; top: 0; right: 0;">ELEVEN</div></span>
+<!-- transformed inline block inside transformed inline block -->
+<span style="display: inline-block; transform: scale(2, 1); margin-left: 30px;">TWELVE<span style="display: inline-block; transform: rotate(180deg);">THIRTEEN</span></span>
+<div style="page-break-before: always; margin-top: 100px;">NEW PAGE</div>
+<!-- inline block on new page -->
+<span style="display: inline-block; transform: scale(2, 1); margin-left: 30px;">FOURTEEN<span style="display: inline-block; transform: rotate(180deg);">FIFTEEN</span></span>
+
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-642-transform-inline.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/issue-642-transform-inline.html
@@ -9,5 +9,8 @@
 </head>
 <body>
 <div><span style="transform: scale(2, 2); display: inline-block;">O N E</span></div>
+<div><span style="display: inline-block;">T W O</span></div>
+<div> <span style="display: inline-block;">T H R E E</span> </div>
+<div> <span style="transform: scale(2, 2); display: inline-block;">F O U R</span> </div>
 </body>
 </html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/RepeatContentRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/RepeatContentRegressionTest.java
@@ -1,0 +1,203 @@
+package com.openhtmltopdf.nonvisualregressiontests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.pdfbox.io.IOUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.util.Charsets;
+import org.junit.Test;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.testcases.TestcaseRunner;
+import com.openhtmltopdf.visualtest.VisualTester.BuilderConfig;
+
+public class RepeatContentRegressionTest {
+    private static final String RES_PATH = "/repeated-content-tests/";
+    private static final String OUT_PATH = "target/test/visual-tests/test-output/";
+
+    interface StringMatcher {
+        List<String> problems(String expected, String actual);
+        void doAssert(String expected, String actual, String fileName, List<String> problems);
+    }
+
+    /**
+     * Simple tests with content all in one layer
+     * (ie. no z-index, absolute, relative, fixed, transform)
+     * should generally use an ordered matcher.
+     */
+    private static class OrderedMatcher implements StringMatcher {
+        public List<String> problems(String expected, String actual) {
+            if (!expected.equals(actual)) {
+                return Collections.singletonList("Mismatched ordered");
+            }
+
+            return Collections.emptyList();
+        }
+
+        public void doAssert(String expected, String actual, String fileName, List<String> problems) {
+            assertEquals("Mismatched: " + fileName, expected, actual);
+        }
+    }
+
+    /**
+     * Layers have to follow a specific painting order so they may be out of order.
+     */
+    private static class UnOrderedMatcher implements StringMatcher {
+        public List<String> problems(String expected, String actual) {
+            String[] expWords = expected.split("\\s");
+            String[] actWords = actual.split("\\s");
+
+            Predicate<String> filter = w -> !w.trim().isEmpty();
+
+            Set<String> exp = Arrays.stream(expWords)
+                                    .filter(filter)
+                                    .collect(Collectors.toSet());
+
+            List<String> act = Arrays.stream(actWords)
+                                     .filter(filter)
+                                     .collect(Collectors.toList());
+
+            Set<String> seen = new HashSet<>();
+
+            List<String> problems = new ArrayList<>();
+
+            for (String word : act) {
+                if (seen.contains(word)) {
+                    problems.add("Repeat content: " + word);
+                }
+
+                seen.add(word);
+
+                if (!exp.contains(word)) {
+                    problems.add("Unexpected content: " + word);
+                }
+            }
+
+            for (String word : exp) {
+                if (!act.contains(word)) {
+                    problems.add("Missing: " + word);
+                }
+            }
+
+            return problems;
+        }
+
+        public void doAssert(String expected, String actual, String fileName, List<String> problems) {
+            fail(problems.stream().collect(Collectors.joining("\n")));
+        }
+    }
+
+    private static final StringMatcher ORDERED = new OrderedMatcher();
+    private static final StringMatcher UNORDERED = new UnOrderedMatcher();
+
+    private static void render(String fileName, String html, BuilderConfig config, String proof, StringMatcher matcher) throws IOException {
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, NonVisualRegressionTest.class.getResource(RES_PATH).toString());
+        builder.toStream(actual);
+        builder.useFastMode();
+        builder.testMode(true);
+        config.configure(builder);
+
+        try {
+            builder.run();
+        } catch (IOException e) {
+            System.err.println("Failed to render resource (" + fileName + ")");
+            e.printStackTrace();
+            throw e;
+        }
+
+        byte[] pdfBytes = actual.toByteArray();
+
+        try (PDDocument doc = PDDocument.load(pdfBytes)) {
+            PDFTextStripper stripper = new PDFTextStripper();
+            stripper.setSuppressDuplicateOverlappingText(false);
+            stripper.setLineSeparator("\n");
+
+            String text = stripper.getText(doc).trim();
+            String expected = proof.trim().replace("\r\n", "\n");
+
+            List<String> problems = matcher.problems(expected, text);
+
+            if (!problems.isEmpty()) {
+                FileUtils.writeByteArrayToFile(new File(OUT_PATH, fileName + ".pdf"), pdfBytes);
+
+                matcher.doAssert(expected, text, fileName, problems);
+            }
+        }
+    }
+
+    private static void run(String fileName, BuilderConfig config, StringMatcher matcher) throws IOException {
+        String absResPath = RES_PATH + fileName + ".html";
+
+        try (InputStream is = TestcaseRunner.class.getResourceAsStream(absResPath)) {
+            byte[] htmlBytes = IOUtils.toByteArray(is);
+            String htmlWithProof = new String(htmlBytes, Charsets.UTF_8);
+
+            String[] parts = htmlWithProof.split(Pattern.quote("======="));
+            String html = parts[0];
+            String proof = parts[1];
+
+            render(fileName, html, config, proof, matcher);
+        }
+    }
+
+    private static void runOrdered(String fileName) throws IOException {
+        run(fileName, builder -> { }, ORDERED);
+    }
+
+    private static void runUnOrdered(String fileName) throws IOException {
+        run(fileName, builder -> { }, UNORDERED);
+    }
+
+    /**
+     * inline-blocks/relative/absolute with z-index.
+     */
+    @Test
+    public void testInlineBlockZIndex() throws IOException {
+        runOrdered("inline-block-z-index");
+    }
+
+    /**
+     * Multiple in-flow inline-blocks on the one page. 
+     */
+    @Test
+    public void testInlineBlockMultiple() throws IOException {
+        runUnOrdered("inline-block-multiple");
+    }
+
+    /**
+     * Multiple in-flow inline-blocks across pages with large page margin.
+     */
+    @Test
+    public void testInlineBlockPages() throws IOException {
+        runUnOrdered("inline-block-pages");
+    }
+
+    /**
+     * Float that goes over two pages.
+     */
+    @Test
+    public void testFloatsPages() throws IOException {
+        runUnOrdered("floats-pages");
+    }
+
+}

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1367,10 +1367,10 @@ public class VisualRegressionTest {
     /**
      * Transforms on inline-block or inline elements output twice,
      * once as the non-transformed output and once as transformed.
+     * Also affected inline-blocks with a z-index.
      * https://github.com/danfickle/openhtmltopdf/issues/642
      */
     @Test
-    @Ignore // Not debugged yet.
     public void testIssue642TransformInline() throws IOException {
         assertTrue(vt.runTest("issue-642-transform-inline"));
     }

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1376,6 +1376,15 @@ public class VisualRegressionTest {
     }
 
     /**
+     * Combinations of inline-blocks with other display and positioned
+     * content.
+     */
+    @Test
+    public void testIssue642InlineBlocks() throws IOException {
+        assertTrue(vt.runTest("issue-642-inline-blocks"));
+    }
+
+    /**
      * Tests that the background-image property allows multiple values.
      */
     @Test

--- a/openhtmltopdf-examples/src/test/resources/repeated-content-tests/floats-pages.html
+++ b/openhtmltopdf-examples/src/test/resources/repeated-content-tests/floats-pages.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+<style>
+@page {
+  size: 180px 100px;
+  margin: 20px;
+}
+body {
+  font-size: 14px;
+  margin: 0;
+}
+.flt-l {
+  float: left;
+  border: 1px solid red;
+  margin: 3px;
+}
+.flt-r {
+  float: right;
+  border: 1px solid green;
+  width: 60%;
+}
+</style>
+</head>
+<body>
+<div class="flt-l">one two three</div>
+four five six seven eleven
+<div class="flt-r">eight nine ten sixteen seventeen eighteen</div>
+ twelve thirteen fourteen
+fifteen
+</body>
+</html>
+=======
+one
+two
+three
+four
+five
+six
+seven
+eight
+nine
+ten
+eleven
+twelve
+thirteen
+fourteen
+fifteen
+sixteen
+seventeen
+eighteen

--- a/openhtmltopdf-examples/src/test/resources/repeated-content-tests/inline-block-multiple.html
+++ b/openhtmltopdf-examples/src/test/resources/repeated-content-tests/inline-block-multiple.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+<style>
+span {
+  display: inline-block;
+}
+</style>
+</head>
+<body>
+<div><span>one</span></div>
+<div> <span>two</span> </div>
+<span>three</span>
+<span>four</span>
+<div><span>five</span> <span>six</span></div>
+<div> seven <span>eight</span> nine <span>ten</span></div>
+</body>
+</html>
+=======
+one
+two
+three
+four
+five
+six
+seven
+eight
+nine
+ten

--- a/openhtmltopdf-examples/src/test/resources/repeated-content-tests/inline-block-pages.html
+++ b/openhtmltopdf-examples/src/test/resources/repeated-content-tests/inline-block-pages.html
@@ -1,0 +1,36 @@
+<html>
+<head>
+<style>
+@page {
+  size: 100px 100px;
+  margin: 20px;
+}
+body {
+  font-size: 9px;
+  margin: 0;
+}
+span {
+  display: inline-block;
+}
+</style>
+</head>
+<body>
+<div><span>one</span></div>
+<div> <span>two</span> </div>
+<span>three</span>
+<span>four</span>
+<div><span>five</span> <span>six</span></div>
+<div> seven <span>eight</span> nine <span>ten</span></div>
+</body>
+</html>
+=======
+one
+two
+three
+four
+five
+six
+seven
+eight
+nine
+ten

--- a/openhtmltopdf-examples/src/test/resources/repeated-content-tests/inline-block-z-index.html
+++ b/openhtmltopdf-examples/src/test/resources/repeated-content-tests/inline-block-z-index.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<style>
+span {
+  display: inline-block;
+}
+</style>
+</head>
+<body>
+<div><span style="position: relative; z-index: 100;">one</span></div>
+<div> <span style="position: relative; z-index: 101;">two</span> </div>
+<span style="position: relative; z-index: 102;">three</span>
+<span style="position: absolute; z-index: 103; top: 100px;">four</span>
+</body>
+</html>
+=======
+one
+two
+three
+four


### PR DESCRIPTION
This is a fix for #642 which was that `inline-block` boxes with a layer (such as `z-index` or `transform`) were being output twice.

While issue is fixed, I have created this PR to add more tests for:
+ [x] Inline blocks.
+ [x] Doubled up content.