### PR TITLE
Upgrade  Batik Version  to 1.14 (CVE-2020-11987)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <open.bundle.plugin.version>5.1.1</open.bundle.plugin.version>
     <open.jar.plugin.version>3.2.0</open.jar.plugin.version>
 
-    <open.batik.version>1.13</open.batik.version>
+    <open.batik.version>1.14</open.batik.version>
     <open.junit4.version>4.13.1</open.junit4.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Details see here https://xmlgraphics.apache.org/security.html and https://nvd.nist.gov/vuln/detail/CVE-2020-11987

I don't think that this is super urgent.  But should be upgraded anyway