### PR TITLE
#692 allow shape-rendering

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/SVGProperty.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/SVGProperty.java
@@ -35,7 +35,8 @@ public enum SVGProperty {
     STROKE_LINEJOIN,
     STROKE_MITERLIMIT,
     STROKE_OPACITY,
-    STROKE_WIDTH;
+    STROKE_WIDTH,
+    SHAPE_RENDERING;
 
     private static final Set<String> _set =
             Arrays.stream(values())


### PR DESCRIPTION
hi @danfickle , this PR allow the CSS property shape-rendering to the svg batik backend.
I've tested with the following html:

```
<html>
<head>
    <style>
        svg.my-svg circle {
            fill:blue;
            shape-rendering: geometricPrecision;
        }
    </style>
</head>
<body>
<svg xmlns="http://www.w3.org/2000/svg" height="100" width="100" class="my-svg">
    <circle id="icon-1" r="100" stroke="black" stroke-width="1" />
</svg>
</body>
</html>
```

The java2d backend render without shape-rendering:

![no-shape](https://user-images.githubusercontent.com/498146/119679757-e5f2a180-be40-11eb-9067-ef43c168a9dc.png)

with shape:

![with-shape](https://user-images.githubusercontent.com/498146/119680067-26eab600-be41-11eb-8b74-15e18d45905b.png)


You can notice the applied anti aliasing, as described in the issue #692 




