### PR TITLE
[#712] Optional Content (aka PDF Layers) implementation

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -36,6 +36,7 @@ import com.openhtmltopdf.css.extend.AttributeResolver;
 import com.openhtmltopdf.css.extend.lib.DOMTreeResolver;
 import com.openhtmltopdf.css.newmatch.CascadedStyle;
 import com.openhtmltopdf.css.newmatch.PageInfo;
+import com.openhtmltopdf.css.newmatch.Selector;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.Stylesheet;
@@ -83,6 +84,10 @@ public class StyleReference {
         } else {
             return null;
         }
+    }
+
+    public List<Selector> getSelectors() {
+        return _matcher.getSelectors();
     }
 
     /**

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -20,14 +20,21 @@
  */
 package com.openhtmltopdf.css.constants;
 
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.css.parser.CSSParseException;
 import com.openhtmltopdf.css.parser.CSSParser;
+import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.css.parser.PropertyValue;
+import com.openhtmltopdf.css.parser.property.AbstractPropertyBuilder;
 import com.openhtmltopdf.css.parser.property.BackgroundPropertyBuilder;
 import com.openhtmltopdf.css.parser.property.PrimitiveBackgroundPropertyBuilders;
 import com.openhtmltopdf.css.parser.property.BorderPropertyBuilders;
@@ -41,6 +48,7 @@ import com.openhtmltopdf.css.parser.property.PrimitivePropertyBuilders;
 import com.openhtmltopdf.css.parser.property.PropertyBuilder;
 import com.openhtmltopdf.css.parser.property.QuotesPropertyBuilder;
 import com.openhtmltopdf.css.parser.property.SizePropertyBuilder;
+import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 import com.openhtmltopdf.css.style.FSDerivedValue;
 import com.openhtmltopdf.css.style.derived.DerivedValueFactory;
@@ -301,6 +309,87 @@ public final class CSSName implements Comparable<CSSName> {
                     NOT_INHERITED,
                     new PrimitivePropertyBuilders.FSKeepWithInline()
             );
+
+    /**
+     * Layer identifier (document-scoped).
+     */
+    public final static CSSName FS_OCG_ID =
+            addProperty(
+                    "-fs-ocg-id",
+                    PRIMITIVE,
+                    "",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSOcId()
+                    );
+    /**
+     * Layer name, suitable for UI presentation (see {@code Name} entry in optional content group
+     * dictionary [PDF:1.7:8.11.2.1]).
+     */
+    public final static CSSName FS_OCG_LABEL =
+            addProperty(
+                    "-fs-ocg-label",
+                    PRIMITIVE,
+                    "",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSOcgLabel()
+                    );
+    /**
+     * Layer parent {@link #FS_OCG_ID reference}.
+     */
+    public final static CSSName FS_OCG_PARENT =
+            addProperty(
+                    "-fs-ocg-parent",
+                    PRIMITIVE,
+                    "",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSOcId()
+                    );
+    /**
+     * Layer visibility.
+     */
+    public final static CSSName FS_OCG_VISIBILITY =
+            addProperty(
+                    "-fs-ocg-visibility",
+                    PRIMITIVE,
+                    IdentValue.VISIBLE.asString(),
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSOcgVisibility()
+            );
+    /**
+     * Layer membership identifier (document-scoped).
+     */
+    public final static CSSName FS_OCM_ID =
+            addProperty(
+                    "-fs-ocm-id",
+                    PRIMITIVE,
+                    "",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSOcId()
+            );
+    /**
+     * Layer visibility policy (see {@code BaseState}, {@code ON}, {@code OFF} entries in {@code D}
+     * entry in optional content configuration dictionary [PDF:1.7:8.11.4.3]).
+     */
+    public final static CSSName FS_OCM_VISIBLE =
+            addProperty(
+                    "-fs-ocm-visible",
+                    PRIMITIVE,
+                    IdentValue.ANY_VISIBLE.asString(),
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSOcmVisible()
+            );
+    /**
+     * Layers belonging to the membership.
+     *
+     * <p>Value: list of {@link #FS_OCG_ID layer references}.</p>
+     */
+    public final static CSSName FS_OCM_OCGS =
+            addProperty(
+                    "-fs-ocm-ocgs",
+                    PRIMITIVE,
+                    "",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSOcmOcgs());
 
     /**
      * Unique CSSName instance for CSS2 property.
@@ -1981,7 +2070,8 @@ public final class CSSName implements Comparable<CSSName> {
         });
         for (Iterator<CSSName> i = ALL_PRIMITIVE_PROPERTY_NAMES.values().iterator(); i.hasNext(); ) {
             CSSName cssName = i.next();
-            if (cssName.initialValue.charAt(0) != '=' && cssName.implemented) {
+            if ((cssName.initialValue.length() == 0 || cssName.initialValue.charAt(0) != '=')
+                    && cssName.implemented) {
                 PropertyValue value = parser.parsePropertyValue(
                         cssName, StylesheetInfo.USER_AGENT, cssName.initialValue);
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -20,21 +20,14 @@
  */
 package com.openhtmltopdf.css.constants;
 
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 
-import com.openhtmltopdf.css.parser.CSSParseException;
 import com.openhtmltopdf.css.parser.CSSParser;
