### PR TITLE
Fix some deprecation compiler warnings

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/ValueConstants.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/ValueConstants.java
@@ -23,38 +23,24 @@ package com.openhtmltopdf.css.constants;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
-import com.openhtmltopdf.util.XRRuntimeException;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.logging.Level;
 
 
 /**
  * Utility class for working with <code>CSSValue</code> instances.
- *
- * @author empty
  */
 public final class ValueConstants {
-    /**
-     * Type descriptions--a crude approximation taken by scanning CSSValue
-     * statics
-     */
-    private final static List<String> TYPE_DESCRIPTIONS;
-    /**
-     * Description of the Field
-     */
     private final static Map<Short, String> sacTypesStrings;
 
     /**
-     * Description of the Method
+     * Given a unit constant like <code>CSSPrimitiveValue.CSS_EMS</code>
+     * will return the unit suffix like <code>em</code>.
      *
-     * @param type PARAM
-     * @return Returns
+     * FIXME: Not exhaustive.
      */
     public static String stringForSACPrimitiveType(short type) {
-        return sacTypesStrings.get(new Short(type));
+        return sacTypesStrings.get(type);
     }
 
     /**
@@ -62,14 +48,14 @@ public final class ValueConstants {
      * value for it), meaning that either the value can be used directly (e.g.
      * pixels) or there is a fixed context-independent conversion for it (e.g.
      * inches). Proportional types (e.g. %) return false.
+     * 
+     * FIXME: Font proportional units are returned as absolute. Probably
+     * wrong method name rather than wrong behavior.
      *
      * @param type The CSSValue type to check.
      * @return See desc.
      */
-    //TODO: method may be unnecessary (tobe)
     public static boolean isAbsoluteUnit(short type) {
-        // TODO: check this list...
-
         // note, all types are included here to make sure none are missed
         switch (type) {
             // proportional length or size
@@ -130,10 +116,10 @@ public final class ValueConstants {
      * Returns true if the SAC primitive value type is a number unit--a unit
      * that can only contain a numeric value. This is a shorthand way of saying,
      * did the user declare this as a number unit (like px)?
-     *
-     * @param cssPrimitiveType PARAM
-     * @return See desc.
+     * 
+     * @deprecated Only used by the broken DOMInspector.
      */
+    @Deprecated
     public static boolean isNumber(short cssPrimitiveType) {
         switch (cssPrimitiveType) {
             // fall thru on all these
@@ -157,95 +143,15 @@ public final class ValueConstants {
     }
 
     static {
-        SortedMap<Short, String> map = new TreeMap<>();
-        TYPE_DESCRIPTIONS = new ArrayList<>();
-        try {
-            Field[] fields = CSSPrimitiveValue.class.getFields();
-            for (int i = 0; i < fields.length; i++) {
-                Field f = fields[i];
-                int mod = f.getModifiers();
-                if (Modifier.isFinal(mod) &&
-                        Modifier.isStatic(mod) &&
-                        Modifier.isPublic(mod)) {
-
-                    Short val = (Short) f.get(null);
-                    String name = f.getName();
-                    if (name.startsWith("CSS_")) {
-                        if (!name.equals("CSS_INHERIT") &&
-                                !name.equals("CSS_PRIMITIVE_VALUE") &&
-                                !name.equals("CSS_VALUE_LIST") &&
-                                !name.equals("CSS_CUSTOM")) {
-
-                            map.put(val, name.substring("CSS_".length()));
-                        }
-                    }
-                }
-            }
-            // now sort by the key--the short constant for the public fields
-            List<Short> keys = new ArrayList<>(map.keySet());
-            Collections.sort(keys);
-
-            // then add to our static list, in the order the keys appear. this means
-            // list.get(index) will return the item at index, which should be the description
-            // for that constant
-            Iterator<Short> iter = keys.iterator();
-            while (iter.hasNext()) {
-                TYPE_DESCRIPTIONS.add(map.get(iter.next()));
-            }
-        } catch (Exception ex) {
-            throw new XRRuntimeException("Could not build static list of CSS type descriptions.", ex);
-        }
-
-        // HACK: this is a quick way to perform the lookup, but dumb if the short assigned are > 100; but the compiler will tell us that (PWW 21-01-05)
         sacTypesStrings = new HashMap<>(25);
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_EMS), "em");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_EXS), "ex");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_PX), "px");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_PERCENTAGE), "%");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_IN), "in");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_CM), "cm");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_MM), "mm");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_PT), "pt");
-        sacTypesStrings.put(new Short(CSSPrimitiveValue.CSS_PC), "pc");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_EMS, "em");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_EXS, "ex");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_PX, "px");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_PERCENTAGE, "%");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_IN, "in");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_CM, "cm");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_MM, "mm");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_PT, "pt");
+        sacTypesStrings.put(CSSPrimitiveValue.CSS_PC, "pc");
     }
