### PR TITLE
Do not use org.apache.pdfbox.util.Charsets, use StandardCharsets

### DIFF
--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/benchmark/RenderTextBenchmark.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/benchmark/RenderTextBenchmark.java
@@ -3,7 +3,6 @@ package com.openhtmltopdf.benchmark;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.openhtmltopdf.util.XRLog;
 import org.apache.pdfbox.io.IOUtils;
-import org.apache.pdfbox.util.Charsets;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -18,6 +17,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +77,7 @@ public class RenderTextBenchmark {
     private String readContent(String path) {
         try (InputStream htmlIs = RenderTextBenchmark.class.getResourceAsStream(path)) {
             byte[] htmlBytes = IOUtils.toByteArray(htmlIs);
-            return new String(htmlBytes, Charsets.UTF_8);
+            return new String(htmlBytes, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/documentation/generator/TemplateAuthorGuideGenerator.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/documentation/generator/TemplateAuthorGuideGenerator.java
@@ -2,10 +2,10 @@ package com.openhtmltopdf.documentation.generator;
 
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.pdfbox.io.IOUtils;
-import org.apache.pdfbox.util.Charsets;
 
 import com.openhtmltopdf.mathmlsupport.MathMLDrawer;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
@@ -22,13 +22,13 @@ public class TemplateAuthorGuideGenerator {
 		
 		byte[] markdownBytes = IOUtils
 				.toByteArray(TemplateAuthorGuideGenerator.class.getResourceAsStream("/documentation/documentation.md"));
-		String md = new String(markdownBytes, Charsets.UTF_8);
+		String md = new String(markdownBytes, StandardCharsets.UTF_8);
 		
 		String html = markdown(md);
 		
 		byte[] hdrBytes = IOUtils
 				.toByteArray(TemplateAuthorGuideGenerator.class.getResourceAsStream("/documentation/documentation-header.htm"));
-		String hdr = new String(hdrBytes, Charsets.UTF_8);
+		String hdr = new String(hdrBytes, StandardCharsets.UTF_8);
 		
 		// FileUtils.writeStringToFile(new File("./docs-xxxx.htm"), hdr + html + "</body></html>\n");
 		

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java
@@ -5,6 +5,7 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.logging.Level;
@@ -15,7 +16,6 @@ import com.openhtmltopdf.latexsupport.LaTeXDOMMutator;
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
 import com.openhtmltopdf.util.Diagnostic;
 import org.apache.pdfbox.io.IOUtils;
-import org.apache.pdfbox.util.Charsets;
 import org.w3c.dom.Element;
 
 import com.openhtmltopdf.bidi.support.ICUBidiReorderer;
@@ -149,7 +149,7 @@ public class TestcaseRunner {
 
 		byte[] htmlBytes = IOUtils
 				.toByteArray(TestcaseRunner.class.getResourceAsStream("/testcases/" + testCaseFile + ".html"));
-		String html = new String(htmlBytes, Charsets.UTF_8);
+		String html = new String(htmlBytes, StandardCharsets.UTF_8);
 		OutputStream outputStream = new ByteArrayOutputStream(4096);
 
 		// We wan't to throw if we get a warning or severe log message.
@@ -254,7 +254,7 @@ public class TestcaseRunner {
 			return;
 		byte[] htmlBytes = IOUtils
 				.toByteArray(TestcaseRunner.class.getResourceAsStream("/testcases/" + testCaseFile + ".html"));
-		String html = new String(htmlBytes, Charsets.UTF_8);
+		String html = new String(htmlBytes, StandardCharsets.UTF_8);
 		String outDir = prepareOutDir();
 		String testCaseOutputFile = outDir + "/" + testCaseFile + ".pdf";
 		String testCaseOutputPNGFile = outDir + "/" + testCaseFile + ".png";

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/visualtest/Java2DVisualTester.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/visualtest/Java2DVisualTester.java
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +25,6 @@ import javax.imageio.ImageIO;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.io.IOUtils;
-import org.apache.pdfbox.util.Charsets;
 
 import com.openhtmltopdf.java2d.api.BufferedImagePageProcessor;
 import com.openhtmltopdf.java2d.api.Java2DRendererBuilder;
@@ -139,7 +139,7 @@ public class Java2DVisualTester {
         if (actual == null) {
             System.err.println("When running test (" + resource + ") on single-page mode, rendering failed, writing log to failure file.");
             File output = new File(this.outputPath, resource + ".failure.txt");
-            FileUtils.writeByteArrayToFile(output, sb.toString().getBytes(Charsets.UTF_8));
+            FileUtils.writeByteArrayToFile(output, sb.toString().getBytes(StandardCharsets.UTF_8));
             return false;
         } else if (TestcaseRunner.class.getResource(absExpPath) == null) {
             System.err.println("When running test (" + resource + ") on single-page mode, nothing to compare against as resource (" + absExpPath + ") does not exist.");
@@ -178,7 +178,7 @@ public class Java2DVisualTester {
     private String readHtml(String absResPath) throws IOException {
         try (InputStream htmlIs = TestcaseRunner.class.getResourceAsStream(absResPath)) {
             byte[] htmlBytes = IOUtils.toByteArray(htmlIs);
-            return new String(htmlBytes, Charsets.UTF_8);
+            return new String(htmlBytes, StandardCharsets.UTF_8);
         }
     }
 
@@ -197,7 +197,7 @@ public class Java2DVisualTester {
         if (actualPages == null) {
             System.err.println("When running test (" + resource + "), rendering failed, writing log to failure file.");
             File output = new File(this.outputPath, resource + ".failure.txt");
-            FileUtils.writeByteArrayToFile(output, sb.toString().getBytes(Charsets.UTF_8));
+            FileUtils.writeByteArrayToFile(output, sb.toString().getBytes(StandardCharsets.UTF_8));
             return false;
         }
 

--- a/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/visualtest/VisualTester.java
+++ b/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/visualtest/VisualTester.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,7 +13,6 @@ import javax.imageio.ImageIO;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.io.IOUtils;
-import org.apache.pdfbox.util.Charsets;
 
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.openhtmltopdf.pdfboxout.visualtester.PdfVisualTester;
@@ -91,7 +91,7 @@ public class VisualTester {
         
         try (InputStream htmlIs = TestcaseRunner.class.getResourceAsStream(absResPath)) {
             byte[] htmlBytes = IOUtils.toByteArray(htmlIs);
-            html = new String(htmlBytes, Charsets.UTF_8);
+            html = new String(htmlBytes, StandardCharsets.UTF_8);
         }
 
         StringBuilder sb = logToStringBuilder();
@@ -100,7 +100,7 @@ public class VisualTester {
         if (actualPdfBytes == null) {
             System.err.println("When running test (" + resource + "), rendering failed, writing log to failure file.");
             File output = new File(this.outputPath, resource + ".failure.txt");
-            FileUtils.writeByteArrayToFile(output, sb.toString().getBytes(Charsets.UTF_8));
+            FileUtils.writeByteArrayToFile(output, sb.toString().getBytes(StandardCharsets.UTF_8));
             return false;
         }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/freemarker/FreeMarkerGeneratorTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/freemarker/FreeMarkerGeneratorTest.java
@@ -3,10 +3,10 @@ package com.openhtmltopdf.freemarker;
 import com.openhtmltopdf.freemarker.FreeMarkerGenerator.FreemarkerRootObject;
 import com.openhtmltopdf.util.XRLog;
 import freemarker.template.TemplateException;
-import org.apache.pdfbox.util.Charsets;
 import org.junit.Test;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 public class FreeMarkerGeneratorTest {
@@ -21,7 +21,7 @@ public class FreeMarkerGeneratorTest {
 		String html = freeMarkerGenerator.generateHTML("featuredocumentation.ftl", Locale.GERMAN, object);
 		byte[] pdf = freeMarkerGenerator.generatePDF(html);
 		FileOutputStream fileOutputStream = new FileOutputStream(new File(targetDir, "featuredocumentation.html"));
-		fileOutputStream.write(html.getBytes(Charsets.UTF_8));
+		fileOutputStream.write(html.getBytes(StandardCharsets.UTF_8));
 		fileOutputStream.close();
 		fileOutputStream = new FileOutputStream(new File(targetDir, "featuredocumentation.pdf"));
 		fileOutputStream.write(pdf);

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +42,6 @@ import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.apache.pdfbox.util.Charsets;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.Assert;
 import org.junit.Test;
@@ -93,7 +93,7 @@ public class NonVisualRegressionTest {
             byte[] htmlBytes = IOUtils
                       .toByteArray(is);
 
-            return new String(htmlBytes, Charsets.UTF_8);
+            return new String(htmlBytes, StandardCharsets.UTF_8);
         }
     }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/RepeatContentRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/RepeatContentRegressionTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,7 +22,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.apache.pdfbox.util.Charsets;
 import org.junit.Test;
 
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
@@ -150,7 +150,7 @@ public class RepeatContentRegressionTest {
 
         try (InputStream is = TestcaseRunner.class.getResourceAsStream(absResPath)) {
             byte[] htmlBytes = IOUtils.toByteArray(is);
-            String htmlWithProof = new String(htmlBytes, Charsets.UTF_8);
+            String htmlWithProof = new String(htmlBytes, StandardCharsets.UTF_8);
 
             String[] parts = htmlWithProof.split(Pattern.quote("======="));
             String html = parts[0];

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/ConcateOutputTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/ConcateOutputTest.java
@@ -3,11 +3,11 @@ package com.openhtmltopdf.testcases;
 import static com.openhtmltopdf.testcases.TestcaseRunner.buildObjectDrawerFactory;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.util.Charsets;
 import org.junit.Test;
 
 import com.openhtmltopdf.bidi.support.ICUBidiReorderer;
@@ -42,7 +42,7 @@ public class ConcateOutputTest {
 	private static void renderPDF(String testCaseFile, PDDocument document) throws Exception {
 		byte[] htmlBytes = IOUtils
 				.toByteArray(TestcaseRunner.class.getResourceAsStream("/testcases/" + testCaseFile + ".html"));
-		String html = new String(htmlBytes, Charsets.UTF_8);
+		String html = new String(htmlBytes, StandardCharsets.UTF_8);
 		PdfRendererBuilder builder = new PdfRendererBuilder();
 		builder.useUnicodeBidiSplitter(new ICUBidiSplitter.ICUBidiSplitterFactory());
 		builder.useUnicodeBidiReorderer(new ICUBidiReorderer());

--- a/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/ForegroundPdfDrawer.java
+++ b/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/ForegroundPdfDrawer.java
@@ -9,12 +9,12 @@ import org.apache.pdfbox.cos.COSStream;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
-import org.apache.pdfbox.util.Charsets;
 import org.w3c.dom.Element;
 
 import java.awt.*;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class ForegroundPdfDrawer extends PdfDrawerBase
@@ -50,12 +50,12 @@ public class ForegroundPdfDrawer extends PdfDrawerBase
 
             COSStream restoreStateAndPlaceWatermark = (COSStream) cosArray.get(cosArray.size() - 1);
             OutputStream watermarkOutputStream = restoreStateAndPlaceWatermark.createOutputStream();
-            watermarkOutputStream.write("Q\nq\n".getBytes(Charsets.US_ASCII));
+            watermarkOutputStream.write("Q\nq\n".getBytes(StandardCharsets.US_ASCII));
             COSName name = page.getResources().add(pdFormXObject);
             name.writePDF(watermarkOutputStream);
             watermarkOutputStream.write(' ');
-            watermarkOutputStream.write("Do\n".getBytes(Charsets.US_ASCII));
-            watermarkOutputStream.write("Q\n".getBytes(Charsets.US_ASCII));
+            watermarkOutputStream.write("Do\n".getBytes(StandardCharsets.US_ASCII));
+            watermarkOutputStream.write("Q\n".getBytes(StandardCharsets.US_ASCII));
             watermarkOutputStream.close();
         }
         catch (IOException e1)

--- a/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/MergeBackgroundPdfDrawer.java
+++ b/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/MergeBackgroundPdfDrawer.java
@@ -3,6 +3,7 @@ package com.openhtmltopdf.objects.pdf;
 import java.awt.*;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.pdfbox.cos.COSArray;
@@ -11,7 +12,6 @@ import org.apache.pdfbox.cos.COSStream;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
-import org.apache.pdfbox.util.Charsets;
 import org.w3c.dom.Element;
 
 import com.openhtmltopdf.extend.OutputDevice;
@@ -52,13 +52,13 @@ public class MergeBackgroundPdfDrawer extends PdfDrawerBase
             COSStream saveStateAndPlacePageBackgroundStream = (COSStream) cosArray.get(0);
             OutputStream saveAndPlaceStream = saveStateAndPlacePageBackgroundStream
                     .createOutputStream();
-            saveAndPlaceStream.write("q\n".getBytes(Charsets.US_ASCII));
+            saveAndPlaceStream.write("q\n".getBytes(StandardCharsets.US_ASCII));
             COSName name = page.getResources().add(pdFormXObject);
             name.writePDF(saveAndPlaceStream);
             saveAndPlaceStream.write(' ');
-            saveAndPlaceStream.write("Do\n".getBytes(Charsets.US_ASCII));
-            saveAndPlaceStream.write("Q\n".getBytes(Charsets.US_ASCII));
-            saveAndPlaceStream.write("q\n".getBytes(Charsets.US_ASCII));
+            saveAndPlaceStream.write("Do\n".getBytes(StandardCharsets.US_ASCII));
+            saveAndPlaceStream.write("Q\n".getBytes(StandardCharsets.US_ASCII));
+            saveAndPlaceStream.write("q\n".getBytes(StandardCharsets.US_ASCII));
             saveAndPlaceStream.close();
 
         }


### PR DESCRIPTION
In PDFBox 3.0 org.apache.pdfbox.util.Charsets has been removed,
as it has been obsoleted by StandardCharsets which exists since
Java 1.7