### PR TITLE
#715 replace printStacktrace()

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/FSEntityResolver.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/FSEntityResolver.java
@@ -84,7 +84,7 @@ public class FSEntityResolver implements EntityResolver {
             try {
                 is = realUrl.openStream();
             } catch (IOException e) {
-                e.printStackTrace();
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_IO_PROBLEM_FOR_URI, url, e);
             }
 
             if (is == null) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -149,6 +149,7 @@ public interface LogMessageId {
         EXCEPTION_FONT_METRICS_NOT_AVAILABLE(XRLog.EXCEPTION, "Font metrics not available for font-description: {}"),
         EXCEPTION_URI_SYNTAX_WHILE_LOADING_EXTERNAL_SVG_RESOURCE(XRLog.EXCEPTION, "URI syntax exception while loading external svg resource: {}"),
         EXCEPTION_SVG_ERROR_HANDLER(XRLog.EXCEPTION, "SVG {}"),
+        EXCEPTION_SVG_CREATE_FONT(XRLog.EXCEPTION, "Error while creating a font with family: {}"),
         EXCEPTION_PDF_IN_WRITING_METHOD(XRLog.EXCEPTION, "Exception in PDF writing method: {}"),
         EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI(XRLog.EXCEPTION, "Can't read image file; unexpected problem for URI '{}'"),
         EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI_NOT_FOUND(XRLog.EXCEPTION, "Can't read image file; image at URI '{}' not found"),

--- a/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/ForegroundPdfDrawer.java
+++ b/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/ForegroundPdfDrawer.java
@@ -3,6 +3,8 @@ package com.openhtmltopdf.objects.pdf;
 import com.openhtmltopdf.extend.OutputDevice;
 import com.openhtmltopdf.pdfboxout.PdfBoxOutputDevice;
 import com.openhtmltopdf.render.RenderingContext;
+import com.openhtmltopdf.util.LogMessageId;
+import com.openhtmltopdf.util.XRLog;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
@@ -16,6 +18,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class ForegroundPdfDrawer extends PdfDrawerBase
 {
@@ -60,7 +63,7 @@ public class ForegroundPdfDrawer extends PdfDrawerBase
         }
         catch (IOException e1)
         {
-            e1.printStackTrace();
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_MESSAGE, "Error while drawing with the ForegroundPdfDrawer ", e1);
         }
         return null;
     }

--- a/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/MergeBackgroundPdfDrawer.java
+++ b/openhtmltopdf-objects/src/main/java/com/openhtmltopdf/objects/pdf/MergeBackgroundPdfDrawer.java
@@ -5,7 +5,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
+import com.openhtmltopdf.util.XRLog;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
@@ -64,7 +67,7 @@ public class MergeBackgroundPdfDrawer extends PdfDrawerBase
         }
         catch (IOException e1)
         {
-            e1.printStackTrace();
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_MESSAGE, "Error while drawing with the MergeBackgroundPdfDrawer ", e1);
         }
         return null;
     }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlGvtFont.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlGvtFont.java
@@ -8,7 +8,10 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.text.CharacterIterator;
+import java.util.logging.Level;
 
+import com.openhtmltopdf.util.LogMessageId;
+import com.openhtmltopdf.util.XRLog;
 import org.apache.batik.gvt.font.GVTFont;
 import org.apache.batik.gvt.font.GVTFontFamily;
 import org.apache.batik.gvt.font.GVTGlyphVector;
@@ -56,7 +59,7 @@ public class OpenHtmlGvtFont implements GVTFont {
 			font = Font.createFont(Font.TRUETYPE_FONT, new ByteArrayInputStream(fontBytes)).deriveFont(toFontWeight(fontWeight) | toStyle(fontStyle) , size);
 		} catch (IOException e) {
 			// Shouldn't happen
-			e.printStackTrace();
+			XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_SVG_CREATE_FONT, family != null ? family.getFamilyName() : "", e);
 			font = null;
 		}
 


### PR DESCRIPTION
Hi this PR replace various printStackTrace() call with the XRLog infrastructure as noticed in the issue #715 

Should cover _most_ of the ones still present in the codebase. There are still 2 calls in the `Configuration` class.