### PR TITLE
Forms on multi page pdfs

### DIFF
--- a/openhtmltopdf-examples/src/main/resources/testcases/form-controls.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/form-controls.html
@@ -4,6 +4,7 @@
 input { color: orange; font-family: monospace; }
 textarea { color: red; font-family: monospace;  }
 button { color: blue; font-family: monospace; border-radius: 8px; background-color: yellow; }
+input[name="signature"] { color: green; }
 </style>
 </head>
 <body>
@@ -20,6 +21,7 @@ button { color: blue; font-family: monospace; border-radius: 8px; background-col
  <input type="submit" value="GO!"/>
  <button type="submit">SUBMIT</button>
  <input type="password" name="notvery" value="secret"/>
+ <input type="text" name="signature" class="signature"/>
  
  <div>
   <input type="checkbox" name="checker1" value="1" checked="" style="-fs-checkbox-style: check;" />

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/form-control-on-second-page.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/form-control-on-second-page.pdf
@@ -1,0 +1,316 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+/AcroForm 3 0 R
+>>
+endobj
+4 0 obj
+<<
+/CreationDate (D:20230228111156+01'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [5 0 R 6 0 R 7 0 R]
+/Count 3
+>>
+endobj
+3 0 obj
+<<
+/Fields [8 0 R 9 0 R]
+/NeedAppearances true
+/DR 10 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 150.0 75.0]
+/Parent 2 0 R
+/Contents 11 0 R
+/Resources 12 0 R
+/Annots [8 0 R]
+>>
+endobj
+6 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 150.0 75.0]
+/Parent 2 0 R
+/Contents 13 0 R
+/Resources 14 0 R
+/Annots [9 0 R]
+>>
+endobj
+7 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 150.0 75.0]
+/Parent 2 0 R
+/Contents 15 0 R
+/Resources 16 0 R
+>>
+endobj
+8 0 obj
+<<
+/FT /Tx
+/T (text-input)
+/DA (/OpenHTMLFont0 0 Tf 0.0000 0.0000 0.0000 rg)
+/DV (Hello World!)
+/V (Hello World!)
+/Type /Annot
+/Subtype /Widget
+/Rect [7.5 16.574997 127.65 54.074997]
+/P 5 0 R
+/F 4
+>>
+endobj
+9 0 obj
+<<
+/FT /Tx
+/T (text-input2)
+/DA (/OpenHTMLFont0 0 Tf 0.0000 0.0000 0.0000 rg)
+/DV (Hello Second World!)
+/V (Hello Second World!)
+/Type /Annot
+/Subtype /Widget
+/Rect [7.5 16.574997 127.65 54.074997]
+/P 6 0 R
+/F 4
+>>
+endobj
+10 0 obj
+<<
+/Font 17 0 R
+>>
+endobj
+11 0 obj
+<<
+/Length 531
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+3.75 71.25 m
+146.25 71.25 l
+146.25 3.7875 l
+3.75 3.7875 l
+3.75 71.25 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 12 Tf
+1 0 0 1 3.75 60.4875 Tm
+(Text) Tj
+ET
+1 1 1 rg
+4.5 57.075 m
+4.5 13.575 l
+130.65001 13.575 l
+130.65001 57.075 l
+h
+f
+1 0 0 rg
+3.75 57.825 m
+131.40001 57.825 l
+130.65001 57.075 l
+4.5 57.075 l
+h
+f
+131.40001 12.825 m
+3.75 12.825 l
+4.5 13.575 l
+130.65001 13.575 l
+h
+f
+3.75 12.825 m
+3.75 57.825 l
+4.5 57.075 l
+4.5 13.575 l
+h
+f
+131.40001 57.825 m
+131.40001 12.825 l
+130.65001 13.575 l
+130.65001 57.075 l
+h
+f
+Q
+
+endstream
+endobj
+12 0 obj
+<<
+/Font 18 0 R
+>>
+endobj
+13 0 obj
+<<
+/Length 537
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+3.75 71.25 m
+146.25 71.25 l
+146.25 3.7875 l
+3.75 3.7875 l
+3.75 71.25 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 12 Tf
+1 0 0 1 3.75 60.4875 Tm
+(Text) Tj
+ET
+1 1 1 rg
+4.5 57.075 m
+4.5 13.575 l
+130.65001 13.575 l
+130.65001 57.075 l
+h
+f
+0 0.50196 0 rg
+3.75 57.825 m
+131.40001 57.825 l
+130.65001 57.075 l
+4.5 57.075 l
+h
+f
+131.40001 12.825 m
+3.75 12.825 l
+4.5 13.575 l
+130.65001 13.575 l
+h
+f
+3.75 12.825 m
+3.75 57.825 l
+4.5 57.075 l
+4.5 13.575 l
+h
+f
+131.40001 57.825 m
+131.40001 12.825 l
+130.65001 13.575 l
+130.65001 57.075 l
+h
+f
+Q
+
+endstream
+endobj
+14 0 obj
+<<
+/Font 19 0 R
+>>
+endobj
+15 0 obj
+<<
+/Length 110
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+3.75 71.25 m
+146.25 71.25 l
+146.25 3.7875 l
+3.75 3.7875 l
+3.75 71.25 l
+h
+W
+n
+Q
+
+endstream
+endobj
+16 0 obj
+<<
+>>
+endobj
+17 0 obj
+<<
+/OpenHTMLFont0 20 0 R
+>>
+endobj
+18 0 obj
+<<
+/F1 21 0 R
+>>
+endobj
+19 0 obj
+<<
+/F1 21 0 R
+>>
+endobj
+20 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+21 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 22
+0000000000 65535 f
+0000000015 00000 n
+0000000185 00000 n
+0000000254 00000 n
+0000000094 00000 n
+0000000330 00000 n
+0000000459 00000 n
+0000000588 00000 n
+0000000701 00000 n
+0000000916 00000 n
+0000001146 00000 n
+0000001181 00000 n
+0000001766 00000 n
+0000001801 00000 n
+0000002392 00000 n
+0000002427 00000 n
+0000002591 00000 n
+0000002613 00000 n
+0000002657 00000 n
+0000002690 00000 n
+0000002723 00000 n
+0000002821 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 4 0 R
+/ID [<927F70E72CF00F931757EA194AF01758> <927F70E72CF00F931757EA194AF01758>]
+/Size 22
+>>
+startxref
+2921
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/expected/form-signature-field.pdf
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/expected/form-signature-field.pdf
@@ -1,0 +1,207 @@
+%PDF-1.4
+%öäüß
+1 0 obj
+<<
+/Type /Catalog
+/Version /1.7
+/Pages 2 0 R
+/AcroForm 3 0 R
+>>
+endobj
+4 0 obj
+<<
+/CreationDate (D:20230215161630+01'00')
+/Producer (openhtmltopdf.com)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [5 0 R]
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Fields [6 0 R 7 0 R]
+/NeedAppearances true
+/DR 8 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/MediaBox [0.0 0.0 375.0 187.5]
+/Parent 2 0 R
+/Contents 9 0 R
+/Resources 10 0 R
+/Annots [7 0 R 6 0 R]
+>>
+endobj
+6 0 obj
+<<
+/FT /Sig
+/Type /Annot
+/Subtype /Widget
+/F 132
+/T (another-signature)
+/TU (Alternate Field Name)
+/Rect [18.0 117.2625 318.0 142.3125]
+/P 5 0 R
+>>
+endobj
+7 0 obj
+<<
+/FT /Sig
+/Type /Annot
+/Subtype /Widget
+/F 132
+/T (signature1)
+/Ff 2
+/Rect [100.275 150.7125 200.4 168.75]
+/P 5 0 R
+>>
+endobj
+8 0 obj
+<<
+/Font 11 0 R
+>>
+endobj
+9 0 obj
+<<
+/Length 798
+>>
+stream
+0.0375 w
+2 J
+0 j
+10 M
+[] 0 d
+q
+15 172.5 m
+360 172.5 l
+360 15.03749 l
+15 15.03749 l
+15 172.5 l
+h
+W
+n
+0 0 0 rg
+BT
+/F1 7.5 Tf
+1 0 0 1 15 146.96249 Tm
+(Required signature please: ) Tj
+ET
+1 1 1 rg
+97.275 171.75 m
+97.275 147.71249 l
+203.40001 147.71249 l
+203.40001 171.75 l
+h
+f
+0 0 0 rg
+96.525 172.5 m
+204.15001 172.5 l
+203.40001 171.75 l
+97.275 171.75 l
+h
+f
+204.15001 146.96249 m
+96.525 146.96249 l
+97.275 147.71249 l
+203.40001 147.71249 l
+h
+f
+96.525 146.96249 m
+96.525 172.5 l
+97.275 171.75 l
+97.275 147.71249 l
+h
+f
+204.15001 172.5 m
+204.15001 146.96249 l
+203.40001 147.71249 l
+203.40001 171.75 l
+h
+f
+1 1 1 rg
+15 145.3125 m
+15 114.2625 l
+321 114.2625 l
+321 145.3125 l
+h
+f
+0 0 0 rg
+321 113.5125 m
+15 113.5125 l
+15 114.2625 l
+321 114.2625 l
+h
+f
+BT
+/F1 7.5 Tf
+1 0 0 1 15 105.1125 Tm
+(Another one) Tj
+ET
+Q
+
+endstream
+endobj
+10 0 obj
+<<
+/Font 12 0 R
+>>
+endobj
+11 0 obj
+<<
+/OpenHTMLFont0 13 0 R
+>>
+endobj
+12 0 obj
+<<
+/F1 14 0 R
+>>
+endobj
+13 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+14 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 15
+0000000000 65535 f
+0000000015 00000 n
+0000000185 00000 n
+0000000242 00000 n
+0000000094 00000 n
+0000000317 00000 n
+0000000452 00000 n
+0000000615 00000 n
+0000000751 00000 n
+0000000785 00000 n
+0000001636 00000 n
+0000001671 00000 n
+0000001715 00000 n
+0000001748 00000 n
+0000001846 00000 n
+trailer
+<<
+/Root 1 0 R
+/Info 4 0 R
+/ID [<875971F50C1C1739AF62CC6B6F637FE9> <875971F50C1C1739AF62CC6B6F637FE9>]
+/Size 15
+>>
+startxref
+1946
+%%EOF

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/form-control-on-second-page.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/form-control-on-second-page.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+<style>
+@page {
+  size: 200px 100px;
+  margin: 5px;
+}
+body {
+  margin: 0;
+}
+input {
+  width: 12em;
+  height: 50px;
+}
+</style>
+</head>
+<body>
+  <form>
+      <div>Text</div>
+      <input type="text" name="text-input" value="Hello World!" style="border: 1px solid red;" />
+      <div>Text</div>
+      <input type="text" name="text-input2" value="Hello Second World!" style="border: 1px solid green;" />
+  </form>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/form-signature-field.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/form-signature-field.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+    <style>
+        @page {
+            size: 500px 250px;
+            margin:0;padding:20px;
+        }
+        body {margin:0;padding:0;font-size:10px; font-famliy: TestFont, serif, sans-serif; }
+        div {border: 0px}
+        input[name="signature"] {
+            height: 80px;
+            width: 150px;
+            border: 0;
+            background-color: lightgrey;
+        }
+        input[name="another-signature"] {
+            width: 400px;
+            height: 2.5em;
+            border: 0;
+            border-bottom: 1px solid black;
+        }
+    </style>
+</head>
+
+<body>
+<div>
+    <form>
+        <div>
+            Required signature please:
+            <input type="text" name="signature1" required="required" class="signature"/>
+        </div>
+        <div>
+
+            <input type="text" name="another-signature" title="Alternate Field Name" alt="Partial Nameeee" class="signature"/>
+            <div>Another one</div>
+        </div>
+
+    </form>
+</div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1492,6 +1492,11 @@ public class VisualRegressionTest {
         assertTrue(vt.runTest("issue-792-target-counter-style"));
     }
 
