### PR TITLE
Improve error reporting for missing font

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -71,8 +71,8 @@ public abstract class AbstractOutputDevice implements OutputDevice {
        
         if (text != null && text.length() > 0) {
             setColor(iB.getStyle().getColor());
-            setFont(iB.getStyle().getFSFont(c));
             setFontSpecification(iB.getStyle().getFontSpecification());
+            setFont(iB.getStyle().getFSFont(c));
             if (inlineText.getLetterSpacing() != 0f) {
                 JustificationInfo info = new JustificationInfo();
                 info.setNonSpaceAdjust(inlineText.getLetterSpacing());

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/ListItemPainter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/ListItemPainter.java
@@ -171,10 +171,10 @@ public class ListItemPainter {
         }
 
         c.getOutputDevice().setColor(box.getStyle().getColor());
-        c.getOutputDevice().setFont(box.getStyle().getFSFont(c));
         if (c.getOutputDevice() instanceof AbstractOutputDevice) {
             ((AbstractOutputDevice) c.getOutputDevice()).setFontSpecification(box.getStyle().getFontSpecification());
         }
+        c.getOutputDevice().setFont(box.getStyle().getFSFont(c));
         c.getTextRenderer().drawString(
                 c.getOutputDevice(), text.getText(), x, y);
     }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -39,6 +39,7 @@ import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription;
 import com.openhtmltopdf.pdfboxout.PdfBoxUtil.FontRun;
 import com.openhtmltopdf.pdfboxout.PdfBoxUtil.Metadata;
+import com.openhtmltopdf.pdfboxout.fontstore.FontNotFoundException;
 import com.openhtmltopdf.render.*;
 import com.openhtmltopdf.simple.extend.ReplacedElementScaleHelper;
 import com.openhtmltopdf.util.ArrayUtil;
@@ -381,6 +382,9 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
     @Override
     public void setFont(FSFont font) {
         _font = ((PdfBoxFSFont) font);
+        if (_font.getFontDescription().isEmpty()) {
+            throw new FontNotFoundException(this.getFontSpecification());
+        }
     }
 
     /**

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FontNotFoundException.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FontNotFoundException.java
@@ -1,0 +1,20 @@
+package com.openhtmltopdf.pdfboxout.fontstore;
+
+import com.openhtmltopdf.css.value.FontSpecification;
+
+/**
+ * An extension thrown when a font isn't found.
+ *
+ * @author Quentin Ligier
+ **/
+public class FontNotFoundException extends RuntimeException {
+
+    /**
+     * Constructs a new font not found exception with the specified font specification.
+     *
+     * @param fontSpecification The specification of the font that hasn't been found.
+     */
+    public FontNotFoundException(final FontSpecification fontSpecification) {
+        super("No font for the following specification has been found: " + fontSpecification.toString());
+    }
+}


### PR DESCRIPTION
This modifies the PdfBox renderer to throw a new exception (`FontNotFoundException`) in the case of a missing font instead of trying to access an empty font list and throw `IndexOutOfBoundsException`. A check is added in `PdfBoxFastOutputDevice.setFont(FSFont)` to assert the font description isn't null. The methods `AbstractOutputDevice.drawText(RenderingContext, InlineText)` and `ListItemPainter.drawText(RenderingContext, BlockBox, IdentValue)` are modified to set the font specification before the font itself to make it available in the `PdfBoxFastOutputDevice.setFont(FSFont)` call.

The exception thrown goes from:
`java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0`
to 
`com.openhtmltopdf.pdfboxout.fontstore.FontNotFoundException: No font for the following specification has been found: Font specification:  families: [arimo, serif] size: 320.0 weight: normal style: normal variant: normal`

I've tested it in some of my documents and all tests are passing.