### PR TITLE
Adding JPEG autorotation

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -30,7 +30,7 @@ public interface LogMessageId {
         LAYOUT_ERROR_PARSING_SHAPE_COORDS(XRLog.LAYOUT, "Error while parsing shape coords"),
         LAYOUT_NO_CONTENT_LIMIT_FOUND(XRLog.LAYOUT, "No content limit found"),
         LAYOUT_BOX_HAS_NO_PAGE(XRLog.LAYOUT, "Box has no page"),
-        LAYOUT_NO_INLINE_LAYERS(XRLog.LAYOUT, "Boxes with display: inline can not be positioned or transformed, try using inline-block"),
+		LAYOUT_NO_INLINE_LAYERS(XRLog.LAYOUT, "Boxes with display: inline can not be positioned or transformed, try using inline-block"),
 
         CASCADE_IS_ABSOLUTE_CSS_UNKNOWN_GIVEN(XRLog.CASCADE, "Asked whether type was absolute, given CSS_UNKNOWN as the type. " +
                 "Might be one of those funny values like background-position."),
@@ -47,6 +47,7 @@ public interface LogMessageId {
         GENERAL_PDF_USING_GET_REQUEST_FOR_FORM(XRLog.GENERAL, "Using GET request method for form. You probably meant to add a method=\"post\" attribute to your form"),
         GENERAL_PDF_ACROBAT_READER_DOES_NOT_SUPPORT_FORMS_WITH_FILE_INPUT(XRLog.GENERAL, "Acrobat Reader does not support forms with file input controls"),
 
+        EXCEPTION_IMAGE_METADATA_COULD_NOT_BE_FOUND(XRLog.EXCEPTION, "Image metadata could not be found."),
         EXCEPTION_SVG_COULD_NOT_DRAW(XRLog.EXCEPTION, "Couldn't draw SVG."),
         EXCEPTION_SVG_COULD_NOT_READ_FONT(XRLog.EXCEPTION, "Couldn't read font"),
         EXCEPTION_MATHML_COULD_NOT_REGISTER_FONT(XRLog.EXCEPTION, "Could not register font correctly"),

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -30,7 +30,7 @@ public interface LogMessageId {
         LAYOUT_ERROR_PARSING_SHAPE_COORDS(XRLog.LAYOUT, "Error while parsing shape coords"),
         LAYOUT_NO_CONTENT_LIMIT_FOUND(XRLog.LAYOUT, "No content limit found"),
         LAYOUT_BOX_HAS_NO_PAGE(XRLog.LAYOUT, "Box has no page"),
-		LAYOUT_NO_INLINE_LAYERS(XRLog.LAYOUT, "Boxes with display: inline can not be positioned or transformed, try using inline-block"),
+        LAYOUT_NO_INLINE_LAYERS(XRLog.LAYOUT, "Boxes with display: inline can not be positioned or transformed, try using inline-block"),
 
         CASCADE_IS_ABSOLUTE_CSS_UNKNOWN_GIVEN(XRLog.CASCADE, "Asked whether type was absolute, given CSS_UNKNOWN as the type. " +
                 "Might be one of those funny values like background-position."),

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -47,7 +47,7 @@
   </distributionManagement>
 
   <profiles>
-  <profile>
+    <profile>
       <id>release</id>
       <build>
         <plugins>

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -47,7 +47,7 @@
   </distributionManagement>
 
   <profiles>
-    <profile>
+  <profile>
       <id>release</id>
       <build>
         <plugins>
@@ -102,6 +102,11 @@
 		  <artifactId>graphics2d</artifactId>
 		  <version>0.34</version>
 	  </dependency>
+     <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-imaging</artifactId>
+       <version>1.0-alpha3</version>
+     </dependency>     
   </dependencies>
 
   <build>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
@@ -112,7 +112,7 @@ public class PdfBoxImage implements FSImage {
 
             if (height == -1 && _intrinsicWidth != 0) {
                 // Use the width ratio to set the height.
-                setHeight = (int) (((float) setWidth / (float) _intrinsicWidth) * _intrinsicHeight);
+                setHeight = (int) ((setWidth / _intrinsicWidth) * _intrinsicHeight);
             } else {
                 setHeight = height;
             }
@@ -121,7 +121,7 @@ public class PdfBoxImage implements FSImage {
 
             if (_intrinsicHeight != 0) {
                 // Use the height ratio to set the width.
-                setWidth = (int) (((float) setHeight / (float) _intrinsicHeight) * _intrinsicWidth);
+                setWidth = (int) ((setHeight / _intrinsicHeight) * _intrinsicWidth);
             } else {
                 setWidth = 0;
             }
@@ -196,7 +196,7 @@ public class PdfBoxImage implements FSImage {
         BufferedImage rimg;
 
         // Create a rotated image buffer and establish the center of rotation 
-		// from the rotation angle.
+        // from the rotation angle.
         switch (angle) {
             case 90:
                 rimg = new BufferedImage(ih, iw, img.getType());

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxImage.java
@@ -1,6 +1,10 @@
 package com.openhtmltopdf.pdfboxout;
 
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.logging.Level;
@@ -10,6 +14,12 @@ import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
 import com.openhtmltopdf.util.LogMessageId;
+import org.apache.commons.imaging.ImageReadException;
+import org.apache.commons.imaging.Imaging;
+import org.apache.commons.imaging.common.ImageMetadata;
+import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
+import org.apache.commons.imaging.formats.tiff.TiffField;
+import org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 
 import com.openhtmltopdf.extend.FSImage;
@@ -36,16 +46,28 @@ public class PdfBoxImage implements FSImage {
             if (readers.hasNext()) {
                 reader = readers.next();
                 reader.setInput(in);
-                _intrinsicWidth = reader.getWidth(0);
-                _intrinsicHeight = reader.getHeight(0);
+                
+                int rotation = getImageRotation(image);
+                if (rotation != 0) {
+                    BufferedImage newimg = rotateImage(reader.read(0), rotation);
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    ImageIO.write(newimg, "jpg", baos);
+                    _bytes = baos.toByteArray();
+                    _intrinsicWidth = newimg.getWidth();
+                    _intrinsicHeight = newimg.getHeight();
+                } else {
+                    _intrinsicWidth = reader.getWidth(0);
+                    _intrinsicHeight = reader.getHeight(0);
+                }
             } else {
                 XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_UNRECOGNIZED_IMAGE_FORMAT_FOR_URI, uri);
                 // TODO: Avoid throw here.
                 throw new IOException("Unrecognized Image format");
             }
         } finally {
-            if (reader != null)
+            if (reader != null) {
                 reader.dispose();
+            }
         }
     }
 
@@ -90,7 +112,7 @@ public class PdfBoxImage implements FSImage {
 
             if (height == -1 && _intrinsicWidth != 0) {
                 // Use the width ratio to set the height.
-                setHeight = (int) ((setWidth / _intrinsicWidth) * _intrinsicHeight);
+                setHeight = (int) (((float) setWidth / (float) _intrinsicWidth) * _intrinsicHeight);
             } else {
                 setHeight = height;
             }
@@ -99,7 +121,7 @@ public class PdfBoxImage implements FSImage {
 
             if (_intrinsicHeight != 0) {
                 // Use the height ratio to set the width.
-                setWidth = (int) ((setHeight / _intrinsicHeight) * _intrinsicWidth);
+                setWidth = (int) (((float) setHeight / (float) _intrinsicHeight) * _intrinsicWidth);
             } else {
                 setWidth = 0;
             }
@@ -132,4 +154,77 @@ public class PdfBoxImage implements FSImage {
     public String getUri() {
         return _uri;
     }
+    
+    private int getImageRotation( byte[] image ) {
+        // Get image rotation from the metadata
+        int rotation = 0;
+
+        final ImageMetadata metadata;
+        try {
+            metadata = Imaging.getMetadata(image);
+            if (metadata instanceof JpegImageMetadata) {
+                final JpegImageMetadata jpegMetadata = (JpegImageMetadata) metadata;
+                TiffField orientation = jpegMetadata.findEXIFValueWithExactMatch(TiffTagConstants.TIFF_TAG_ORIENTATION);
+                if (orientation != null) {
+                    switch ((Short) orientation.getValue()) {
+                        case TiffTagConstants.ORIENTATION_VALUE_ROTATE_180:
+                            rotation = 180;
+                            break;
+                        case TiffTagConstants.ORIENTATION_VALUE_ROTATE_270_CW:
+                            rotation = 270;
+                            break;
+                        case TiffTagConstants.ORIENTATION_VALUE_ROTATE_90_CW:
+                            rotation = 90;
+                            break;
+                        default:
+                            // No need.  We default the setting to 0...
+                            break;
+                    }
+                }
+            }
+        } catch (ImageReadException | IOException ex) {
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_IMAGE_METADATA_COULD_NOT_BE_FOUND, ex);            
+        }
+        
+        return rotation;
+    }
+
+    private static BufferedImage rotateImage(BufferedImage img, int angle) {  
+        int iw = img.getWidth();  
+        int ih = img.getHeight();
+        int rotx, roty;
+        BufferedImage rimg;
+
+        // Create a rotated image buffer and establish the center of rotation 
+		// from the rotation angle.
+        switch (angle) {
+            case 90:
+                rimg = new BufferedImage(ih, iw, img.getType());
+                rotx = roty = ih/2;
+                break;
+            case 180:
+                rimg = new BufferedImage(iw, ih, img.getType());
+                rotx = iw/2;
+                roty = ih/2;
+                break;
+            case 270:
+                rimg = new BufferedImage(ih, iw, img.getType());
+                rotx = roty = iw/2;
+                break;
+            default: 
+                // Any other angle: take no action
+                return img;
+        }
+        
+        // Perform the rotation by drawing a rotated version of the original
+        // image into the new (rotated) image buffer.
+        Graphics2D g2d = rimg.createGraphics();
+        AffineTransform transformer = new AffineTransform();
+        transformer.rotate(Math.toRadians(angle), rotx, roty);
+        g2d.drawRenderedImage(img, transformer);
+        g2d.dispose();
+        
+        return rimg;  
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <debug>false</debug>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,6 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
-          <debug>false</debug>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This change adds automatic image rotation for JPEG images with orientation EXIF data.

Almost all cell phone cameras store the image data in an un-rotated state, and write EXIF data to indicate "which side should be up".  All modern browsers understand these EXIF tags and automatically orient the image correctly.  Thus, when the pictures are viewed in a web page they appear correct.  When the page is output to PDF, however, the image is rotated.

This change modifies the pdfboximage class to read the EXIF data (if it exists) and rotate the image data if necessary.  This results in a "rotate on load" behavior (i.e. before the resource cache), so the rotation only needs to be done once, even if the image appears multiple times in the document.

This change utilizes the apache-commons imaging library (which is currently in alpha-3) to read the EXIF data.  

Please go easy on me.  This is my first pull request.  Let me know if I've done something incorrectly, and I'll do my best to comply.