+    @Test
+    public void testSignatureField() throws IOException {
+        assertTrue(vt.runTest("form-signature-field"));
+    }
+
     // TODO:
     // + Elements that appear just on generated overflow pages.
     // + content property (page counters, etc)

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/visualregressiontests/VisualRegressionTest.java
@@ -1496,6 +1496,10 @@ public class VisualRegressionTest {
     public void testSignatureField() throws IOException {
         assertTrue(vt.runTest("form-signature-field"));
     }
+    @Test
+    public void testFormFieldOnSecondPage() throws IOException {
+        assertTrue(vt.runTest("form-control-on-second-page"));
+    }
 
     // TODO:
     // + Elements that appear just on generated overflow pages.

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/DOMUtil.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/DOMUtil.java
@@ -21,7 +21,9 @@ package com.openhtmltopdf.pdfboxout;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -31,7 +33,7 @@ public class DOMUtil {
         for (int i = 0; i < children.getLength(); i++) {
             Node n = children.item(i);
             if (n.getNodeType() == Node.ELEMENT_NODE) {
-                Element elem = (Element)n;
+                Element elem = (Element) n;
                 if (elem.getTagName().equals(name)) {
                     return elem;
                 }
@@ -39,14 +41,14 @@ public class DOMUtil {
         }
         return null;
     }
-    
+
     public static List<Element> getChildren(Element parent, String name) {
         List<Element> result = new ArrayList<>();
         NodeList children = parent.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             Node n = children.item(i);
             if (n.getNodeType() == Node.ELEMENT_NODE) {
-                Element elem = (Element)n;
+                Element elem = (Element) n;
                 if (elem.getTagName().equals(name)) {
                     result.add(elem);
                 }
@@ -54,7 +56,7 @@ public class DOMUtil {
         }
         return result.size() == 0 ? null : result;
     }
-    
+
     /**
      * Helper function to find an enclosing element with given node name. Returns null on failure.
      */
@@ -62,14 +64,14 @@ public class DOMUtil {
         Node parent;
         while ((parent = e.getParentNode()) != null) {
             if (parent.getNodeType() == Node.ELEMENT_NODE &&
-                parent.getNodeName().equals(nodeName)) {
+                    parent.getNodeName().equals(nodeName)) {
                 return (Element) parent;
             }
             e = parent;
         }
         return null;
     }
-    
+
     /**
      * Loads all of the text content in all offspring of an element.
      * Ignores all attributes, comments and processing instructions.
@@ -77,11 +79,11 @@ public class DOMUtil {
      * @return a String with the text content of an element (may be an empty string but will not be null).
      */
     public static String getText(Element parent) {
-    	StringBuilder sb = new StringBuilder();
-    	getText(parent, sb);
+        StringBuilder sb = new StringBuilder();
+        getText(parent, sb);
         return sb.toString();
     }
-    
+
     /**
      * Appends all text content in all offspring of an element to a StringBuffer.
      * Ignores all attributes, comments and processing instructions.
@@ -93,10 +95,28 @@ public class DOMUtil {
         for (int i = 0; i < children.getLength(); i++) {
             Node n = children.item(i);
             if (n.getNodeType() == Node.ELEMENT_NODE) {
-            	getText((Element)n, sb);
+                getText((Element) n, sb);
             } else if (n.getNodeType() == Node.TEXT_NODE) {
                 sb.append(n.getNodeValue());
             }
         }
+    }
+
+    public static String toDebugInfo(Element element) {
+        if (element == null)
+            return "null";
+        StringBuilder elementString = new StringBuilder();
+        elementString.append('<');
+        elementString.append(element.getNodeName());
+        NamedNodeMap attributes = element.getAttributes();
+        for (int i = 0; i < attributes.getLength(); i++) {
+            Node attribute = attributes.item(i);
+            elementString.append(' ');
+            elementString.append(attribute.getNodeName());
+            elementString.append("=\"");
+            elementString.append(attribute.getNodeValue());
+            elementString.append('"');
+        }
+        return elementString.toString();
     }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -9,6 +9,7 @@ import com.openhtmltopdf.pdfboxout.quads.KongAlgo;
 import com.openhtmltopdf.pdfboxout.quads.Triangle;
 import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.Box;
+import com.openhtmltopdf.render.PageBox;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.render.displaylist.PagedBoxCollector;
 import com.openhtmltopdf.util.LogMessageId;
@@ -46,12 +47,12 @@ import java.util.logging.Level;
 
 public class PdfBoxFastLinkManager {
 
-	private final Map<PDPage, Set<String>> _linkTargetAreas;
-	private final SharedContext _sharedContext;
-	private final float _dotsPerPoint;
-	private final Box _root;
-	private final PdfBoxFastOutputDevice _od;
-	private final List<LinkDetails> _links;
+    private final Map<PDPage, Set<String>> _linkTargetAreas;
+    private final SharedContext _sharedContext;
+    private final float _dotsPerPoint;
+    private final Box _root;
+    private final PdfBoxFastOutputDevice _od;
+    private final List<LinkDetails> _links;
     private PdfBoxAccessibilityHelper _pdfUa;
 
     /**
@@ -66,198 +67,198 @@ public class PdfBoxFastLinkManager {
      */
     private PDAppearanceDictionary _embeddedFileAppearance;
 
-	public PdfBoxFastLinkManager(SharedContext ctx, float dotsPerPoint, Box root, PdfBoxFastOutputDevice od) {
-		this._sharedContext = ctx;
-		this._dotsPerPoint = dotsPerPoint;
-		this._root = root;
-		this._od = od;
-		this._linkTargetAreas = new HashMap<>();
-		this._links = new ArrayList<>();
+    public PdfBoxFastLinkManager(SharedContext ctx, float dotsPerPoint, Box root, PdfBoxFastOutputDevice od) {
+        this._sharedContext = ctx;
+        this._dotsPerPoint = dotsPerPoint;
+        this._root = root;
+        this._od = od;
+        this._linkTargetAreas = new HashMap<>();
+        this._links = new ArrayList<>();
         this._embeddedFiles = new HashMap<>();
-	}
+    }
 
-	private Rectangle2D calcTotalLinkArea(RenderingContext c, Box box, float pageHeight, AffineTransform transform) {
-	    if (_pdfUa != null) {
-	        // For PDF/UA we need one link annotation per box.
-	        return createTargetArea(c, box, pageHeight, transform, _root, _od);
-	    }
-	    
-		Box current = box;
-		while (true) {
-			Box prev = current.getPreviousSibling();
-			if (prev == null || prev.getElement() != box.getElement()) {
-				break;
-			}
+    private Rectangle2D calcTotalLinkArea(RenderingContext c, Box box, float pageHeight, AffineTransform transform) {
+        if (_pdfUa != null) {
+            // For PDF/UA we need one link annotation per box.
+            return createTargetArea(c, box, pageHeight, transform, c.getPage(), _od);
+        }
 
-			current = prev;
-		}
+        Box current = box;
+        while (true) {
+            Box prev = current.getPreviousSibling();
+            if (prev == null || prev.getElement() != box.getElement()) {
+                break;
+            }
 
-		Rectangle2D result = createTargetArea(c, current, pageHeight, transform, _root, _od);
+            current = prev;
+        }
 
-		current = current.getNextSibling();
-		while (current != null && current.getElement() == box.getElement()) {
-			result = add(result, createTargetArea(c, current, pageHeight, transform, _root, _od));
+        Rectangle2D result = createTargetArea(c, current, pageHeight, transform, c.getPage(), _od);
 
-			current = current.getNextSibling();
-		}
+        current = current.getNextSibling();
+        while (current != null && current.getElement() == box.getElement()) {
+            result = add(result, createTargetArea(c, current, pageHeight, transform, c.getPage(), _od));
 
-		return result;
-	}
+            current = current.getNextSibling();
+        }
 
-	private Rectangle2D add(Rectangle2D r1, Rectangle2D r2) {
-		return r1.createUnion(r2);
-	}
+        return result;
+    }
 
-	private String createRectKey(Rectangle2D rect, Shape linkShape, AffineTransform transform) {
-		StringBuilder key = new StringBuilder(
-				rect.getMinX() + ":" + rect.getMaxY() + ":" + rect.getMaxX() + ":" + rect.getMinY());
-		if (linkShape != null) {
-			PathIterator pathIterator = linkShape.getPathIterator(transform);
-			double[] vals = new double[6];
-			while (!pathIterator.isDone()) {
-				int type = pathIterator.currentSegment(vals);
-				switch (type) {
-				case PathIterator.SEG_CUBICTO:
-					key.append("C");
-					key.append(vals[0]).append(":").append(vals[1]).append(":").append(vals[2]).append(":")
-							.append(vals[3]).append(":").append(vals[4]).append(":").append(vals[5]);
-					break;
-				case PathIterator.SEG_LINETO:
-					key.append("L");
-					key.append(vals[0]).append(":").append(vals[1]).append(":");
-					break;
-				case PathIterator.SEG_MOVETO:
-					key.append("M");
-					key.append(vals[0]).append(":").append(vals[1]).append(":");
-					break;
-				case PathIterator.SEG_QUADTO:
-					key.append("Q");
-					key.append(vals[0]).append(":").append(vals[1]).append(":").append(vals[2]).append(":")
-							.append(vals[3]);
-					break;
-				case PathIterator.SEG_CLOSE:
-					key.append("cp");
-					break;
-				default:
-					break;
-				}
-				pathIterator.next();
-			}
-		}
-		return key.toString();
-	}
+    private Rectangle2D add(Rectangle2D r1, Rectangle2D r2) {
+        return r1.createUnion(r2);
+    }
 
-	private Rectangle2D checkLinkArea(LinkDetails link, Shape linkShape) {
-		Rectangle2D targetArea = calcTotalLinkArea(link.c, link.box, link.pageHeight, link.transform);
-		String key = createRectKey(targetArea, linkShape, link.transform);
-		Set<String> keys = _linkTargetAreas.get(link.page);
-		if (keys == null) {
-			keys = new HashSet<>();
-			_linkTargetAreas.put(link.page, keys);
-		}
-		if (keys.contains(key)) {
-			return null;
-		}
-		keys.add(key);
-		return targetArea;
-	}
+    private String createRectKey(Rectangle2D rect, Shape linkShape, AffineTransform transform) {
+        StringBuilder key = new StringBuilder(
+                rect.getMinX() + ":" + rect.getMaxY() + ":" + rect.getMaxX() + ":" + rect.getMinY());
+        if (linkShape != null) {
+            PathIterator pathIterator = linkShape.getPathIterator(transform);
+            double[] vals = new double[6];
+            while (!pathIterator.isDone()) {
+                int type = pathIterator.currentSegment(vals);
+                switch (type) {
+                    case PathIterator.SEG_CUBICTO:
+                        key.append("C");
+                        key.append(vals[0]).append(":").append(vals[1]).append(":").append(vals[2]).append(":")
+                                .append(vals[3]).append(":").append(vals[4]).append(":").append(vals[5]);
+                        break;
+                    case PathIterator.SEG_LINETO:
+                        key.append("L");
+                        key.append(vals[0]).append(":").append(vals[1]).append(":");
+                        break;
+                    case PathIterator.SEG_MOVETO:
+                        key.append("M");
+                        key.append(vals[0]).append(":").append(vals[1]).append(":");
+                        break;
+                    case PathIterator.SEG_QUADTO:
+                        key.append("Q");
+                        key.append(vals[0]).append(":").append(vals[1]).append(":").append(vals[2]).append(":")
+                                .append(vals[3]);
+                        break;
+                    case PathIterator.SEG_CLOSE:
+                        key.append("cp");
+                        break;
+                    default:
+                        break;
+                }
+                pathIterator.next();
+            }
+        }
+        return key.toString();
+    }
 
-	private void processLink(LinkDetails linkDetails) {
-		Element elem = linkDetails.box.getElement();
-		if (elem != null) {
-			NamespaceHandler handler = _sharedContext.getNamespaceHandler();
-			String uri = handler.getLinkUri(elem);
-			if (uri != null) {
-				addUriAsLink(linkDetails, elem, handler, uri, null);
-			}
-		}
-		if (linkDetails.box instanceof BlockBox) {
-			ReplacedElement element = ((BlockBox) linkDetails.box).getReplacedElement();
-			if (element instanceof IPdfBoxElementWithShapedLinks) {
-				Map<Shape, String> linkMap = ((IPdfBoxElementWithShapedLinks) element).getLinkMap();
-				if (linkMap != null) {
-					for (Entry<Shape, String> shapeStringEntry : linkMap.entrySet()) {
-						Shape shape = shapeStringEntry.getKey();
-						String shapeUri = shapeStringEntry.getValue();
-						NamespaceHandler handler = _sharedContext.getNamespaceHandler();
-						addUriAsLink(linkDetails, elem, handler, shapeUri, shape);
-					}
-				}
-			}
-		}
-	}
+    private Rectangle2D checkLinkArea(LinkDetails link, Shape linkShape) {
+        Rectangle2D targetArea = calcTotalLinkArea(link.c, link.box, link.pageHeight, link.transform);
+        String key = createRectKey(targetArea, linkShape, link.transform);
+        Set<String> keys = _linkTargetAreas.get(link.page);
+        if (keys == null) {
+            keys = new HashSet<>();
+            _linkTargetAreas.put(link.page, keys);
+        }
+        if (keys.contains(key)) {
+            return null;
+        }
+        keys.add(key);
+        return targetArea;
+    }
 
-	private static boolean isPointEqual(Point2D.Float p1, Point2D.Float p2) {
-		final double epsilon = 0.000001;
-		return Math.abs(p1.x - p2.x) < epsilon && Math.abs(p1.y - p2.y) < epsilon;
-	}
+    private void processLink(LinkDetails linkDetails) {
+        Element elem = linkDetails.box.getElement();
+        if (elem != null) {
+            NamespaceHandler handler = _sharedContext.getNamespaceHandler();
+            String uri = handler.getLinkUri(elem);
+            if (uri != null) {
+                addUriAsLink(linkDetails, elem, handler, uri, null);
+            }
+        }
+        if (linkDetails.box instanceof BlockBox) {
+            ReplacedElement element = ((BlockBox) linkDetails.box).getReplacedElement();
+            if (element instanceof IPdfBoxElementWithShapedLinks) {
+                Map<Shape, String> linkMap = ((IPdfBoxElementWithShapedLinks) element).getLinkMap();
+                if (linkMap != null) {
+                    for (Entry<Shape, String> shapeStringEntry : linkMap.entrySet()) {
+                        Shape shape = shapeStringEntry.getKey();
+                        String shapeUri = shapeStringEntry.getValue();
+                        NamespaceHandler handler = _sharedContext.getNamespaceHandler();
+                        addUriAsLink(linkDetails, elem, handler, shapeUri, shape);
+                    }
+                }
+            }
+        }
+    }
 
-	private static void removeDoublicatePoints(List<Point2D.Float> points) {
-		boolean rerun;
-		do {
-			rerun = false;
-			/*
-			 * We can only form triangles if three points are not the same. So we must
-			 * filter out all points which follow each other and are the same.
-			 */
-			for (int i = 0; i < points.size() - 1; i++) {
-				Point2D.Float p1 = points.get(i);
-				Point2D.Float p2 = points.get(i + 1);
-				if (isPointEqual(p1, p2)) {
-					points.remove(i);
-					rerun = true;
-				}
-			}
-			/*
-			 * And we must filter out the same points with gap of 1 between them
-			 */
-			for (int i = 0; i < points.size() - 2; i++) {
-				Point2D.Float p1 = points.get(i);
-				Point2D.Float p2 = points.get(i + 2);
-				if (isPointEqual(p1, p2)) {
-					points.remove(i);
-					rerun = true;
-				}
-			}
-		} while (rerun);
-	}
+    private static boolean isPointEqual(Point2D.Float p1, Point2D.Float p2) {
+        final double epsilon = 0.000001;
+        return Math.abs(p1.x - p2.x) < epsilon && Math.abs(p1.y - p2.y) < epsilon;
+    }
 
-	private void addUriAsLink(LinkDetails linkDetails,
-			Element elem, NamespaceHandler handler, String uri, Shape linkShape) {
-		if (uri.length() > 1 && uri.charAt(0) == '#') {
-			String anchor = uri.substring(1);
-			Box target = _sharedContext.getBoxById(anchor);
-			if (target != null) {
-				PDPageXYZDestination dest = createDestination(linkDetails.c, target);
+    private static void removeDoublicatePoints(List<Point2D.Float> points) {
+        boolean rerun;
+        do {
+            rerun = false;
+            /*
+             * We can only form triangles if three points are not the same. So we must
+             * filter out all points which follow each other and are the same.
+             */
+            for (int i = 0; i < points.size() - 1; i++) {
+                Point2D.Float p1 = points.get(i);
+                Point2D.Float p2 = points.get(i + 1);
+                if (isPointEqual(p1, p2)) {
+                    points.remove(i);
+                    rerun = true;
+                }
+            }
+            /*
+             * And we must filter out the same points with gap of 1 between them
+             */
+            for (int i = 0; i < points.size() - 2; i++) {
+                Point2D.Float p1 = points.get(i);
+                Point2D.Float p2 = points.get(i + 2);
+                if (isPointEqual(p1, p2)) {
+                    points.remove(i);
+                    rerun = true;
+                }
+            }
+        } while (rerun);
+    }
 
-				PDAction action;
-				if (handler.getAttributeValue(elem, "onclick") != null
-						&& !"".equals(handler.getAttributeValue(elem, "onclick"))) {
-					action = new PDActionJavaScript(handler.getAttributeValue(elem, "onclick"));
-				} else {
-					PDActionGoTo go = new PDActionGoTo();
-					go.setDestination(dest);
-					action = go;
-				}
+    private void addUriAsLink(LinkDetails linkDetails,
+                              Element elem, NamespaceHandler handler, String uri, Shape linkShape) {
+        if (uri.length() > 1 && uri.charAt(0) == '#') {
+            String anchor = uri.substring(1);
+            Box target = _sharedContext.getBoxById(anchor);
+            if (target != null) {
+                PDPageXYZDestination dest = createDestination(linkDetails.c, target);
 
-				Rectangle2D targetArea = checkLinkArea(linkDetails, linkShape);
-				if (targetArea == null) {
-					return;
-				}
+                PDAction action;
+                if (handler.getAttributeValue(elem, "onclick") != null
+                        && !"".equals(handler.getAttributeValue(elem, "onclick"))) {
+                    action = new PDActionJavaScript(handler.getAttributeValue(elem, "onclick"));
+                } else {
+                    PDActionGoTo go = new PDActionGoTo();
+                    go.setDestination(dest);
+                    action = go;
+                }
 
-				PDAnnotationLink annot = new PDAnnotationLink();
-				annot.setAction(action);
+                Rectangle2D targetArea = checkLinkArea(linkDetails, linkShape);
+                if (targetArea == null) {
+                    return;
+                }
+
+                PDAnnotationLink annot = new PDAnnotationLink();
+                annot.setAction(action);
 
                 AnnotationContainer annotContainer = new AnnotationContainer.PDAnnotationLinkContainer(annot);
 
-				if (!placeAnnotation(linkDetails.transform, linkShape, targetArea, annotContainer))
-					return;
+                if (!placeAnnotation(linkDetails.transform, linkShape, targetArea, annotContainer))
+                    return;
 
                 addLinkToPage(linkDetails.page, annotContainer, linkDetails.box, target);
-			} else {
-				XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_LINK, uri);
-			}
-		} else if (isURI(uri)) {
+            } else {
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.GENERAL_PDF_COULD_NOT_FIND_VALID_TARGET_FOR_LINK, uri);
+            }
+        } else if (isURI(uri)) {
             AnnotationContainer annotContainer = null;
 
             if (!elem.hasAttribute("download")) {
@@ -289,7 +290,7 @@ public class PdfBoxFastLinkManager {
     /**
      * Create a file attachment link, being careful not to embed the same
      * file (as specified by uri) more than once.
-     *
+     * <p>
      * The element should have the following attributes:
      * download="embedded-filename.ext",
      * data-content-type="file-mime-type" which
@@ -315,8 +316,8 @@ public class PdfBoxFastLinkManager {
 
         if (file != null) {
             try {
-                String contentType = elem.getAttribute("data-content-type").isEmpty() ? 
-                        "application/octet-stream" : 
+                String contentType = elem.getAttribute("data-content-type").isEmpty() ?
+                        "application/octet-stream" :
                         elem.getAttribute("data-content-type");
 
                 PDEmbeddedFile embeddedFile = new PDEmbeddedFile(_od.getWriter(), new ByteArrayInputStream(file));
@@ -339,8 +340,8 @@ public class PdfBoxFastLinkManager {
                 // The PDF/A3 standard requires one to specify the relationship
                 // this embedded file has to the link annotation.
                 if (elem.hasAttribute("relationship") &&
-                    Arrays.asList("Source", "Supplement", "Data", "Alternative", "Unspecified")
-                          .contains(elem.getAttribute("relationship"))) {
+                        Arrays.asList("Source", "Supplement", "Data", "Alternative", "Unspecified")
+                                .contains(elem.getAttribute("relationship"))) {
                     fs.getCOSObject().setItem(
                             COSName.getPDFName("AFRelationship"),
                             COSName.getPDFName(elem.getAttribute("relationship")));
@@ -392,218 +393,220 @@ public class PdfBoxFastLinkManager {
         return appearanceDictionary;
     }
 
-	private static boolean isURI(String uri) {
-		try {
-			return URI.create(uri) != null;
-		} catch (IllegalArgumentException e) {
-			XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.GENERAL_PDF_URI_IN_HREF_IS_NOT_A_VALID_URI, uri);
-			return false;
-		}
-	}
+    private static boolean isURI(String uri) {
+        try {
+            return URI.create(uri) != null;
+        } catch (IllegalArgumentException e) {
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.GENERAL_PDF_URI_IN_HREF_IS_NOT_A_VALID_URI, uri);
+            return false;
+        }
+    }
 
-	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
-	private boolean placeAnnotation(AffineTransform transform, Shape linkShape, Rectangle2D targetArea,
-			AnnotationContainer annot) {
-		annot.setRectangle(new PDRectangle((float) targetArea.getMinX(), (float) targetArea.getMinY(),
-				(float) targetArea.getWidth(), (float) targetArea.getHeight()));
-		
-		// PDF/A standard requires the print flag to be set and there shouldn't
-		// be any harm in setting it for other documents.
-		annot.setPrinted(true);
-		
-		if (linkShape != null) {
-			QuadPointShape quadPointsResult = mapShapeToQuadPoints(transform, linkShape, targetArea);
-			/*
-			 * Is this not an area shape? Then we can not setup quads - ignore this shape.
-			 */
-			if (quadPointsResult.quadPoints.length == 0)
-				return false;
-			annot.setQuadPoints(quadPointsResult.quadPoints);
-			Rectangle2D reducedTarget = quadPointsResult.boundingBox;
-			annot.setRectangle(new PDRectangle((float) reducedTarget.getMinX(), (float) reducedTarget.getMinY(),
-					(float) reducedTarget.getWidth(), (float) reducedTarget.getHeight()));
-		}
-		return true;
-	}
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private boolean placeAnnotation(AffineTransform transform, Shape linkShape, Rectangle2D targetArea,
+                                    AnnotationContainer annot) {
+        annot.setRectangle(new PDRectangle((float) targetArea.getMinX(), (float) targetArea.getMinY(),
+                (float) targetArea.getWidth(), (float) targetArea.getHeight()));
 
-	static class QuadPointShape {
-		float[] quadPoints;
-		Rectangle2D boundingBox;
-	}
-	
-	static QuadPointShape mapShapeToQuadPoints(AffineTransform transform, Shape linkShape, Rectangle2D targetArea) {
-		List<Point2D.Float> points = new ArrayList<>();
-		AffineTransform transformForQuads = new AffineTransform();
-		transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());
-		// We must flip the whole thing upside down
-		transformForQuads.translate(0, targetArea.getHeight());
-		transformForQuads.scale(1, -1);
-		transformForQuads.concatenate(AffineTransform.getScaleInstance(transform.getScaleX(), transform.getScaleX()));
-		Area area = new Area(linkShape);
-		PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
-		double[] vals = new double[6];
-		while (!pathIterator.isDone()) {
-			int type = pathIterator.currentSegment(vals);
-			switch (type) {
-			case PathIterator.SEG_CUBICTO:
-				throw new RuntimeException("Invalid State, Area should never give us a curve here!");
-			case PathIterator.SEG_LINETO:
-				points.add(new Point2D.Float((float) vals[0], (float) vals[1]));
-				break;
-			case PathIterator.SEG_MOVETO:
-				points.add(new Point2D.Float((float) vals[0], (float) vals[1]));
-				break;
-			case PathIterator.SEG_QUADTO:
-				throw new RuntimeException("Invalid State, Area should never give us a curve here!");
-			case PathIterator.SEG_CLOSE:
-				break;
-			default:
-				break;
-			}
-			pathIterator.next();
-		}
+        // PDF/A standard requires the print flag to be set and there shouldn't
+        // be any harm in setting it for other documents.
+        annot.setPrinted(true);
 
-		removeDoublicatePoints(points);
+        if (linkShape != null) {
+            QuadPointShape quadPointsResult = mapShapeToQuadPoints(transform, linkShape, targetArea);
+            /*
+             * Is this not an area shape? Then we can not setup quads - ignore this shape.
+             */
+            if (quadPointsResult.quadPoints.length == 0)
+                return false;
+            annot.setQuadPoints(quadPointsResult.quadPoints);
+            Rectangle2D reducedTarget = quadPointsResult.boundingBox;
+            annot.setRectangle(new PDRectangle((float) reducedTarget.getMinX(), (float) reducedTarget.getMinY(),
+                    (float) reducedTarget.getWidth(), (float) reducedTarget.getHeight()));
+        }
+        return true;
+    }
 
-		KongAlgo algo = new KongAlgo(points);
-		algo.runKong();
+    static class QuadPointShape {
+        float[] quadPoints;
+        Rectangle2D boundingBox;
+    }
 
-		float minX = (float) targetArea.getMaxX();
-		float maxX = (float) targetArea.getMinX();
-		float minY = (float) targetArea.getMaxY();
-		float maxY = (float) targetArea.getMinY();
-		
-		float[] ret = new float[algo.getTriangles().size() * 8];
-		int i = 0;
-		for (Triangle triangle : algo.getTriangles()) {
-			ret[i++] = triangle.a.x;
-			ret[i++] = triangle.a.y;
-			ret[i++] = triangle.b.x;
-			ret[i++] = triangle.b.y;
-			/*
-			 * To get a quad we add the point between b and c
-			 */
-			ret[i++] = triangle.b.x + (triangle.c.x - triangle.b.x) / 2;
-			ret[i++] = triangle.b.y + (triangle.c.y - triangle.b.y) / 2;
+    static QuadPointShape mapShapeToQuadPoints(AffineTransform transform, Shape linkShape, Rectangle2D targetArea) {
+        List<Point2D.Float> points = new ArrayList<>();
+        AffineTransform transformForQuads = new AffineTransform();
+        transformForQuads.translate(targetArea.getMinX(), targetArea.getMinY());
+        // We must flip the whole thing upside down
+        transformForQuads.translate(0, targetArea.getHeight());
+        transformForQuads.scale(1, -1);
+        transformForQuads.concatenate(AffineTransform.getScaleInstance(transform.getScaleX(), transform.getScaleX()));
+        Area area = new Area(linkShape);
+        PathIterator pathIterator = area.getPathIterator(transformForQuads, 1.0);
+        double[] vals = new double[6];
+        while (!pathIterator.isDone()) {
+            int type = pathIterator.currentSegment(vals);
+            switch (type) {
+                case PathIterator.SEG_CUBICTO:
+                    throw new RuntimeException("Invalid State, Area should never give us a curve here!");
+                case PathIterator.SEG_LINETO:
+                    points.add(new Point2D.Float((float) vals[0], (float) vals[1]));
+                    break;
+                case PathIterator.SEG_MOVETO:
+                    points.add(new Point2D.Float((float) vals[0], (float) vals[1]));
+                    break;
+                case PathIterator.SEG_QUADTO:
+                    throw new RuntimeException("Invalid State, Area should never give us a curve here!");
+                case PathIterator.SEG_CLOSE:
+                    break;
+                default:
+                    break;
+            }
+            pathIterator.next();
+        }
 
-			ret[i++] = triangle.c.x;
-			ret[i++] = triangle.c.y;
-			
-			for (Point2D.Float p : new Point2D.Float[] { triangle.a, triangle.b, triangle.c }) {
-				float x = p.x;
-				float y = p.y;
+        removeDoublicatePoints(points);
 
-				minX = Math.min(x, minX);
-				minY = Math.min(y, minY);
+        KongAlgo algo = new KongAlgo(points);
+        algo.runKong();
 
-				maxX = Math.max(x, maxX);
-				maxY = Math.max(y, maxY);
-			}
-		}
+        float minX = (float) targetArea.getMaxX();
+        float maxX = (float) targetArea.getMinX();
+        float minY = (float) targetArea.getMaxY();
+        float maxY = (float) targetArea.getMinY();
 
-		//noinspection ConstantConditions
-		if (ret.length % 8 != 0)
-			throw new IllegalStateException("Not exact 8xn QuadPoints!");
-		for (; i < ret.length; i += 2) {
-			if (ret[i] < targetArea.getMinX() || ret[i] > targetArea.getMaxX())
-				throw new IllegalStateException("Invalid rectangle calculation. Map shape is out of bound.");
-			if (ret[i + 1] < targetArea.getMinY() || ret[
-					i + 1] > targetArea.getMaxY())
-				throw new IllegalStateException("Invalid rectangle calculation. Map shape is out of bound.");
-		}
+        float[] ret = new float[algo.getTriangles().size() * 8];
+        int i = 0;
+        for (Triangle triangle : algo.getTriangles()) {
+            ret[i++] = triangle.a.x;
+            ret[i++] = triangle.a.y;
+            ret[i++] = triangle.b.x;
+            ret[i++] = triangle.b.y;
+            /*
+             * To get a quad we add the point between b and c
+             */
+            ret[i++] = triangle.b.x + (triangle.c.x - triangle.b.x) / 2;
+            ret[i++] = triangle.b.y + (triangle.c.y - triangle.b.y) / 2;
 
-		QuadPointShape result = new QuadPointShape();
-		result.quadPoints = ret;
-		Rectangle2D.Float boundingRectangle = new Rectangle2D.Float(minX, minY, maxX - minX, maxY - minY);
-		Rectangle2D.intersect(targetArea, boundingRectangle, boundingRectangle);
-		result.boundingBox = boundingRectangle;
-		return result;
-	}
+            ret[i++] = triangle.c.x;
+            ret[i++] = triangle.c.y;
 
-	private void addLinkToPage(
-          PDPage page, AnnotationContainer annot, Box anchor, Box target) {
-		PDBorderStyleDictionary styleDict = new PDBorderStyleDictionary();
-		styleDict.setWidth(0);
-		styleDict.setStyle(PDBorderStyleDictionary.STYLE_SOLID);
-		annot.setBorderStyle(styleDict);
+            for (Point2D.Float p : new Point2D.Float[]{triangle.a, triangle.b, triangle.c}) {
+                float x = p.x;
+                float y = p.y;
 
-		try {
-			List<PDAnnotation> annots = page.getAnnotations();
+                minX = Math.min(x, minX);
+                minY = Math.min(y, minY);
 
-			if (annots == null) {
-				annots = new ArrayList<>();
-				page.setAnnotations(annots);
-			}
+                maxX = Math.max(x, maxX);
+                maxY = Math.max(y, maxY);
+            }
+        }
 
-			annots.add(annot.getPdAnnotation());
-			
-			if (_pdfUa != null) {
-			    _pdfUa.addLink(anchor, target, annot.getPdAnnotation(), page);
-			}
-		} catch (IOException e) {
-			throw new PdfContentStreamAdapter.PdfException("processLink", e);
-		}
-	}
+        //noinspection ConstantConditions
+        if (ret.length % 8 != 0)
+            throw new IllegalStateException("Not exact 8xn QuadPoints!");
+        for (; i < ret.length; i += 2) {
+            if (ret[i] < targetArea.getMinX() || ret[i] > targetArea.getMaxX())
+                throw new IllegalStateException("Invalid rectangle calculation. Map shape is out of bound.");
+            if (ret[i + 1] < targetArea.getMinY() || ret[
+                    i + 1] > targetArea.getMaxY())
+                throw new IllegalStateException("Invalid rectangle calculation. Map shape is out of bound.");
+        }
 
-	private PDPageXYZDestination createDestination(RenderingContext c, Box box) {
-	    return PdfBoxBookmarkManager.createBoxDestination(c, _od.getWriter(), _od, _dotsPerPoint, _root, box);
-	}
+        QuadPointShape result = new QuadPointShape();
+        result.quadPoints = ret;
+        Rectangle2D.Float boundingRectangle = new Rectangle2D.Float(minX, minY, maxX - minX, maxY - minY);
+        Rectangle2D.intersect(targetArea, boundingRectangle, boundingRectangle);
+        result.boundingBox = boundingRectangle;
+        return result;
+    }
 
-	public static Rectangle2D createTargetArea(RenderingContext c, Box box, float pageHeight, AffineTransform transform,
-			Box _root, PdfBoxOutputDevice _od) {
-		Rectangle bounds = PagedBoxCollector.findAdjustedBoundsForContentBox(c, box); 
-		
-		if (!c.isInPageMargins()) {
-		    int shadow = c.getShadowPageNumber();
-		    Rectangle pageBounds = shadow == -1 ? 
-		        c.getPage().getDocumentCoordinatesContentBounds(c) :
-		        c.getPage().getDocumentCoordinatesContentBoundsForInsertedPage(c, shadow);
-		    
-		    bounds = bounds.intersection(pageBounds);
-		}
-		
-		Point2D pt = new Point2D.Float(bounds.x, (float) bounds.getMaxY());
-		Point2D ptTransformed = transform.transform(pt, null);
-		
-		return new Rectangle2D.Float((float) ptTransformed.getX(),
-                    _od.normalizeY((float) ptTransformed.getY(), pageHeight),
-                    _od.getDeviceLength(bounds.width),
-                    _od.getDeviceLength(bounds.height));
-	}
+    private void addLinkToPage(
+            PDPage page, AnnotationContainer annot, Box anchor, Box target) {
+        PDBorderStyleDictionary styleDict = new PDBorderStyleDictionary();
+        styleDict.setWidth(0);
+        styleDict.setStyle(PDBorderStyleDictionary.STYLE_SOLID);
+        annot.setBorderStyle(styleDict);
 
-	private static class LinkDetails {
+        try {
+            List<PDAnnotation> annots = page.getAnnotations();
 
-		RenderingContext c;
-		Box box;
-		Rectangle2D targetArea;
-		PDPage page;
-		float pageHeight;
-		AffineTransform transform;
-	}
+            if (annots == null) {
+                annots = new ArrayList<>();
+                page.setAnnotations(annots);
+            }
 
-	public void processLinkLater(RenderingContext c, Box box, PDPage page, float pageHeight,
-			AffineTransform transform) {
-	    
-	    if ((box instanceof BlockBox &&
-	        ((BlockBox) box).getReplacedElement() != null) ||
-	        (box.getElement() != null && box.getElement().getNodeName().equals("a"))) {
-	    
-		LinkDetails link = new LinkDetails();
-		link.c = (RenderingContext) c.clone();
-		link.box = box;
-		link.page = page;
-		link.pageHeight = pageHeight;
-		link.transform = (AffineTransform) transform.clone();
-		link.targetArea = calcTotalLinkArea(c, box, pageHeight, transform);
+            annots.add(annot.getPdAnnotation());
 
-		_links.add(link);
-	    }
-	}
+            if (_pdfUa != null) {
+                _pdfUa.addLink(anchor, target, annot.getPdAnnotation(), page);
+            }
+        } catch (IOException e) {
+            throw new PdfContentStreamAdapter.PdfException("processLink", e);
+        }
+    }
 
-	public void processLinks(PdfBoxAccessibilityHelper pdfUa) {
-	    this._pdfUa = pdfUa;
-		for (LinkDetails link : _links) {
-			processLink(link);
-		}
-	}
+    private PDPageXYZDestination createDestination(RenderingContext c, Box box) {
+        return PdfBoxBookmarkManager.createBoxDestination(c, _od.getWriter(), _od, _dotsPerPoint, _root, box);
+    }
+
+
+    public static Rectangle2D createTargetArea(RenderingContext c, Box box, float pageHeight, AffineTransform transform,
+                                               PageBox pageBox, PdfBoxOutputDevice _od) {
+        Rectangle bounds = PagedBoxCollector.findAdjustedBoundsForContentBox(c, box);
+
+        if (!c.isInPageMargins()) {
+            int shadow = c.getShadowPageNumber();
+
+            Rectangle pageBounds = shadow == -1 ?
+                    pageBox.getDocumentCoordinatesContentBounds(c) :
+                    pageBox.getDocumentCoordinatesContentBoundsForInsertedPage(c, shadow);
+
+            bounds = bounds.intersection(pageBounds);
+        }
+
+        Point2D pt = new Point2D.Float(bounds.x, (float) bounds.getMaxY());
+        Point2D ptTransformed = transform.transform(pt, null);
+
+        return new Rectangle2D.Float((float) ptTransformed.getX(),
+                _od.normalizeY((float) ptTransformed.getY(), pageHeight),
+                _od.getDeviceLength(bounds.width),
+                _od.getDeviceLength(bounds.height));
+    }
+
+    private static class LinkDetails {
+
+        RenderingContext c;
+        Box box;
+        Rectangle2D targetArea;
+        PDPage page;
+        float pageHeight;
+        AffineTransform transform;
+    }
+
+    public void processLinkLater(RenderingContext c, Box box, PDPage page, float pageHeight,
+                                 AffineTransform transform) {
+
+        if ((box instanceof BlockBox &&
+                ((BlockBox) box).getReplacedElement() != null) ||
+                (box.getElement() != null && box.getElement().getNodeName().equals("a"))) {
+
+            LinkDetails link = new LinkDetails();
+            link.c = (RenderingContext) c.clone();
+            link.box = box;
+            link.page = page;
+            link.pageHeight = pageHeight;
+            link.transform = (AffineTransform) transform.clone();
+            link.targetArea = calcTotalLinkArea(c, box, pageHeight, transform);
+
+            _links.add(link);
+        }
+    }
+
+    public void processLinks(PdfBoxAccessibilityHelper pdfUa) {
+        this._pdfUa = pdfUa;
+        for (LinkDetails link : _links) {
+            processLink(link);
+        }
+    }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -293,8 +293,8 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
         }
     }
 
-    private void processControls() {
-        _formState.processControls(_sharedContext, _writer, _root);
+	private void processControls(RenderingContext renderingContext) {
+		_formState.processControls(_sharedContext, _writer, _root, renderingContext);
     }
 
     /**
@@ -898,7 +898,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
         _bmManager.writeOutline(c, root);
 
         // Also need access to the structure tree.
-        processControls();
+		processControls(c);
         _linkManager.processLinks(_pdfUa);
         
         if (_pdfUa != null) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxForm.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxForm.java
@@ -41,6 +41,7 @@ import org.apache.pdfbox.pdmodel.interactive.form.PDListBox;
 import org.apache.pdfbox.pdmodel.interactive.form.PDNonTerminalField;
 import org.apache.pdfbox.pdmodel.interactive.form.PDPushButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
+import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
 import org.w3c.dom.Element;
 
@@ -61,13 +62,13 @@ import org.w3c.dom.Node;
 public class PdfBoxForm {
     // The global(per document) form state container
     private final PdfBoxPerDocumentFormState docFormsStateContainer;
-    
+
     // The output device
     private final PdfBoxOutputDevice od;
-    
+
     // The form element itself.
     private final Element element;
-    
+
     // All controls, with a font name if needed.
     private final List<ControlFontPair> controls = new ArrayList<>();
 
@@ -76,7 +77,7 @@ public class PdfBoxForm {
 
     // We've got to find all the radio button controls that belong to a group (common name).
     private final Map<String, List<PdfBoxForm.Control>> radioGroups = new LinkedHashMap<>();
-    
+
     // Contains a tree of fields in the form:
     // person
     // person.details
@@ -84,7 +85,7 @@ public class PdfBoxForm {
     // person.details.phone
     // etc.
     private final Map<String, Field> allFieldMap = new HashMap<>();
-    
+
     // A link in the tree of fields. We have this so that each field can look up
     // its parent field.
     private static class Field {
@@ -95,14 +96,14 @@ public class PdfBoxForm {
         // set its kids appropriately.
         private boolean isTerminal;
     }
-    
+
     public static class Control {
         public final Box box;
         private final PDPage page;
         private final AffineTransform transform;
         private final RenderingContext c;
         private final float pageHeight;
-        
+
         public Control(Box box, PDPage page, AffineTransform transform, RenderingContext c, float pageHeight) {
             this.box = box;
             this.page = page;
@@ -111,23 +112,23 @@ public class PdfBoxForm {
             this.pageHeight = pageHeight;
         }
     }
-    
+
     private static class ControlFontPair {
         private final String fontName;
         private final Control control;
-        
+
         private ControlFontPair(Control control, String fontName) {
             this.control = control;
             this.fontName = fontName;
         }
     }
-    
+
     private PdfBoxForm(Element element, PdfBoxPerDocumentFormState forms, PdfBoxOutputDevice od) {
         this.element = element;
         this.od = od;
         this.docFormsStateContainer = forms;
     }
-    
+
     public static PdfBoxForm createForm(Element e, PdfBoxPerDocumentFormState forms, PdfBoxOutputDevice od) {
         return new PdfBoxForm(e, forms, od);
     }
@@ -135,8 +136,8 @@ public class PdfBoxForm {
     public void addControl(Control ctrl, String fontName) {
         controls.add(new ControlFontPair(ctrl, fontName));
     }
-    
-    /** 
+
+    /**
      * This method will create a tree of names, both non-terminal
      * and terminal.
      */
@@ -145,9 +146,9 @@ public class PdfBoxForm {
             if (!control.control.box.getElement().hasAttribute("name")) {
                 continue;
             }
-            
+
             String name = control.control.box.getElement().getAttribute("name");
-            
+
             if (!name.contains(".")) {
                 // It's a root field!
                 Field f = new Field();
@@ -157,12 +158,12 @@ public class PdfBoxForm {
                 allFieldMap.put(name, f);
             } else {
                 String[] partials = name.split(Pattern.quote("."));
-                
+
                 for (int i = 1; i <= partials.length; i++) {
                     // Given a field name such as person.details.name
                     // we check that 'person' is created first, then 'person.details' and
                     // finally 'person.details.name'.
-                    
+
                     String[] parent = new String[i];
                     System.arraycopy(partials, 0, parent, 0, i);
                     String parentQualifiedName = ArrayUtil.join(parent, ".");
@@ -171,7 +172,7 @@ public class PdfBoxForm {
                     if (f == null) {
                         Field fCreated = new Field();
                         fCreated.qualifiedName = parentQualifiedName;
-                        fCreated.partialName = parent[i - 1]; 
+                        fCreated.partialName = parent[i - 1];
                         fCreated.isTerminal = (i == partials.length);
                         allFieldMap.put(parentQualifiedName, fCreated);
                     }
@@ -179,7 +180,7 @@ public class PdfBoxForm {
             }
         }
     }
-    
+
     /**
      * This method will create the non terminal fields.
      * It is called recursively to create all non-terminal field descendants.
@@ -199,9 +200,9 @@ public class PdfBoxForm {
                         createNonTerminalFields(f2, form);
                     }
                 }
-                
 
-                f.field.getCOSObject().setItem(COSName.KIDS, kids); 
+
+                f.field.getCOSObject().setItem(COSName.KIDS, kids);
             }
       }
 
@@ -217,7 +218,7 @@ public class PdfBoxForm {
                   f.field = nonTerminal;
               }
           }
-          
+
           for (Field f : allFieldMap.values()) {
               if (!f.qualifiedName.contains(".")) {
                   createNonTerminalFields(f, form);
@@ -225,22 +226,22 @@ public class PdfBoxForm {
               }
           }
       }
-    
+
     /**
      * Get a PDF graphics operator for a specific color.
      */
     private static String getColorOperator(FSColor color) {
         String colorOperator = "";
-        
+
         if (color instanceof FSRGBColor) {
             FSRGBColor rgb = (FSRGBColor) color;
             float r = (float) rgb.getRed() / 255;
             float g = (float) rgb.getGreen() / 255;
             float b = (float) rgb.getBlue() / 255;
-            
+
             colorOperator =
-                    String.format(Locale.US, "%.4f", r) + ' ' + 
-                    String.format(Locale.US, "%.4f", g) + ' ' + 
+                    String.format(Locale.US, "%.4f", r) + ' ' +
+                    String.format(Locale.US, "%.4f", g) + ' ' +
                     String.format(Locale.US, "%.4f", b) + ' ' +
                     "rg";
         } else if (color instanceof FSCMYKColor) {
@@ -249,22 +250,22 @@ public class PdfBoxForm {
             float m = cmyk.getMagenta();
             float y = cmyk.getYellow();
             float k = cmyk.getBlack();
-            
-            colorOperator = 
+
+            colorOperator =
                     String.format(Locale.US, "%.4f", c) + ' ' +
                     String.format(Locale.US, "%.4f", m) + ' ' +
                     String.format(Locale.US, "%.4f", y) + ' ' +
                     String.format(Locale.US, "%.4f", k) + ' ' +
                     "k";
         }
-        
+
         return colorOperator;
     }
-    
+
     private String getTextareaText(Element e) {
         return DOMUtil.getText(e);
     }
-    
+
     private String populateOptions(Element e, List<String> labels, List<String> values, List<Integer> selectedIndices) {
         List<Element> opts = DOMUtil.getChildren(e, "option");
         if (opts == null) {
@@ -273,141 +274,147 @@ public class PdfBoxForm {
         }
         String selected = "";
         int i = 0;
-        
+
         for (Element opt : opts) {
             String label = DOMUtil.getText(opt);
             labels.add(label);
-            
+
             if (opt.hasAttribute("value")) {
                 values.add(opt.getAttribute("value"));
             } else {
                 values.add(label);
             }
-            
+
             if (selected.isEmpty()) {
                 selected = label;
             }
-            
+
             if (opt.hasAttribute("selected")) {
                 selected = label;
             }
-            
+
             if (opt.hasAttribute("selected") && selectedIndices != null) {
                 selectedIndices.add(i);
             }
 
             i++;
         }
-        
+
         return selected;
     }
-    
+
     private void processMultiSelectControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root) throws IOException {
         PDListBox field = new PDListBox(acro);
 
         setPartialNameToField(ctrl, field);
 
         field.setMultiSelect(true);
-        
+
         List<String> labels = new ArrayList<>();
         List<String> values = new ArrayList<>();
         List<Integer> selected = new ArrayList<>();
         populateOptions(ctrl.box.getElement(), labels, values, selected);
-        
+
         field.setOptions(values, labels);
         field.setSelectedOptionsIndex(selected);
-        
+
         FSColor color = ctrl.box.getStyle().getColor();
         String colorOperator = getColorOperator(color);
-        
+
         String fontInstruction = "/" + pair.fontName + " 0 Tf";
         field.setDefaultAppearance(fontInstruction + ' ' + colorOperator);
-        
+
         if (ctrl.box.getElement().hasAttribute("required")) {
             field.setRequired(true);
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("readonly")) {
             field.setReadOnly(true);
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("title")) {
             field.setAlternateFieldName(ctrl.box.getElement().getAttribute("title"));
         }
-        
+
         PDAnnotationWidget widget = field.getWidgets().get(0);
 
-        Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform, root, od);
-        PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(), (float) rect2D.getWidth(), (float) rect2D.getHeight());
+		Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform,
+				root, od);
+		PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(),
+				(float) rect2D.getWidth(), (float) rect2D.getHeight());
 
         widget.setRectangle(rect);
         widget.setPage(ctrl.page);
         widget.setPrinted(true);
-      
+
         ctrl.page.getAnnotations().add(widget);
     }
-    
+
     /**
      * Processes select controls and the custom openhtmltopdf-combo control.
      */
-    private void processSelectControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root) throws IOException {
+	private void processSelectControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root)
+			throws IOException {
         PDComboBox field = new PDComboBox(acro);
 
         setPartialNameToField(ctrl, field);
-        
+
         List<String> labels = new ArrayList<>();
         List<String> values = new ArrayList<>();
         String selectedLabel = populateOptions(ctrl.box.getElement(), labels, values, null);
-        
+
         field.setOptions(values, labels);
         field.setValue(selectedLabel);
         field.setDefaultValue(selectedLabel);
-        
+
         FSColor color = ctrl.box.getStyle().getColor();
         String colorOperator = getColorOperator(color);
-        
+
         String fontInstruction = "/" + pair.fontName + " 0 Tf";
         field.setDefaultAppearance(fontInstruction + ' ' + colorOperator);
-        
+
         if (ctrl.box.getElement().hasAttribute("required")) {
             field.setRequired(true);
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("readonly")) {
             field.setReadOnly(true);
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("title")) {
             field.setAlternateFieldName(ctrl.box.getElement().getAttribute("title"));
         }
-        
+
         if (ctrl.box.getElement().getNodeName().equals("openhtmltopdf-combo")) {
             field.setEdit(true);
             field.setCombo(true);
         }
-        
+
         PDAnnotationWidget widget = field.getWidgets().get(0);
 
-        Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform, root, od);
-        PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(), (float) rect2D.getWidth(), (float) rect2D.getHeight());
+		Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform,
+				root, od);
+		PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(),
+				(float) rect2D.getWidth(), (float) rect2D.getHeight());
 
         widget.setRectangle(rect);
         widget.setPage(ctrl.page);
         widget.setPrinted(true);
