### PR TITLE
Update batik and xmlgraphics-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,10 +214,10 @@
   </build>
 
   <properties>
-    <open.batik.version>1.14</open.batik.version>
+    <open.batik.version>1.16</open.batik.version>
 
     <!-- Please keep xmlgraphics-commons up to date with batik. -->
-    <open.xmlgraphics.commons.version>2.6</open.xmlgraphics.commons.version>
+    <open.xmlgraphics.commons.version>2.7</open.xmlgraphics.commons.version>
 
     <!-- NOTE: Rhino is an optional dependency of Batik-Bridge. This version should match
          the version specified by Batik-Bridge. -->


### PR DESCRIPTION
Fixes
- CVE-2022-42890 A vulnerability in Batik of Apache XML Graphics allows an attacker to run Java code from untrusted SVG via JavaScript. This issue affects Apache XML Graphics prior to 1.16. Users are recommended to upgrade to version 1.16.
- CVE-2022-41704 A vulnerability in Batik of Apache XML Graphics allows an attacker to run untrusted Java code from an SVG. This issue affects Apache XML Graphics prior to 1.16. It is recommended to update to version 1.16.
- CVE-2022-40146 Server-Side Request Forgery (SSRF) vulnerability in Batik of Apache XML Graphics allows an attacker to access files using a Jar url. This issue affects Apache XML Graphics Batik 1.14.
- CVE-2022-38648 Server-Side Request Forgery (SSRF) vulnerability in Batik of Apache XML Graphics allows an attacker to fetch external resources. This issue affects Apache XML Graphics Batik 1.14.
- CVE-2022-38398 Server-Side Request Forgery (SSRF) vulnerability in Batik of Apache XML Graphics allows an attacker to load a url thru the jar protocol. This issue affects Apache XML Graphics Batik 1.14.