### PR TITLE
Existing pdf PDDocumentInformation should not be removed

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -873,23 +873,25 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
 
     // Sets the document information dictionary values from html metadata
     private void setDidValues(PDDocument doc) {
-        PDDocumentInformation info = new PDDocumentInformation();
+        if(doc.getDocumentInformation() == null) {
+            doc.setDocumentInformation(new PDDocumentInformation());
+        }
+        final PDDocumentInformation info = doc.getDocumentInformation();
 
-        info.setCreationDate(Calendar.getInstance());
-
-        if (_producer == null) {
-            info.setProducer("openhtmltopdf.com");
-        } else {
-            info.setProducer(_producer);
+        if(info.getCreationDate() == null) {
+            info.setCreationDate(Calendar.getInstance());
+        }
+        if(info.getProducer() == null) {
+            info.setProducer(_producer == null ? "openhtmltopdf.com": _producer);
         }
 
         for (Metadata metadata : _outputDevice.getMetadata()) {
-        	String name = metadata.getName();
-			if (name.isEmpty())
-				continue;
-        	String content = metadata.getContent();
-        	if( content == null )
-        	    continue;
+            String name = metadata.getName();
+            if (name.isEmpty())
+                continue;
+            String content = metadata.getContent();
+            if( content == null )
+                continue;
             if( name.equals("title"))
                 info.setTitle(content);
             else if( name.equals("author"))
@@ -901,8 +903,6 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
             else
                 info.setCustomMetadataValue(name,content);
         }
-
-        doc.setDocumentInformation(info);
     }
     
     private void paintPageFast(RenderingContext c, PageBox page, DisplayListPageContainer pageOperations, int additionalTranslateX) {


### PR DESCRIPTION
Motivation:

The method PdfRendererBuilder#usePDDocument(PDDocument) allow the user to provided an existing document. During the process, the information contains in PDDocumentInformation are removed.

Modification:
* Methods PdfBoxRenderer#setDidValues(PDDocument) add only missing information