-      
+
         ctrl.page.getAnnotations().add(widget);
     }
-    
-    private void processHiddenControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root) throws IOException {
+
+	private void processHiddenControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root)
+			throws IOException {
         PDTextField field = new PDTextField(acro);
 
         setPartialNameToField(ctrl, field);
-        
+
         String value = ctrl.box.getElement().getAttribute("value");
-        
+
         field.setDefaultValue(value);
         field.setValue(value);
-        
+
         // Even hidden fields need an associated widget to work.
         PDAnnotationWidget widgy = field.getWidgets().get(0);
         widgy.setPage(ctrl.page);
@@ -415,59 +422,99 @@ public class PdfBoxForm {
         widgy.setRectangle(new PDRectangle(0, 0, 1, 1));
         ctrl.page.getAnnotations().add(widgy);
     }
-    
-    private void processTextControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root) throws IOException {
+
+	private void processTextControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root)
+			throws IOException {
         PDTextField field = new PDTextField(acro);
 
         setPartialNameToField(ctrl, field);
-        
+
         FSColor color = ctrl.box.getStyle().getColor();
         String colorOperator = getColorOperator(color);
 
         String fontInstruction = "/" + pair.fontName + " 0 Tf";
         field.setDefaultAppearance(fontInstruction + ' ' + colorOperator);
-        
+
         String value = ctrl.box.getElement().getNodeName().equals("textarea") ?
                 getTextareaText(ctrl.box.getElement()) :
                 ctrl.box.getElement().getAttribute("value");
-        
+
         field.setDefaultValue(value); // The reset value.
         field.setValue(value);        // The original value.
-    
+
         if (OpenUtil.parseIntegerOrNull(ctrl.box.getElement().getAttribute("max-length")) != null) {
             field.setMaxLen(OpenUtil.parseIntegerOrNull(ctrl.box.getElement().getAttribute("max-length")));
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("required")) {
             field.setRequired(true);
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("readonly")) {
             field.setReadOnly(true);
         }
-        
+
         if (ctrl.box.getElement().getNodeName().equals("textarea")) {
             field.setMultiline(true);
         } else if (ctrl.box.getElement().getAttribute("type").equals("password")) {
             field.setPassword(true);
         } else if (ctrl.box.getElement().getAttribute("type").equals("file")) {
-            XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.GENERAL_PDF_ACROBAT_READER_DOES_NOT_SUPPORT_FORMS_WITH_FILE_INPUT);
+			XRLog.log(Level.WARNING,
+					LogMessageId.LogMessageId0Param.GENERAL_PDF_ACROBAT_READER_DOES_NOT_SUPPORT_FORMS_WITH_FILE_INPUT);
             field.setFileSelect(true);
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("title")) {
             field.setAlternateFieldName(ctrl.box.getElement().getAttribute("title"));
         }
