### PR TITLE
[#683] Font reuse and override introduced to support multiple runs against the same target PDF document

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
@@ -2,6 +2,7 @@ package com.openhtmltopdf.outputdevice.helper;
 
 import com.openhtmltopdf.bidi.BidiReorderer;
 import com.openhtmltopdf.bidi.BidiSplitterFactory;
+import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.extend.*;
 import com.openhtmltopdf.layout.Layer;
 import com.openhtmltopdf.swing.NaiveUserAgent;
@@ -634,9 +635,22 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 		MM, INCHES
 	}
 
-	public enum FontStyle {
-		NORMAL, ITALIC, OBLIQUE
-	}
+    public enum FontStyle {
+        NORMAL, ITALIC, OBLIQUE;
+
+        public IdentValue toIdentValue() {
+            switch (this) {
+            case NORMAL:
+                return IdentValue.NORMAL;
+            case ITALIC:
+                return IdentValue.ITALIC;
+            case OBLIQUE:
+                return IdentValue.OBLIQUE;
+            default:
+                return null;
+            }
+        }
+    }
 
     /**
      * Use cases for fonts.

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFamily.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFamily.java
@@ -24,7 +24,10 @@ public class FontFamily<T extends MinimalFontDescription> {
     }
 
     public void addFontDescription(T descr) {
-        _fontDescriptions.add(descr);
+        /*
+         * NOTE: Font is prepended, so newer fonts can override predecessors.
+         */
+        _fontDescriptions.add(0, descr);
         Collections.sort(_fontDescriptions, Comparator.comparing(T::getWeight));
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -19,6 +19,23 @@
  */
 package com.openhtmltopdf.pdfboxout;
 
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.apache.fontbox.ttf.TrueTypeCollection;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
+
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.css.sheet.FontFaceRule;
@@ -40,19 +57,6 @@ import com.openhtmltopdf.render.FSFont;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
-import org.apache.fontbox.ttf.TrueTypeCollection;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.font.PDFont;
-import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
-import org.apache.pdfbox.pdmodel.font.PDType0Font;
-
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
-import java.util.logging.Level;
-
 /**
  * This class handles all font resolving for the PDF generation.
  */