-import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.css.parser.PropertyValue;
-import com.openhtmltopdf.css.parser.property.AbstractPropertyBuilder;
 import com.openhtmltopdf.css.parser.property.BackgroundPropertyBuilder;
 import com.openhtmltopdf.css.parser.property.PrimitiveBackgroundPropertyBuilders;
 import com.openhtmltopdf.css.parser.property.BorderPropertyBuilders;
@@ -48,7 +41,6 @@ import com.openhtmltopdf.css.parser.property.PrimitivePropertyBuilders;
 import com.openhtmltopdf.css.parser.property.PropertyBuilder;
 import com.openhtmltopdf.css.parser.property.QuotesPropertyBuilder;
 import com.openhtmltopdf.css.parser.property.SizePropertyBuilder;
-import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 import com.openhtmltopdf.css.style.FSDerivedValue;
 import com.openhtmltopdf.css.style.derived.DerivedValueFactory;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -309,7 +309,7 @@ public final class CSSName implements Comparable<CSSName> {
             addProperty(
                     "-fs-ocg-id",
                     PRIMITIVE,
-                    "",
+                    IdentValue.NONE.asString(),
                     NOT_INHERITED,
                     new PrimitivePropertyBuilders.FSOcId()
                     );
@@ -321,7 +321,7 @@ public final class CSSName implements Comparable<CSSName> {
             addProperty(
                     "-fs-ocg-label",
                     PRIMITIVE,
-                    "",
+                    IdentValue.NONE.asString(),
                     NOT_INHERITED,
                     new PrimitivePropertyBuilders.FSOcgLabel()
                     );
@@ -332,7 +332,7 @@ public final class CSSName implements Comparable<CSSName> {
             addProperty(
                     "-fs-ocg-parent",
                     PRIMITIVE,
-                    "",
+                    IdentValue.NONE.asString(),
                     NOT_INHERITED,
                     new PrimitivePropertyBuilders.FSOcId()
                     );
@@ -354,7 +354,7 @@ public final class CSSName implements Comparable<CSSName> {
             addProperty(
                     "-fs-ocm-id",
                     PRIMITIVE,
-                    "",
+                    IdentValue.NONE.asString(),
                     NOT_INHERITED,
                     new PrimitivePropertyBuilders.FSOcId()
             );
@@ -379,9 +379,9 @@ public final class CSSName implements Comparable<CSSName> {
             addProperty(
                     "-fs-ocm-ocgs",
                     PRIMITIVE,
-                    "",
+                    IdentValue.NONE.asString(),
                     NOT_INHERITED,
-                    new PrimitivePropertyBuilders.FSOcmOcgs());
+                    new PrimitivePropertyBuilders.FSOcIds());
 
     /**
      * Unique CSSName instance for CSS2 property.
@@ -2062,8 +2062,7 @@ public final class CSSName implements Comparable<CSSName> {
         });
         for (Iterator<CSSName> i = ALL_PRIMITIVE_PROPERTY_NAMES.values().iterator(); i.hasNext(); ) {
             CSSName cssName = i.next();
-            if ((cssName.initialValue.length() == 0 || cssName.initialValue.charAt(0) != '=')
-                    && cssName.implemented) {
+            if (cssName.initialValue.charAt(0) != '=' && cssName.implemented) {
                 PropertyValue value = parser.parsePropertyValue(
                         cssName, StylesheetInfo.USER_AGENT, cssName.initialValue);
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -315,7 +315,7 @@ public final class CSSName implements Comparable<CSSName> {
                     );
     /**
      * Layer name, suitable for UI presentation (see {@code Name} entry in optional content group
-     * dictionary [PDF:1.7:8.11.2.1]).
+     * dictionary [ISO:32000-1:8.11.2.1]).
      */
     public final static CSSName FS_OCG_LABEL =
             addProperty(
@@ -360,7 +360,7 @@ public final class CSSName implements Comparable<CSSName> {
             );
     /**
      * Layer visibility policy (see {@code BaseState}, {@code ON}, {@code OFF} entries in {@code D}
-     * entry in optional content configuration dictionary [PDF:1.7:8.11.4.3]).
+     * entry in optional content configuration dictionary [ISO:32000-1:8.11.4.3]).
      */
     public final static CSSName FS_OCM_VISIBLE =
             addProperty(

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
@@ -60,7 +60,11 @@ public class IdentValue implements FSDerivedValue {
     public final int FS_ID;
 
     public final static IdentValue ABSOLUTE = addValue("absolute");
+    public final static IdentValue ALL_HIDDEN = addValue("all-hidden");
+    public final static IdentValue ALL_VISIBLE = addValue("all-visible");
     public final static IdentValue ALWAYS = addValue("always");
+    public final static IdentValue ANY_HIDDEN = addValue("any-hidden");
+    public final static IdentValue ANY_VISIBLE = addValue("any-visible");
     public final static IdentValue ARMENIAN = addValue("armenian");
     public final static IdentValue AUTO = addValue("auto");
     public final static IdentValue AVOID = addValue("avoid");

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
@@ -139,6 +139,10 @@ public class Matcher {
     public List<FontFaceRule> getFontFaceRules() {
         return _fontFaceRules;
     }
+
+    public List<Selector> getSelectors() {
+        return docMapper.axes;
+    }
     
     public boolean isVisitedStyled(Object e) {
         return _visitElements.contains(e);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
@@ -184,7 +184,24 @@ public class PrimitivePropertyBuilders {
             return BORDER_STYLES;
         }
     }
-    
+
+    private static class GenericString extends AbstractPropertyBuilder {
+        @Override
+        public List<PropertyDeclaration> buildDeclarations(CSSName cssName,
+                List<PropertyValue> values, int origin, boolean important,
+                boolean inheritAllowed) {
+            if (values.size() > 1)
+                throw new CSSParseException("Single value expected", -1);
+
+            PropertyValue value = values.get(0);
+            if (value.getPrimitiveType() == CSSPrimitiveValue.CSS_STRING)
+                return Collections.singletonList(
+                        new PropertyDeclaration(cssName, value, important, origin));
+
+            return Collections.emptyList();
+        }
+    }
+
     public static class Direction extends SingleIdent {
 		@Override
 		protected BitSet getAllowed() {
@@ -1007,6 +1024,53 @@ public class PrimitivePropertyBuilders {
         // none | create
         private static final BitSet ALLOWED = setFor(
                 new IdentValue[] { IdentValue.NONE, IdentValue.CREATE });
+
+        @Override
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
+
+    public static class FSOcId extends GenericString {
+    }
+
+    public static class FSOcgLabel extends GenericString {
+    }
+
+    public static class FSOcgVisibility extends SingleIdent {
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] {
+                        IdentValue.VISIBLE, IdentValue.HIDDEN });
+
+        @Override
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
+
+    public static class FSOcmOcgs extends AbstractPropertyBuilder {
+        @Override
+        public List<PropertyDeclaration> buildDeclarations(CSSName cssName,
+                List<PropertyValue> values, int origin, boolean important,
+                boolean inheritAllowed) {
+            if (values.isEmpty())
+                throw new CSSParseException("Undefined value (should be at least one OCG identifier)", -1);
+
+            List<PropertyDeclaration> declarations = new ArrayList<>();
+            for(PropertyValue value : values) {
+                if (value.getPrimitiveType() == CSSPrimitiveValue.CSS_STRING) {
+                    declarations.add(new PropertyDeclaration(cssName, value, important, origin));
+                }
+            }
+            return Collections.unmodifiableList(declarations);
+        }
+    }
+
+    public static class FSOcmVisible extends SingleIdent {
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] {
+                        IdentValue.ALL_HIDDEN, IdentValue.ALL_VISIBLE, IdentValue.ANY_HIDDEN,
+                        IdentValue.ANY_VISIBLE });
 
         @Override
         protected BitSet getAllowed() {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/Ruleset.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/Ruleset.java
@@ -105,4 +105,11 @@ public class Ruleset {
     public List<InvalidPropertyDeclaration> getInvalidPropertyDeclarations() {
         return _invalidProperties == null ? Collections.emptyList() : _invalidProperties;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder b=new StringBuilder();
+        toCSS(b);
+        return b.toString();
+    }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -573,7 +573,7 @@ public class CalculatedStyle {
                     throw new XRRuntimeException("Property '" + cssName + "' has no initial values assigned. " +
                             "Check CSSName declarations.");
                 }
-                if (initialValue.charAt(0) == '=') {
+                if (initialValue.length() > 0 && initialValue.charAt(0) == '=') {
                     CSSName ref = CSSName.getByPropertyName(initialValue.substring(1));
                     val = valueByName(ref);
                 } else {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -573,7 +573,7 @@ public class CalculatedStyle {
                     throw new XRRuntimeException("Property '" + cssName + "' has no initial values assigned. " +
                             "Check CSSName declarations.");
                 }
-                if (initialValue.length() > 0 && initialValue.charAt(0) == '=') {
+                if (initialValue.charAt(0) == '=') {
                     CSSName ref = CSSName.getByPropertyName(initialValue.substring(1));
                     val = valueByName(ref);
                 } else {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -231,7 +231,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
         paintBackground0(c, box.getStyle(), backgroundBounds, backgroundBounds, border);
     }
 
-    protected void onPaintBackground(RenderingContext c, CalculatedStyle style,
+    protected void onBackgroundPaint(RenderingContext c, CalculatedStyle style,
             Rectangle backgroundBounds, Rectangle bgImageContainer,
             BorderPropertySet border) {
     }
@@ -245,7 +245,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
             return;
         }
 
-        onPaintBackground(c, style, backgroundBounds, bgImageContainer, border);
+        onBackgroundPaint(c, style, backgroundBounds, bgImageContainer, border);
 
         FSColor backgroundColor = style.getBackgroundColor();
         List<BackgroundContainer> bgImages = style.getBackgroundImages();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/AbstractOutputDevice.java
@@ -231,6 +231,11 @@ public abstract class AbstractOutputDevice implements OutputDevice {
         paintBackground0(c, box.getStyle(), backgroundBounds, backgroundBounds, border);
     }
 
+    protected void onPaintBackground(RenderingContext c, CalculatedStyle style,
+            Rectangle backgroundBounds, Rectangle bgImageContainer,
+            BorderPropertySet border) {
+    }
+
     private void paintBackground0(
             RenderingContext c, CalculatedStyle style,
             Rectangle backgroundBounds, Rectangle bgImageContainer,
@@ -239,6 +244,8 @@ public abstract class AbstractOutputDevice implements OutputDevice {
         if (!style.isHasBackground()) {
             return;
         }
+
+        onPaintBackground(c, style, backgroundBounds, bgImageContainer, border);
 
         FSColor backgroundColor = style.getBackgroundColor();
         List<BackgroundContainer> bgImages = style.getBackgroundImages();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/displaylist/DisplayListPainter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/displaylist/DisplayListPainter.java
@@ -75,6 +75,9 @@ public class DisplayListPainter {
 				box.paintBackground(c);
 				box.paintBorder(c);
 
+                c.getOutputDevice().endStructure(innerToken);
+                c.getOutputDevice().endStructure(outerToken);
+
 				if (collapsedTableBorders != null && box instanceof TableCellBox) {
 					TableCellBox cell = (TableCellBox) box;
 
@@ -88,9 +91,6 @@ public class DisplayListPainter {
 						}
 					}
 				}
-
-				c.getOutputDevice().endStructure(innerToken);
-				c.getOutputDevice().endStructure(outerToken);
 			}
 		}
 	}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -144,7 +144,7 @@ public interface LogMessageId {
         GENERAL_PDF_ACCESSIBILITY_NO_TITLE_TEXT_PROVIDED_FOR(XRLog.GENERAL, "PDF/UA - No title text provided for {}."),
         GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_BOOKMARK(XRLog.GENERAL, "Could not find valid target for bookmark. Bookmark href = {}"),
         GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_LINK(XRLog.GENERAL, "Could not find valid target for link. Link href = {}"),
-        GENERAL_PDF_OCG_END(XRLog.GENERAL, "Optional content layer '{}' ended"),
+        GENERAL_PDF_LAYER_END(XRLog.GENERAL, "OC: {} END"),
         GENERAL_PDF_URI_IN_HREF_IS_NOT_A_VALID_URI(XRLog.GENERAL, "'{}' in href is not a valid URI, will be skipped"),
         GENERAL_PDF_FOUND_FORM_CONTROL_WITH_NO_ENCLOSING_FORM(XRLog.GENERAL, "Found form control ({}) with no enclosing form. Ignoring."),
         GENERAL_PDF_A_ELEMENT_DOES_NOT_HAVE_OPTION_CHILDREN(XRLog.GENERAL, "A <{}> element does not have <option> children"),
@@ -279,10 +279,10 @@ public interface LogMessageId {
                 ", parent type={}" +
                 ", expected child type={}" +
                 ". Document will not be PDF/UA compliant."),
-        GENERAL_PDF_OCG_BEGIN(XRLog.GENERAL, "Optional content layer '{}' begun (" +
+        GENERAL_PDF_LAYER_BEGIN(XRLog.GENERAL, "OC: {} BEGIN (" +
                 "box type={}" +
                 ", element={})"),
-        GENERAL_PDF_OCG_CONTINUE(XRLog.GENERAL, "Optional content layer '{}' continued (" +
+        GENERAL_PDF_LAYER_CONTINUE(XRLog.GENERAL, "OC: {} CONTINUE (" +
                 "box type={}" +
                 ", element={})"),
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -144,6 +144,7 @@ public interface LogMessageId {
         GENERAL_PDF_ACCESSIBILITY_NO_TITLE_TEXT_PROVIDED_FOR(XRLog.GENERAL, "PDF/UA - No title text provided for {}."),
         GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_BOOKMARK(XRLog.GENERAL, "Could not find valid target for bookmark. Bookmark href = {}"),
         GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_LINK(XRLog.GENERAL, "Could not find valid target for link. Link href = {}"),
+        GENERAL_PDF_OCG_END(XRLog.GENERAL, "Optional content layer '{}' ended"),
         GENERAL_PDF_URI_IN_HREF_IS_NOT_A_VALID_URI(XRLog.GENERAL, "'{}' in href is not a valid URI, will be skipped"),
         GENERAL_PDF_FOUND_FORM_CONTROL_WITH_NO_ENCLOSING_FORM(XRLog.GENERAL, "Found form control ({}) with no enclosing form. Ignoring."),
         GENERAL_PDF_A_ELEMENT_DOES_NOT_HAVE_OPTION_CHILDREN(XRLog.GENERAL, "A <{}> element does not have <option> children"),
@@ -278,6 +279,12 @@ public interface LogMessageId {
                 ", parent type={}" +
                 ", expected child type={}" +
                 ". Document will not be PDF/UA compliant."),
+        GENERAL_PDF_OCG_BEGIN(XRLog.GENERAL, "Optional content layer '{}' begun (" +
+                "box type={}" +
+                ", element={})"),
+        GENERAL_PDF_OCG_CONTINUE(XRLog.GENERAL, "Optional content layer '{}' continued (" +
+                "box type={}" +
+                ", element={})"),
 
         EXCEPTION_URI_WITH_BASE_URI_INVALID(XRLog.EXCEPTION, "When trying to load uri({}) with base {} URI({}), one or both were invalid URIs."),
         EXCEPTION_SVG_SCRIPT_NOT_ALLOWED(XRLog.EXCEPTION, "Tried to run script inside SVG. Refusing. Details: {}, {}, {}");

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -587,11 +587,11 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
             {
                 CalculatedStyle style = box.getStyle();
                 layerIdObj = style.valueByName(CSSName.FS_OCG_ID);
-                if(layerIdObj == null) {
+                if(layerIdObj.isIdent()) {
                     layerIdObj = style.valueByName(CSSName.FS_OCM_ID);
                 }
             }
-            return layerIdObj != null ? getLayer(layerIdObj.asString()) : null;
+            return !layerIdObj.isIdent() ? getLayer(layerIdObj.asString()) : null;
         }
 
         private static IdentValue getPropertyValue(Map<CSSName, PropertyDeclaration> properties, CSSName propertyName) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -102,7 +102,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
     }
 
     /**
-     * Optional content manager [PDF:1.7:8.11].
+     * Optional content manager [ISO:32000-1:8.11].
      *
      * <p>Optional content rendering is CSS-driven. In the source HTML document, each content
      * fragment can be marked by a CSS class defining a <b>layer</b> through the following
@@ -248,7 +248,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
         /**
          * Layer fragment.
          */
-        private static class StackLayer {
+        private static final class StackLayer {
             public final PDPropertyList base;
             /**
              * Whether this layer fragment is at block level.
@@ -395,8 +395,8 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
          */
         public void onStructureEnd() {
             /*
-             * NOTE: As recommended by the PDF spec [PDF:1.7:8.11.3.2], layer fragments SHOULD be
-             * nested inside other marked content; therefore, if PDF/UA is active, current layer
+             * NOTE: As recommended by the PDF spec [ISO:32000-1:8.11.3.2], layer fragments SHOULD
+             * be nested inside other marked content; therefore, if PDF/UA is active, current layer
              * fragments are immediately ended. Otherwise, layer fragments can continue across
              * contiguous inline boxes only; on the contrary, layer fragments at block level are
              * always immediately ended, because block-painting operations may be intermingled with
@@ -422,9 +422,9 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
          */
         public void onStructureStart(StructureType type, Box box) {
             /*-
-             * NOTE: For optional content [PDF:1.7:8.11.3.2], to avoid conflict with other features
-             * that used marked content (such as logical structure), the following strategy is
-             * recommended:
+             * NOTE: For optional content [ISO:32000-1:8.11.3.2], to avoid conflict with other
+             * features that used marked content (such as logical structure), the following strategy
+             * is recommended:
              * - where content is to be tagged with optional content markers as well as other
              *   markers, the optional content markers should be nested INSIDE the other marked
              *   content.

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfContentStreamAdapter.java
@@ -356,8 +356,12 @@ public class PdfContentStreamAdapter {
     }
     
     public void beginMarkedContent(COSName tag, COSDictionary dict) {
+        beginMarkedContent(tag, PDPropertyList.create(dict));
+    }
+
+    public void beginMarkedContent(COSName tag, PDPropertyList propertyList) {
         try {
-            cs.beginMarkedContent(tag, PDPropertyList.create(dict));
+            cs.beginMarkedContent(tag, propertyList);
         } catch (IOException e) {
             logAndThrow("beginMarkedContent", e);
         }


### PR DESCRIPTION
This is an implementation of the missing Optional Content / PDF Layers functionality (#712).

In order to introduce the support to layers, I tried to leverage the existing code base as much as possible:

- on input, the inclusion of HTML contents into layers is defined via **non-inheritable extension CSS properties** (<code>-fs-ocg-&ast;</code> for contents belonging to optional content groups and <code>-fs-ocm-&ast;</code> for contents belonging to optional content memberships).
NOTE: An alternative implementation could decouple these definitions from common rulesets to extension at-rules (<code>@-fs-ocg</code> for optional content groups and <code>@-fs-ocm</code> for optional content memberships), achieving a bit tidier stylesheets at the cost of dedicated structures beside existing standard at-rules (such as <code>@font-face</code> and <code>@import</code> rules) in <code>com.openhtmltopdf.css.sheet.Stylesheet</code>.

- on output, during page painting, existing **tagging calls** (see <code>PdfBoxFastOutputDevice.startStructure(..)</code> and <code>endStructure(..)</code>) are intercepted, because of their semantically-compatible granularity, to inject layers inside the content stream. To avoid ghost layer fragments (not all tagging calls wrap actual contents!), layer injection is lazily applied on actual content painting calls.

Layer types:

- simple layer (aka **group**):

    - identity (<code>-fs-ocg-id</code>), which is used for reference (as parent of other groups or member of memberships).
 
    - label (<code>-fs-ocg-label</code>), which maps to <code>PDOptionalContentGroup.getName()</code> (see <code>Name</code> entry in the Optional Content Group dictionary) and is displayed in the viewer's layer tree.
    
    - visibility (<code>-fs-ocg-visibility={visible|hidden}</code>), which maps to <code>PDOptionalContentProperties.isGroupEnabled(..)</code> (see <code>BaseState</code>, <code>ON</code>, <code>OFF</code> entries of <code>D</code> entry of the document's Optional Content Configuration dictionary).
        
    - parent (<code>-fs-ocg-parent={%ocg-id%}</code>), which maps to <code>Order</code> entry of <code>D</code> entry of the document's Optional Content Configuration dictionary for nesting into the viewer's layer tree -- unfortunately, arbitrary nesting seems not to be natively supported by currently-used PDFBox version (2.0), as adding a group via <code>PDOptionalContentProperties.addGroup(..)</code> automatically builds a flat list inside <code>Order</code> entry instead.

- compound layer (aka **membership**):

    - identity (<code>-fs-ocm-id</code>), which is used for internal reference.

    - visibility policy (<code>-fs-ocm-visible={all-visible|all-hidden|any-visible|any-hidden}</code>), which maps to <code>PDOptionalContentMembershipDictionary.getVisibilityPolicy()</code> (see <code>P</code> entry of Optional Content Membership dictionary).
        
    - members (<code>-fs-ocm-ocgs={%ocg-id%...}</code>), which map to <code>PDOptionalContentMembershipDictionary.getOCGs()</code> (see <code>OCGs</code> entry of Optional Content Membership dictionary).

For the sake of consistency, *each content inherits the full layer hierarchy of its ancestor nodes*. For example,

```
<div class="ocg2">
    <p class="ocg1">This is a layered block inside another layered block (OCG 2/OCG 1).</p>
</div>
```

that paragraph element is rendered in the following way inside the content stream (NOTE: layer resource name assignment is an implementation detail internal to the PDF library (PDFBox); for clarity, here we assume that `/oc2` maps to layer `ocg2` and `/oc1` maps to layer `ocg1`):

```
/OC /oc2 BDC
/OC /oc1 BDC
. . .
(This is a layered content block inside another layered block \(OCG 2/OCG 1\)) Tj
. . .
EMC
EMC
```