-        
+
         PDAnnotationWidget widget = field.getWidgets().get(0);
 
-        Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform, root, od);
-        PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(), (float) rect2D.getWidth(), (float) rect2D.getHeight());
+		Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform,
+				root, od);
+		PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(),
+				(float) rect2D.getWidth(), (float) rect2D.getHeight());
+
+		widget.setRectangle(rect);
+		widget.setPage(ctrl.page);
+		widget.setPrinted(true);
+
+		ctrl.page.getAnnotations().add(widget);
+	}
+
+	private void processSignatureControl(ControlFontPair pair, Control ctrl, PDAcroForm acro, int i, Box root)
+			throws IOException {
+		PDSignatureField field = new PDSignatureField(acro);
+
+		setPartialNameToField(ctrl, field);
+
+
+		if (ctrl.box.getElement().hasAttribute("required")) {
+			field.setRequired(true);
+		}
+
+		if (ctrl.box.getElement().hasAttribute("readonly")) {
+			field.setReadOnly(true);
+		}
+
+		if (ctrl.box.getElement().hasAttribute("title")) {
+			field.setAlternateFieldName(ctrl.box.getElement().getAttribute("title"));
+		}
+		if (ctrl.box.getElement().hasAttribute("alt")) {
+			field.setPartialName(ctrl.box.getElement().getAttribute("alt"));
+		}
+
+		PDAnnotationWidget widget = field.getWidgets().get(0);
+
+		Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform,
+				root, od);
+		PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(),
+				(float) rect2D.getWidth(), (float) rect2D.getHeight());
 
         widget.setRectangle(rect);
         widget.setPage(ctrl.page);
         widget.setPrinted(true);