@@ -69,12 +73,12 @@ public class PdfBoxFontResolver implements FontResolver {
     private final AbstractFontStore _builtinFonts;
     private final FallbackFontStore _finalFallbackFonts;
 
-    public PdfBoxFontResolver(SharedContext sharedContext, PDDocument doc, FSCacheEx<String, FSCacheValue> pdfMetricsCache, PdfAConformance pdfAConformance, boolean pdfUaConform) {
+    public PdfBoxFontResolver(SharedContext sharedContext, PDDocument doc, FontCache fontCache, FSCacheEx<String, FSCacheValue> pdfMetricsCache, PdfAConformance pdfAConformance, boolean pdfUaConform) {
         this._doc = doc;
 
-        this._suppliedFonts = new MainFontStore(sharedContext, doc, pdfMetricsCache);
+        this._suppliedFonts = new MainFontStore(sharedContext, doc, pdfMetricsCache, fontCache);
 
-        this._preBuiltinFallbackFonts = new FallbackFontStore(sharedContext, doc, pdfMetricsCache);
+        this._preBuiltinFallbackFonts = new FallbackFontStore(sharedContext, doc, pdfMetricsCache, fontCache);
 
         // All fonts are required to be embedded in PDF/A documents, so we don't add
         // the built-in fonts, if conformance is required.
@@ -82,7 +86,7 @@ public class PdfBoxFontResolver implements FontResolver {
                 new AbstractFontStore.BuiltinFontStore(doc) :
                 new AbstractFontStore.EmptyFontStore();
 
-        this._finalFallbackFonts = new FallbackFontStore(sharedContext, doc, pdfMetricsCache);
+        this._finalFallbackFonts = new FallbackFontStore(sharedContext, doc, pdfMetricsCache, fontCache);
     }
 
     @Override
@@ -98,6 +102,10 @@ public class PdfBoxFontResolver implements FontResolver {
         FontUtil.tryClose(this._suppliedFonts);
         FontUtil.tryClose(this._preBuiltinFallbackFonts);
         FontUtil.tryClose(this._finalFallbackFonts);
+    }
+
+    public Map<String, PDFont> getFontCache() {
+        return _suppliedFonts.getFontCache();
     }
 
     public void importFontFaces(List<FontFaceRule> fontFaces) {
@@ -491,6 +499,50 @@ public class PdfBoxFontResolver implements FontResolver {
     }
 */
 
+    public static class FontCache extends HashMap<String, PDFont> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean containsKey(Object family) {
+            return containsKey((String)family, null, null);
+        }
+
+        public boolean containsKey(String family, Integer weight, IdentValue style) {
+            return super.containsKey(key(family, weight, style));
+        }
+
+        @Override
+        public PDFont get(Object family) {
+            return get((String)family, null, null);
+        }
+
+        public PDFont get(String family, Integer weight, IdentValue style) {
+            return super.get(key(family, weight, style));
+        }
+
+        @Override
+        public PDFont put(String family, PDFont value) {
+            return put(family, null, null, value);
+        }
+
+        public PDFont put(String family, Integer weight, IdentValue style, PDFont value) {
+            return super.put(key(family, weight, style), value);
+        }
+
+        @Override
+        public PDFont remove(Object family) {
+            return remove((String)family, null, null);
+        }
+
+        public PDFont remove(String family, Integer weight, IdentValue style) {
+            return super.remove(key(family, weight, style));
+        }
+
+        protected String key(String family, Integer weight, IdentValue style) {
+            return FontUtil.getFontFQName(family, weight, style);
+        }
+    }
+
     /**
      * A <code>FontDescription</code> can exist in multiple states. Firstly the font may
      * or may not be realized. Fonts are automatically realized upon calling {@link #getFont()}
@@ -513,6 +565,7 @@ public class PdfBoxFontResolver implements FontResolver {
 
         private PdfBoxRawPDFontMetrics _metrics;
         private final FSCacheEx<String, FSCacheValue> _metricsCache;
+        private FontCache _fontCache;
 
         /**
          * Create a font description from one of the PDF built-in fonts.
@@ -530,7 +583,9 @@ public class PdfBoxFontResolver implements FontResolver {
                 PDDocument doc, FSSupplier<InputStream> supplier,
                 int weight, IdentValue style, String family,
                 boolean isFromFontFace, boolean isSubset,
-                FSCacheEx<String, FSCacheValue> metricsCache) {
+                FSCacheEx<String, FSCacheValue> metricsCache,
+                FontCache fontCache) {
+            this._fontSupplier = null;
             this._supplier = supplier;
             this._weight = weight;
             this._style = style;
@@ -540,6 +595,7 @@ public class PdfBoxFontResolver implements FontResolver {
             this._isSubset = isSubset;
             this._metricsCache = metricsCache;
             this._metrics = getFontMetricsFromCache(family, weight, style);
+            this._fontCache = fontCache;
         }
 
         /**
@@ -547,12 +603,14 @@ public class PdfBoxFontResolver implements FontResolver {
          * Currently only used for PDF built-in fonts.
          */
         private FontDescription(PDDocument doc, PDFont font, IdentValue style, int weight) {
+            _fontSupplier = null;
             _font = font;
             _style = style;
             _weight = weight;
             _supplier = null;
             _doc = doc;
             _metricsCache = null;
+            _fontCache = null;
             _family = null;
             _isFromFontFace = false;
             _isSubset = false;
@@ -573,7 +631,8 @@ public class PdfBoxFontResolver implements FontResolver {
                 PDDocument doc, FSSupplier<PDFont> fontSupplier,
                 IdentValue style, int weight, String family, 
                 boolean isFromFontFace, boolean isSubset,
-                FSCacheEx<String, FSCacheValue> metricsCache) {
+                FSCacheEx<String, FSCacheValue> metricsCache,
+                FontCache fontCache) {
             _fontSupplier = fontSupplier;
             _style = style;
             _weight = weight;
@@ -584,6 +643,7 @@ public class PdfBoxFontResolver implements FontResolver {
             _isSubset = isSubset;
             _metricsCache = metricsCache;
             _metrics = getFontMetricsFromCache(family, weight, style);
+            _fontCache = fontCache;
         }
 
         public String getFamily() {
@@ -614,45 +674,67 @@ public class PdfBoxFontResolver implements FontResolver {
             }
         }
 
+        /**
+         * Resolves the font corresponding to this descriptor.
+         * 
+         * @return Whether the font exists.
+         */
         public boolean realizeFont() {
-            if (_font == null && _fontSupplier != null) {
-                XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_LOADING_FONT_FROM_SUPPLIER, _family, "PDFont");
-
-                _font = _fontSupplier.supply();
-		_fontSupplier = null;
-		
-                if (!isMetricsAvailable()) {
-                    // If we already have metrics, they must have come from the cache.
-                    return loadMetrics();
-                }
-	    }
-            
-            if (_font == null && _supplier != null) {
-                XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_LOADING_FONT_FROM_SUPPLIER, _family, "InputStream");
-
-                InputStream is = _supplier.supply();
-                _supplier = null; // We only try once.
-                
-                if (is == null) {
-                    return false;
-                }
-                
-                try {
-                    _font = PDType0Font.load(_doc, is, _isSubset);
-                    
-                    if (!isMetricsAvailable()) {
-                        return loadMetrics();
+            if (_font == null) {
+                if (_fontCache != null) {
+                    // Font cache match?
+                    if ((_font = _fontCache.get(_family, _weight, _style)) != null) {
+                        // Dropping useless suppliers...
+                        _fontCache = null;
+                        _fontSupplier = null;
+                        _supplier = null;
                     }
-                } catch (IOException e) {
-                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, _family);
-                    return false;
-                } finally {
-                    try {
-                        is.close();
-                    } catch (IOException e) { }
+                }
+
+                /*
+                 * NOTE: _fontSupplier and _supplier are mutually exclusive.
+                 */
+                if (_fontSupplier != null) {
+                    XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_LOADING_FONT_FROM_SUPPLIER, _family, "PDFont");
+
+                    _font = _fontSupplier.supply();
+                    _fontSupplier = null /* Only tried once */;
+                } else if (_supplier != null) {
+                    XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_LOADING_FONT_FROM_SUPPLIER, _family, "InputStream");
+
+                    try (InputStream is = _supplier.supply()) {
+                        _supplier = null /* Only tried once */;
+
+                        if (is != null) {
+                            try {
+                                _font = PDType0Font.load(_doc, is, _isSubset);
+                            } catch (IOException e) {
+                                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_FONT, _family);
+                            }
+                        }
+                    } catch (IOException e) {
+                        /* TODO: log failed close()? */
+                    }
+                }
+
+                if (_font != null) {
+                    if (_fontCache != null) {
+                        _fontCache.put(_family, _weight, _style, _font);
+                        _fontCache = null /* Only used once */;
+                    }
+
+                    if (!isMetricsAvailable()) {
+                        /*
+                         * TODO: The old implementation returned loadMetrics() result just one time,
+                         * thus violating the idempotence of this method, as subsequent calls didn't
+                         * return it again. Now the idempotence is honored, but we have to verify
+                         * whether any weak side effect (relying on the old wrong behavior) is
+                         * disrupted (although, according to my tests, it seems to work flawlessly).
+                         */
+                        loadMetrics();
+                    }
                 }
             }
-            
             return _font != null;
         }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFontResolver.java
@@ -73,7 +73,7 @@ public class PdfBoxFontResolver implements FontResolver {
     private final AbstractFontStore _builtinFonts;
     private final FallbackFontStore _finalFallbackFonts;
 
-    public PdfBoxFontResolver(SharedContext sharedContext, PDDocument doc, FontCache fontCache, FSCacheEx<String, FSCacheValue> pdfMetricsCache, PdfAConformance pdfAConformance, boolean pdfUaConform) {
+    public PdfBoxFontResolver(SharedContext sharedContext, PDDocument doc, FSCacheEx<String, FSCacheValue> pdfMetricsCache, FontCache fontCache, PdfAConformance pdfAConformance, boolean pdfUaConform) {
         this._doc = doc;
 
         this._suppliedFonts = new MainFontStore(sharedContext, doc, pdfMetricsCache, fontCache);
@@ -539,7 +539,7 @@ public class PdfBoxFontResolver implements FontResolver {
         }
 
         protected String key(String family, Integer weight, IdentValue style) {
-            return FontUtil.getFontFQName(family, weight, style);
+            return FontUtil.getFontQName(family, weight, style);
         }
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -201,7 +201,7 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
         userAgent.setSharedContext(_sharedContext);
         _outputDevice.setSharedContext(_sharedContext);
 
-        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc, state._fontCache, state._caches.get(CacheStore.PDF_FONT_METRICS), state._pdfAConformance, state._pdfUaConform);
+        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc, state._caches.get(CacheStore.PDF_FONT_METRICS), state._fontCache, state._pdfAConformance, state._pdfUaConform);
         _sharedContext.setFontResolver(fontResolver);
 
         PdfBoxReplacedElementFactory replacedElementFactory = new PdfBoxReplacedElementFactory(_outputDevice, state._svgImpl, state._objectDrawerFactory, state._mathmlImpl);
@@ -274,9 +274,9 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
     }
 
     /**
-     * Creates a new renderer builder inheriting this configuration.
+     * Creates a new builder inheriting this configuration.
      */
-    public PdfRendererBuilder createBuilder() {
+    public PdfRendererBuilder toBuilder() {
         PdfRendererBuilderState newState = state.clone();
         /*
          * NOTE: Old input references are cleared to ensure a clean new run.

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -139,11 +139,14 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
 
     private final Closeable diagnosticConsumer;
     
+    private PdfRendererBuilderState state;
+
     /**
      * This method is constantly changing as options are added to the builder.
      */
     PdfBoxRenderer(BaseDocument doc, UnicodeImplementation unicode,
             PageDimensions pageSize, PdfRendererBuilderState state, Closeable diagnosticConsumer) {
+        this.state = state;
 
         this.diagnosticConsumer = diagnosticConsumer;
 
@@ -198,7 +201,7 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
         userAgent.setSharedContext(_sharedContext);
         _outputDevice.setSharedContext(_sharedContext);
 
-        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc, state._caches.get(CacheStore.PDF_FONT_METRICS), state._pdfAConformance, state._pdfUaConform);
+        PdfBoxFontResolver fontResolver = new PdfBoxFontResolver(_sharedContext, _pdfDoc, state._fontCache, state._caches.get(CacheStore.PDF_FONT_METRICS), state._pdfAConformance, state._pdfUaConform);
         _sharedContext.setFontResolver(fontResolver);
 
         PdfBoxReplacedElementFactory replacedElementFactory = new PdfBoxReplacedElementFactory(_outputDevice, state._svgImpl, state._objectDrawerFactory, state._mathmlImpl);
@@ -268,6 +271,20 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
         }
         
         this._os = state._os;
+    }
+
+    /**
+     * Creates a new renderer builder inheriting this configuration.
+     */
+    public PdfRendererBuilder createBuilder() {
+        PdfRendererBuilderState newState = state.clone();
+        /*
+         * NOTE: Old input references are cleared to ensure a clean new run.
+         */
+        newState._document = null;
+        newState._file = null;
+        newState._html = null;
+        return new PdfRendererBuilder(newState);
     }
 
     public Document getDocument() {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -29,7 +29,7 @@ import com.openhtmltopdf.util.XRLog;
 
 public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, PdfRendererBuilderState> {
     public PdfRendererBuilder() {
-        super(new PdfRendererBuilderState());
+        this(new PdfRendererBuilderState());
     }
 
 	protected PdfRendererBuilder(PdfRendererBuilderState state) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -1,32 +1,40 @@
 package com.openhtmltopdf.pdfboxout;
 
+import java.awt.FontFormatException;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+
 import com.openhtmltopdf.css.constants.IdentValue;
-import com.openhtmltopdf.extend.*;
+import com.openhtmltopdf.extend.FSCacheEx;
+import com.openhtmltopdf.extend.FSCacheValue;
+import com.openhtmltopdf.extend.FSDOMMutator;
+import com.openhtmltopdf.extend.FSSupplier;
 import com.openhtmltopdf.extend.impl.FSNoOpCacheStore;
 import com.openhtmltopdf.outputdevice.helper.AddedFont;
 import com.openhtmltopdf.outputdevice.helper.BaseDocument;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
 import com.openhtmltopdf.outputdevice.helper.PageDimensions;
 import com.openhtmltopdf.outputdevice.helper.UnicodeImplementation;
+import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontCache;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontGroup;
-import com.openhtmltopdf.render.FSFont;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
-
-import java.awt.FontFormatException;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.EnumSet;
-import java.util.logging.Level;
-
 public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, PdfRendererBuilderState> {
+    public PdfRendererBuilder() {
+        super(new PdfRendererBuilderState());
+    }
 
-	public PdfRendererBuilder() {
-		super(new PdfRendererBuilderState());
-		
+	protected PdfRendererBuilder(PdfRendererBuilderState state) {
+		super(state);
+
 		for (CacheStore cacheStore : CacheStore.values()) {
 		    // Use the flyweight pattern to initialize all caches with a no-op implementation to
 		    // avoid excessive null handling.
@@ -58,6 +66,10 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	}
 
 	public PdfBoxRenderer buildPdfRenderer(Closeable diagnosticConsumer) {
+	    if (state._fontCache == null) {
+	        state._fontCache = new FontCache();
+	    }
+
 		UnicodeImplementation unicode = new UnicodeImplementation(state._reorderer, state._splitter, state._lineBreaker,
 				state._unicodeToLowerTransformer, state._unicodeToUpperTransformer, state._unicodeToTitleTransformer, state._textDirection,
 				state._charBreaker);
@@ -98,25 +110,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
             if (font.usedFor.contains(FSFontUseCase.DOCUMENT) ||
                 font.usedFor.contains(FSFontUseCase.FALLBACK_PRE) ||
                 font.usedFor.contains(FSFontUseCase.FALLBACK_FINAL)) {
-                IdentValue fontStyle = null;
-
-				if (font.style != null) {
-					switch (font.style)
-					{
-					case NORMAL:
-						fontStyle = IdentValue.NORMAL;
-						break;
-					case ITALIC:
-						fontStyle = IdentValue.ITALIC;
-						break;
-					case OBLIQUE:
-						fontStyle = IdentValue.OBLIQUE;
-						break;
-					default:
-						fontStyle = null;
-						break;
-					}
-				}
+                IdentValue fontStyle = font.style != null ? font.style.toIdentValue() : null;
 
                 FontGroup group;
                 if (font.usedFor.contains(FSFontUseCase.FALLBACK_PRE)) {
@@ -147,6 +141,38 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
         }
 
         return renderer;
+    }
+
+    public boolean dropDOMMutator(FSDOMMutator domMutator) {
+        return state._domMutators.remove(domMutator);
+    }
+
+    public void dropDOMMutators() {
+        state._domMutators.clear();
+    }
+
+    public boolean dropFont(String fontFamily) {
+        return dropFont(fontFamily, null, null);
+    }
+
+    public boolean dropFont(String fontFamily, Integer fontWeight, FontStyle fontStyle) {
+        boolean dropped = false;
+        for (Iterator<AddedFont> it = state._fonts.iterator(); it.hasNext();) {
+            AddedFont font = it.next();
+            if (font.family.equals(fontFamily)
+                    && (fontWeight == null || fontWeight.equals(font.weight))
+                    && (fontStyle == null || fontStyle.equals(font.style))) {
+                it.remove();
+                state._fontCache.remove(font.family, font.weight,
+                        font.style != null ? font.style.toIdentValue() : null);
+                dropped = true;
+            }
+        }
+        return dropped;
+    }
+
+    public List<AddedFont> getFonts() {
+        return state._fonts;
     }
 
 	/**
@@ -279,6 +305,11 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	    state._caches.put(which, cache);
 	    return this;
 	}
+
+    public PdfRendererBuilder useFontCache(FontCache fontCache) {
+        state._fontCache = fontCache;
+        return this;
+    }
 
 	/**
 	 * Set a PageSupplier that is called whenever a new page is needed.

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilderState.java
@@ -1,21 +1,22 @@
 package com.openhtmltopdf.pdfboxout;
 
-import com.openhtmltopdf.extend.FSCacheEx;
-import com.openhtmltopdf.extend.FSCacheValue;
-import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
-import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.CacheStore;
-import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.PdfAConformance;
-
-import org.apache.pdfbox.pdmodel.PDDocument;
-
 import java.io.OutputStream;
 import java.util.EnumMap;
 import java.util.Map;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+import com.openhtmltopdf.extend.FSCacheEx;
+import com.openhtmltopdf.extend.FSCacheValue;
+import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
+import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontCache;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.CacheStore;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder.PdfAConformance;
+
 /**
  * This class is internal. DO NOT USE! Just ignore it!
  */
-public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState {
+public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBuilderState implements Cloneable {
 	/* Internal! */
 	PdfRendererBuilderState() {
 	}
@@ -29,4 +30,14 @@ public class PdfRendererBuilderState extends BaseRendererBuilder.BaseRendererBui
 	public boolean _pdfUaConform = false;
 	public byte[] _colorProfile;
 	public PageSupplier _pageSupplier;
+	public FontCache _fontCache;
+
+	@Override
+	protected PdfRendererBuilderState clone() {
+	    try {
+            return (PdfRendererBuilderState) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+	}
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FallbackFontStore.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FallbackFontStore.java
@@ -10,8 +10,8 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.fontbox.ttf.TrueTypeCollection;
-import org.apache.fontbox.ttf.TrueTypeFont;
 import org.apache.fontbox.ttf.TrueTypeCollection.TrueTypeFontProcessor;
+import org.apache.fontbox.ttf.TrueTypeFont;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
@@ -23,20 +23,24 @@ import com.openhtmltopdf.extend.FSSupplier;
 import com.openhtmltopdf.layout.SharedContext;
 import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 import com.openhtmltopdf.pdfboxout.PDFontSupplier;
+import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontCache;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription;
 
 public class FallbackFontStore implements Closeable {
     private final List<FontDescription> fonts = new ArrayList<>();
     private final List<TrueTypeCollection> _collectionsToClose = new ArrayList<>();
     private final PDDocument _doc;
+    private final FontCache _fontCache;
     private final FSCacheEx<String, FSCacheValue> _fontMetricsCache;
 
     public FallbackFontStore(
             SharedContext sharedContext,
             PDDocument doc,
-            FSCacheEx<String, FSCacheValue> pdfMetricsCache) {
+            FSCacheEx<String, FSCacheValue> pdfMetricsCache,
+            FontCache fontCache) {
         this._doc = doc;
         this._fontMetricsCache = pdfMetricsCache;
+        this._fontCache = fontCache;
     }
 
     private int getFontPriority(FontDescription font, String[] families, IdentValue weight, IdentValue desiredStyle, IdentValue variant) {
@@ -106,7 +110,8 @@ public class FallbackFontStore implements Closeable {
                 fontFamilyNameOverride,
                 false, // isFromFontFace
                 subset,
-                _fontMetricsCache);
+                _fontMetricsCache,
+                _fontCache);
 
         addFont(subset, descr);
     }
@@ -126,7 +131,8 @@ public class FallbackFontStore implements Closeable {
                 fontFamilyNameOverride,
                 false, // isFromFontFace
                 subset,
-                _fontMetricsCache);
+                _fontMetricsCache,
+                _fontCache);
 
         addFont(subset, descr);
     }
@@ -143,7 +149,8 @@ public class FallbackFontStore implements Closeable {
                 fontFamilyNameOverride,
                 false,   // isFromFontFace
                 subset,
-                _fontMetricsCache);
+                _fontMetricsCache,
+                _fontCache);
 
         addFont(subset, descr);
     }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FontUtil.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FontUtil.java
@@ -7,6 +7,14 @@ import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 
 public class FontUtil {
+    public static final String FQSeparator = "/";
+
+    public static String getFontFQName(String fontFamily, Integer fontWeight, IdentValue fontStyle) {
+        return fontFamily + FQSeparator
+                + normalizeFontStyle(fontStyle) + FQSeparator
+                + normalizeFontWeight(fontWeight);
+    }
+
     public static String normalizeFontFamily(String fontFamily) {
         String result = fontFamily;
         // strip off the "s if they are there

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FontUtil.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FontUtil.java
@@ -7,11 +7,22 @@ import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 
 public class FontUtil {
-    public static final String FQSeparator = "/";
+    public static final String QNameSeparator = "/";
 
-    public static String getFontFQName(String fontFamily, Integer fontWeight, IdentValue fontStyle) {
-        return fontFamily + FQSeparator
-                + normalizeFontStyle(fontStyle) + FQSeparator
+    /**
+     * Gets the qualified name for the given font coordinates.
+     * 
+     * @param fontFamily
+     * @param fontWeight
+     * @param fontStyle
+     * @implNote The result is built according to this rule (ABNF):
+     *           <pre>
+     * fontQName = fontFamily {@link #QNameSeparator} fontStyle QNameSeparator fontWeight</pre>
+     *           where the font coordinates are normalized.
+     */
+    public static String getFontQName(String fontFamily, Integer fontWeight, IdentValue fontStyle) {
+        return normalizeFontFamily(fontFamily) + QNameSeparator
+                + normalizeFontStyle(fontStyle) + QNameSeparator
                 + normalizeFontWeight(fontWeight);
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/MainFontStore.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/MainFontStore.java
@@ -24,10 +24,12 @@ import com.openhtmltopdf.outputdevice.helper.FontFaceFontSupplier;
 import com.openhtmltopdf.outputdevice.helper.FontFamily;
 import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 import com.openhtmltopdf.pdfboxout.PDFontSupplier;
+import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontCache;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription;
 
 public class MainFontStore extends AbstractFontStore implements Closeable {
     private final Map<String, FontFamily<FontDescription>> _fontFamilies = new HashMap<>();
+    private final FontCache _fontCache;
     private final FSCacheEx<String, FSCacheValue> _fontMetricsCache;
     private final PDDocument _doc;
     private final SharedContext _sharedContext;
@@ -35,12 +37,14 @@ public class MainFontStore extends AbstractFontStore implements Closeable {
 
     public MainFontStore(
        SharedContext sharedContext,
-       PDDocument doc, 
-       FSCacheEx<String, FSCacheValue> pdfMetricsCache) {
+       PDDocument doc,
+       FSCacheEx<String, FSCacheValue> pdfMetricsCache,
+       FontCache fontCache) {
 
         this._sharedContext = sharedContext;
         this._doc = doc;
         this._fontMetricsCache = pdfMetricsCache;
+        this._fontCache = fontCache;
     }
 
     public void close() throws IOException {
@@ -75,7 +79,8 @@ public class MainFontStore extends AbstractFontStore implements Closeable {
                 fontFamilyNameOverride,
                 false,   // isFromFontFace
                 subset,
-                _fontMetricsCache);
+                _fontMetricsCache,
+                _fontCache);
 
         addFontToFamily(subset, fontFamily, descr);
     }
@@ -107,7 +112,8 @@ public class MainFontStore extends AbstractFontStore implements Closeable {
                     fontFamilyName,
                     true,  // isFromFontFace
                     subset,
-                    _fontMetricsCache);
+                    _fontMetricsCache,
+                    _fontCache);
 
         addFontToFamily(subset, fontFamily, description);
     }
@@ -129,7 +135,8 @@ public class MainFontStore extends AbstractFontStore implements Closeable {
                 fontFamilyNameOverride,
                 false, // isFromFontFace
                 subset,
-                _fontMetricsCache);
+                _fontMetricsCache,
+                _fontCache);
 
         addFontToFamily(subset, fontFamily, descr);
     }
@@ -153,9 +160,14 @@ public class MainFontStore extends AbstractFontStore implements Closeable {
                 fontFamilyNameOverride,
                 false, // isFromFontFace
                 subset,
-                _fontMetricsCache);
+                _fontMetricsCache,
+                _fontCache);
 
         addFontToFamily(subset, fontFamily, descr);
+    }
+
+    public Map<String, PDFont> getFontCache() {
+        return _fontCache;
     }
 
     @Override


### PR DESCRIPTION
This is the implementation of the proposal discussed in #683 to solve the issues impairing multiple runs against the same target PDF document, in particular:

- **font reuse**: this implementation introduces a concrete-font cache (`com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontCache`) that keeps track of `org.apache.pdfbox.pdmodel.font.PDFont` instances realized by corresponding `com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription` objects across multiple runs, preventing font structures from being reimported at each run;
- **font override**: this implementation introduces CSS-imported fonts overriding via user-supplied fonts, allowing users to programmatically substitute fonts at will.