-
-}// end class
-
-/*
- * $Id$
- *
- * $Log$
- * Revision 1.10  2005/10/25 16:06:49  pdoubleya
- * For guessing type, with no type code, check last char, not first.
- *
- * Revision 1.9  2005/10/25 15:38:27  pdoubleya
- * Moved guessType() to ValueConstants, applied fix to method suggested by Chris Oliver, to avoid exception-based catch.
- *
- * Revision 1.8  2005/09/11 20:43:15  tobega
- * Fixed table-css interaction bug, colspan now works again
- *
- * Revision 1.7  2005/06/01 00:47:01  tobega
- * Partly confused hack trying to get width and height working properly for replaced elements.
- *
- * Revision 1.6  2005/01/29 20:18:40  pdoubleya
- * Clean/reformat code. Removed commented blocks, checked copyright.
- *
- * Revision 1.5  2005/01/24 14:52:20  pdoubleya
- * Fixed accidental access modifier change to private--isAbsoluteUnit() is used in tests.
- *
- * Revision 1.4  2005/01/24 14:36:32  pdoubleya
- * Mass commit, includes: updated for changes to property declaration instantiation, and new use of DerivedValue. Removed any references to older XR... classes (e.g. XRProperty). Cleaned imports.
- *
- * Revision 1.3  2004/11/16 10:38:21  pdoubleya
- * Use XRR exception, added comments.
- *
- * Revision 1.2  2004/10/23 13:09:13  pdoubleya
- * Re-formatted using JavaStyle tool.
- * Cleaned imports to resolve wildcards
- * except for common packages
- * (java.io, java.util, etc).
- * Added CVS log comments at bottom.
- *
- *
- */
-
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/LayoutContext.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/LayoutContext.java
@@ -485,31 +485,34 @@ public class LayoutContext implements CssContext {
          * @return true if a counter was found and incremented
          */
         private boolean incrementCounter(CounterData cd) {
-            if ("list-item".equals(cd.getName())) {//reserved name for list-item counter in CSS3
+            // list-item is a reserved name for list-item counter in CSS3
+            if ("list-item".equals(cd.getName())) {
                 incrementListItemCounter(cd.getValue());
                 return true;
             } else {
-                Integer currentValue = (Integer) _counters.get(cd.getName());
+                Integer currentValue = _counters.get(cd.getName());
                 if (currentValue == null) {
-                    if (_parent == null) return false;
+                    if (_parent == null) {
+                        return false;
+                    }
                     return _parent.incrementCounter(cd);
                 } else {
-                    _counters.put(cd.getName(), new Integer(currentValue.intValue() + cd.getValue()));
+                    _counters.put(cd.getName(), currentValue + cd.getValue());
                     return true;
                 }
             }
         }
 
         private void incrementListItemCounter(int increment) {
-            Integer currentValue = (Integer) _counters.get("list-item");
+            Integer currentValue = _counters.get("list-item");
             if (currentValue == null) {
-                currentValue = new Integer(0);
+                currentValue = 0;
             }
-            _counters.put("list-item", new Integer(currentValue.intValue() + increment));
+            _counters.put("list-item", currentValue + increment);
         }
 
         private void resetCounter(CounterData cd) {
-            _counters.put(cd.getName(), new Integer(cd.getValue()));
+            _counters.put(cd.getName(), cd.getValue());
         }
 
         public int getCurrentCounterValue(String name) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -201,6 +201,7 @@ public interface LogMessageId {
         CSS_PARSE_COULDNT_PARSE_STYLESHEET_AT_URI(XRLog.CSS_PARSE, "Couldn't parse stylesheet at URI {}: {}"),
         CSS_PARSE_GENERIC_MESSAGE(XRLog.CSS_PARSE, "({}) {}"),
 
+        XML_FEATURE_NOT_ABLE_TO_SET(XRLog.LOAD, "Could not set XML/SAX feature. This may be a security issue if using untrusted XML. Feature: {} -> {}"),
         XML_ENTITIES_SAX_FEATURE_SET(XRLog.XML_ENTITIES, "SAX Parser feature: {} set to {}"),
         XML_ENTITIES_ENTITY_PUBLIC_NOT_FOUND_OR_LOCAL(XRLog.XML_ENTITIES, "Entity public: {} -> {}"),
         XML_ENTITIES_ENTITY_CANT_FIND_LOCAL_REFERENCE(XRLog.XML_ENTITIES, "Can't find a local reference for Entity for public ID: {}" +

--- a/openhtmltopdf-core/src/main/resources/resources/conf/xhtmlrenderer.conf
+++ b/openhtmltopdf-core/src/main/resources/resources/conf/xhtmlrenderer.conf
@@ -1,3 +1,4 @@
+# DEPRECATED
 # Configuration file for XHTMLRenderer core
 #
 # Follows formatting specified in JavaDoc for java.util.Properties

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
+          <configuration>
+            <compilerArgs>
+              <arg>-Xlint:deprecation</arg>
+            </compilerArgs>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
In Java 11/Java 17-ea. The most notable are `XMLReaderFactory` and the constructors for the boxed classes - `Short` and `Integer` which may be removed when value types eventually arrive in Java.