-      
+
         ctrl.page.getAnnotations().add(widget);
     }
 
@@ -483,32 +530,32 @@ public class PdfBoxForm {
         STAR(72),
 
         SQUARE(110);
-        
+
         private final int caption;
-        
+
         CheckboxStyle(int caption) {
             this.caption = caption;
         }
-        
+
         public static CheckboxStyle fromIdent(IdentValue id) {
             if (id == IdentValue.CHECK)
                 return CHECK;
-            
+
             if (id == IdentValue.CROSS)
                 return CROSS;
-            
+
             if (id == IdentValue.SQUARE)
                 return SQUARE;
-            
+
             if (id == IdentValue.CIRCLE)
                 return CIRCLE;
-            
+
             if (id == IdentValue.DIAMOND)
                 return DIAMOND;
-            
+
             if (id == IdentValue.STAR)
                 return STAR;
-            
+
             return CHECK;
         }
     }
@@ -516,19 +563,14 @@ public class PdfBoxForm {
     /**
      * Creates a checkbox appearance stream. Uses an ordinal of the zapf dingbats font for the check mark.
      */
-    public static PDAppearanceStream createCheckboxAppearance(CheckboxStyle style, PDDocument doc, PDResources resources) {
-        String appear = 
-                "q\n" + 
-                "BT\n" +
-                "1 0 0 1 15 20 Tm\n" +
-                "/OpenHTMLZap 100 Tf\n" +
-                "(" + (char) style.caption + ") Tj\n" +
-                "ET\n" +
-                "Q\n";
-        
+	public static PDAppearanceStream createCheckboxAppearance(CheckboxStyle style, PDDocument doc,
+			PDResources resources) {
+		String appear = "q\n" + "BT\n" + "1 0 0 1 15 20 Tm\n" + "/OpenHTMLZap 100 Tf\n" + "(" + (char) style.caption
+				+ ") Tj\n" + "ET\n" + "Q\n";
+
         return createCheckboxAppearance(appear, doc, resources);
     }
-    
+
     public static PDAppearanceStream createCheckboxAppearance(String appear, PDDocument doc, PDResources resources) {
         PDAppearanceStream s = new PDAppearanceStream(doc);
         s.setBBox(new PDRectangle(100f, 100f));
@@ -547,12 +589,9 @@ public class PdfBoxForm {
         ByteArrayOutputStream out = new ByteArrayOutputStream(data.length + 2);
         out.write(0xFE); // BOM
         out.write(0xFF); // BOM
-        try
-        {
+		try {
             out.write(data);
-        }
-        catch (IOException e)
-        {
+		} catch (IOException e) {
             // should never happen
             throw new RuntimeException(e);
         }
@@ -560,8 +599,9 @@ public class PdfBoxForm {
         COSString valueEncoded = new COSString(bytes);
         return valueEncoded;
     }
-    
-    private void processCheckboxControl(ControlFontPair pair, PDAcroForm acro, int i, Control ctrl, Box root) throws IOException {
+
+	private void processCheckboxControl(ControlFontPair pair, PDAcroForm acro, int i, Control ctrl, Box root)
+			throws IOException {
         PDCheckBox field = new PDCheckBox(acro);
 
         setPartialNameToField(ctrl, field);
@@ -569,25 +609,25 @@ public class PdfBoxForm {
         if (ctrl.box.getElement().hasAttribute("required")) {
             field.setRequired(true);
         }
-        
+
         if (ctrl.box.getElement().hasAttribute("readonly")) {
             field.setReadOnly(true);
         }
-        
+
         /*
-         * The only way I could get Acrobat Reader to display the checkbox checked properly was to 
+         * The only way I could get Acrobat Reader to display the checkbox checked properly was to
          * use an explicitly encoded unicode string for the OPT entry of the dictionary.
          */
         COSArray arr = new COSArray();
         arr.add(getCOSStringUTF16Encoded(ctrl.box.getElement().getAttribute("value")));
         field.getCOSObject().setItem(COSName.OPT, arr);
-        
+
         if (ctrl.box.getElement().hasAttribute("title")) {
             field.setAlternateFieldName(ctrl.box.getElement().getAttribute("title"));
         }
-        
+
         COSName zero = COSName.getPDFName("0");
-        
+
         if (ctrl.box.getElement().hasAttribute("checked")) {
             field.getCOSObject().setItem(COSName.AS, zero);
             field.getCOSObject().setItem(COSName.V, zero);
@@ -597,18 +637,21 @@ public class PdfBoxForm {
            field.getCOSObject().setItem(COSName.V, COSName.Off);
            field.getCOSObject().setItem(COSName.DV, COSName.Off);
         }
-        
-        Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform, root, od);
-        PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(), (float) rect2D.getWidth(), (float) rect2D.getHeight());
+
+		Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform,
+				root, od);
+		PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(),
+				(float) rect2D.getWidth(), (float) rect2D.getHeight());
 
         PDAnnotationWidget widget = field.getWidgets().get(0);
         widget.setRectangle(rect);
         widget.setPage(ctrl.page);
         widget.setPrinted(true);
-        
+
         CheckboxStyle style = CheckboxStyle.fromIdent(ctrl.box.getStyle().getIdent(CSSName.FS_CHECKBOX_STYLE));
-        
-        PDAppearanceCharacteristicsDictionary appearanceCharacteristics = new PDAppearanceCharacteristicsDictionary(new COSDictionary());
+
+		PDAppearanceCharacteristicsDictionary appearanceCharacteristics = new PDAppearanceCharacteristicsDictionary(
+				new COSDictionary());
         appearanceCharacteristics.setNormalCaption(String.valueOf((char) style.caption));
         widget.setAppearanceCharacteristics(appearanceCharacteristics);
 
@@ -618,10 +661,10 @@ public class PdfBoxForm {
         PDAppearanceDictionary appearanceDict = new PDAppearanceDictionary();
         appearanceDict.getCOSObject().setItem(COSName.N, dict);
         widget.setAppearance(appearanceDict);
-        
+
         ctrl.page.getAnnotations().add(widget);
     }
-    
+
     private void processRadioButtonGroup(List<Control> group, PDAcroForm acro, int i, Box root) throws IOException {
         String groupName = group.get(0).box.getElement().getAttribute("name");
         PDRadioButton field = new PDRadioButton(acro);
@@ -629,33 +672,31 @@ public class PdfBoxForm {
         Field fObj = allFieldMap.get(groupName);
         setPartialNameToField(group.get(0).box.getElement(), fObj, field);
 
-        List<String> values =
-                group.stream()
-                     .map(ctrl -> ctrl.box.getElement().getAttribute("value"))
+		List<String> values = group.stream().map(ctrl -> ctrl.box.getElement().getAttribute("value"))
                      .collect(Collectors.toList());
         field.setExportValues(values);
 
         // We can not make individual members of the group readonly so only make
         // all radio buttons in group readonly if they are all marked readonly.
-        boolean readonly =
-                group.stream()
-                     .allMatch(ctrl -> ctrl.box.getElement().hasAttribute("readonly"));
+		boolean readonly = group.stream().allMatch(ctrl -> ctrl.box.getElement().hasAttribute("readonly"));
         field.setReadOnly(readonly);
 
         List<PDAnnotationWidget> widgets = new ArrayList<>(group.size());
-        
+
         int radioCnt = 0;
-        
+
         for (Control ctrl : group) {
-            Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform, root, od);
-            PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(), (float) rect2D.getWidth(), (float) rect2D.getHeight());
-            
+			Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight,
+					ctrl.transform, root, od);
+			PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(),
+					(float) rect2D.getWidth(), (float) rect2D.getHeight());
+
             PDAnnotationWidget widget = new PDAnnotationWidget();
-            
+
             widget.setRectangle(rect);
             widget.setPage(ctrl.page);
             widget.setPrinted(true);
-            
+
             COSDictionary dict = new COSDictionary();
             dict.setItem(COSName.getPDFName("" + radioCnt), docFormsStateContainer.getRadioOnStream());
             dict.setItem(COSName.Off, docFormsStateContainer.getRadioOffStream());
@@ -669,10 +710,10 @@ public class PdfBoxForm {
             }
 
             widget.setAppearance(appearanceDict);
-            
+
             widgets.add(widget);
             ctrl.page.getAnnotations().add(widget);
-            
+
             radioCnt++;
         }
 
@@ -684,7 +725,7 @@ public class PdfBoxForm {
             }
         }
     }
-    
+
     private void processSubmitControl(PDAcroForm acro, int i, Control ctrl, Box root) throws IOException {
         final int FLAG_USE_GET = 1 << 3;
         final int FLAG_USE_HTML_SUBMIT = 1 << 2;
@@ -694,17 +735,17 @@ public class PdfBoxForm {
         if (ctrl.box.getElement().hasAttribute("name")) {
             // Buttons can't have a value so we create a hidden text field instead.
             PDTextField field = new PDTextField(acro);
-            
+
             Field fObj = allFieldMap.get(ctrl.box.getElement().getAttribute("name"));
             fObj.field = field;
-    
+
             field.setPartialName(fObj.partialName);
-            
+
             String value = ctrl.box.getElement().getAttribute("value");
-            
+
             field.setDefaultValue(value);
             field.setValue(value);
-            
+
             // Even hidden fields need an associated widget to work.
             PDAnnotationWidget widgy = field.getWidgets().get(0);
             widgy.setPage(ctrl.page);
@@ -712,14 +753,16 @@ public class PdfBoxForm {
             widgy.setRectangle(new PDRectangle(0, 0, 1, 1));
             ctrl.page.getAnnotations().add(widgy);
         }
-        
+
         // We use an internal name so as not to conflict with a hidden text that we just created.
         btn.setPartialName("OpenHTMLCtrl" + i);
-        
+
         PDAnnotationWidget widget = btn.getWidgets().get(0);
-        
-        Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform, root, od);
-        PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(), (float) rect2D.getWidth(), (float) rect2D.getHeight());
+
+		Rectangle2D rect2D = PdfBoxFastLinkManager.createTargetArea(ctrl.c, ctrl.box, ctrl.pageHeight, ctrl.transform,
+				root, od);
+		PDRectangle rect = new PDRectangle((float) rect2D.getMinX(), (float) rect2D.getMinY(),
+				(float) rect2D.getWidth(), (float) rect2D.getHeight());
 
         widget.setRectangle(rect);
         widget.setPage(ctrl.page);
@@ -730,15 +773,16 @@ public class PdfBoxForm {
                 fieldsToInclude.add(f.qualifiedName);
             }
         }
-        
+
         if (ctrl.box.getElement().getAttribute("type").equals("reset")) {
             PDActionResetForm reset = new PDActionResetForm();
             reset.setFields(fieldsToInclude.getCOSArray());
-            widget.setAction(reset);;
+			widget.setAction(reset);
+			;
         } else {
             PDFileSpecification fs = PDFileSpecification.createFS(new COSString(element.getAttribute("action")));
             PDActionSubmitForm submit = new PDActionSubmitForm();
-            
+
             submit.setFields(fieldsToInclude.getCOSArray());
             submit.setFile(fs);
 
@@ -778,57 +822,60 @@ public class PdfBoxForm {
             XRLog.log(Level.WARNING, LogMessageId.LogMessageId2Param.GENERAL_PDF_FOUND_ELEMENT_WITHOUT_ATTRIBUTE_NAME, element.getTagName(), sb.toString());
         }
     }
-    
+
     public int process(PDAcroForm acro, int startId, Box root) throws IOException {
         processControlNames();
-        
+
         int  i = startId;
 
         for (ControlFontPair pair : controls) {
             i++;
-            
+
             Control ctrl = pair.control;
             Element e = ctrl.box.getElement();
-            
-            if ((e.getNodeName().equals("input") &&
-                 e.getAttribute("type").equals("text")) ||
-                (e.getNodeName().equals("textarea")) ||
-                (e.getNodeName().equals("input") && 
-                 e.getAttribute("type").equals("password")) ||
-                (e.getNodeName().equals("input") &&
-                 e.getAttribute("type").equals("file"))) {
+
+
+			if ((e.getNodeName().equals("input") && e.getAttribute("type").equals("text")
+					&& e.getAttribute("class").contains("signature"))) {
+
+				processSignatureControl(pair, ctrl, acro, i, root);
+
+			} else if ((e.getNodeName().equals("input") && e.getAttribute("type").equals("text"))
+					|| (e.getNodeName().equals("textarea"))
+					|| (e.getNodeName().equals("input") && e.getAttribute("type").equals("password"))
+					|| (e.getNodeName().equals("input") && e.getAttribute("type").equals("file"))) {
 
                 // Start with the text controls (text, password, file and textarea).
                 processTextControl(pair, ctrl, acro, i, root);
             } else if ((e.getNodeName().equals("select") &&
                         !e.hasAttribute("multiple")) ||
                        (e.getNodeName().equals("openhtmltopdf-combo"))) {
-                
+
                 processSelectControl(pair, ctrl, acro, i, root);
             } else if (e.getNodeName().equals("select") &&
                        e.hasAttribute("multiple")) {
-                
+
                 processMultiSelectControl(pair, ctrl, acro, i, root);
             } else if (e.getNodeName().equals("input") &&
                        e.getAttribute("type").equals("checkbox")) {
-                
+
                 processCheckboxControl(pair, acro, i, ctrl, root);
             } else if (e.getNodeName().equals("input") &&
                        e.getAttribute("type").equals("hidden")) {
-                
+
                 processHiddenControl(pair, ctrl, acro, i, root);
             } else if (e.getNodeName().equals("input") &&
                        e.getAttribute("type").equals("radio")) {
                 // We have to do radio button groups in one hit so add them to a map of list keyed on name.
                 List<Control> radioGroup = radioGroups.get(e.getAttribute("name"));
-                
+
                 if (radioGroup == null) {
                     radioGroup = new ArrayList<>();
                     radioGroups.put(e.getAttribute("name"), radioGroup);
                 }
 
                 radioGroup.add(ctrl);
-            } else if ((e.getNodeName().equals("input") && 
+            } else if ((e.getNodeName().equals("input") &&
                       e.getAttribute("type").equals("submit")) ||
                      (e.getNodeName().equals("button") &&
                       !e.getAttribute("type").equals("button")) ||
@@ -839,21 +886,21 @@ public class PdfBoxForm {
                 submits.add(ctrl);
             }
         }
-        
+
         // Now process each group of radio buttons.
         for (List<Control> group : radioGroups.values()) {
             i++;
             processRadioButtonGroup(group, acro, i, root);
         }
-        
+
         // We do submit controls last as we need all the fields in this form.
         for (Control ctrl : submits) {
             i++;
             processSubmitControl(acro, i, ctrl, root);
         }
-        
+
         createNonTerminalFields(acro);
-        
+
         return i;
     }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxPerDocumentFormState.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxPerDocumentFormState.java
@@ -95,8 +95,8 @@ public class PdfBoxPerDocumentFormState {
         }
     }
     
-    private String getControlFont(SharedContext sharedContext, PdfBoxForm.Control ctrl) {
-        PDFont fnt = ((PdfBoxFSFont) sharedContext.getFont(ctrl.box.getStyle().getFontSpecification())).getFontDescription().get(0).getFont();
+    private String getControlFont(SharedContext sharedContext, PdfBoxForm.Control ctrl, RenderingContext renderingContext) {
+        PDFont fnt = ((PdfBoxFSFont) sharedContext.getFont(ctrl.box.getStyle().getFont(renderingContext))).getFontDescription().get(0).getFont();
         String fontName;
         
         if (!controlFonts.containsKey(fnt)) {
@@ -139,14 +139,14 @@ public class PdfBoxPerDocumentFormState {
         }
     }
     
-    public void processControls(SharedContext sharedContext, PDDocument writer, Box root) {
+    public void processControls(SharedContext sharedContext, PDDocument writer, Box root, RenderingContext renderingContext) {
         for (PdfBoxForm.Control ctrl : controls) {
             PdfBoxForm frm = findEnclosingForm(ctrl.box.getElement());
             String fontName = null;
             
             if (!ArrayUtil.isOneOf(ctrl.box.getElement().getAttribute("type"), "checkbox", "radio", "hidden")) {
                 // Need to embed a font for every control other than checkbox, radio and hidden.
-                fontName = getControlFont(sharedContext, ctrl);
+                fontName = getControlFont(sharedContext, ctrl, renderingContext);
             } else if (ctrl.box.getElement().getAttribute("type").equals("checkbox")) {
                 createCheckboxFontResource();
                 createCheckboxAppearanceStreams(writer, ctrl);


### PR DESCRIPTION
Fixes #914
Forms on PDFs with multiple pages that are not on the last page are broken. They get the last pages RenderingContext and that will calculate wrong coordinates. With this PR it will use the right page, fixing the RenderingContext to be correct and not attach a changing object to the PdfBoxForm.Control would be even better, but more intrusive.