### PR TITLE
update github action from java 17-ea to 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8','11','17-ea']
+        java: ['8','11','17']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
looks like that the 17-ea download the stable version anyway, but I guess at least it's more clear java17 is out :)